### PR TITLE
Check RSI Launcher for current install directory if not default

### DIFF
--- a/src/StarBreaker/Constants.cs
+++ b/src/StarBreaker/Constants.cs
@@ -4,9 +4,10 @@ namespace StarBreaker;
 
 public static class Constants
 {
-    public const string DefaultStarCitizenFolder = @"C:\Program Files\Roberts Space Industries\StarCitizen\";
+    public const string DefaultStarCitizenFolder = @"\Roberts Space Industries\StarCitizen\";
     public const string DataP4k = "Data.p4k";
     public const string BuildManifest = "build_manifest.id";
+    public const string DefaultRSILauncherFolder = @"\rsilauncher\logs";
 
     public static FilePickerOpenOptions GetP4kFilter(IStorageFolder? defaultPath) => new()
     {


### PR DESCRIPTION
Check Launcher Logs for SC install directory. Fall back to default if log not found.

Fixed crash on startup if default "C:\Program Files\Roberts Space Industries\StarCitizen" doesn't exist.

Fixes issue #2 