### PR TITLE
3D Ship Viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ __pycache__/
 Thumbs.db
 
 blender_addon/starbreaker_addon/resources/material_templates.blend1
+console.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ server, export pipeline). Blender-addon-specific guidance lives in
 - `app/` — Tauri + React app (see `tasks.json` for build tasks).
 - `docs/` — in-repo reference: export contract, material authoring,
   shader family inventory.
+- `exports/` - (contents excluded via .gitignore) Temp folder for exports
 
 ## Building
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,6 +5811,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -32,7 +32,8 @@
         "oxlint": "^1.56.0",
         "tailwindcss": "^4",
         "typescript": "^6.0.2",
-        "vite": "^8.0.2"
+        "vite": "^8.0.2",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
@@ -995,6 +996,13 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1529,6 +1537,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -1607,10 +1640,150 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1638,6 +1811,33 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1980,6 +2180,17 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/oxfmt": {
       "version": "0.41.0",
       "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.41.0.tgz",
@@ -2062,6 +2273,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2174,6 +2392,13 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2182,6 +2407,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
@@ -2207,6 +2446,23 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2230,6 +2486,16 @@
       "dev": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2334,6 +2600,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zustand": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1534,6 +1534,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1543,6 +1544,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2072,6 +2074,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2111,6 +2114,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2259,6 +2263,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -b && vite build",
     "lint": "oxlint",
     "format": "oxfmt --write src/",
+    "test": "vitest run",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -35,6 +36,7 @@
     "oxlint": "^1.56.0",
     "tailwindcss": "^4",
     "typescript": "^6.0.2",
-    "vite": "^8.0.2"
+    "vite": "^8.0.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1352,3 +1352,79 @@ pub fn extract_p4k_file(
 
     Ok(())
 }
+
+/// Write a JSON diagnostic capture under the app's data directory.
+///
+/// `subdir` is a single-segment subdirectory under the app data dir
+/// (created if absent). `filename` is the bare filename with extension
+/// (no path separators). Returns the absolute path of the written file.
+///
+/// Path is always resolved under `app_data_dir()`; arbitrary paths are
+/// rejected. Used by the "Save JSON" buttons in the material inspector.
+#[tauri::command]
+pub fn write_diag_file(
+    app: AppHandle,
+    subdir: String,
+    filename: String,
+    content: String,
+) -> Result<String, AppError> {
+    use tauri::Manager;
+
+    if subdir.contains('/')
+        || subdir.contains('\\')
+        || subdir.contains("..")
+        || subdir.is_empty()
+    {
+        return Err(AppError::Internal(
+            "subdir must be a single-segment name with no separators".into(),
+        ));
+    }
+    if filename.contains('/') || filename.contains('\\') || filename.contains('\0') {
+        return Err(AppError::Internal(
+            "filename must not contain path separators".into(),
+        ));
+    }
+
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_data_dir: {e}")))?;
+    let dir_path = base.join(&subdir);
+    std::fs::create_dir_all(&dir_path)?;
+
+    let file_path = dir_path.join(&filename);
+    std::fs::write(&file_path, content.as_bytes())?;
+
+    Ok(file_path.to_string_lossy().into_owned())
+}
+
+/// List filenames in a subdirectory of the app data dir.
+///
+/// Returns an empty list if the directory does not exist.
+/// Used by the "Save JSON" button to find the highest existing counter.
+#[tauri::command]
+pub fn list_diag_dir(app: AppHandle, subdir: String) -> Vec<String> {
+    use tauri::Manager;
+
+    if subdir.contains('/')
+        || subdir.contains('\\')
+        || subdir.contains("..")
+        || subdir.is_empty()
+    {
+        return Vec::new();
+    }
+
+    let base = match app.path().app_data_dir() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let dir_path = base.join(&subdir);
+
+    match std::fs::read_dir(&dir_path) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}

--- a/app/src-tauri/src/decomposed_commands.rs
+++ b/app/src-tauri/src/decomposed_commands.rs
@@ -1,0 +1,1238 @@
+// Tauri commands for browsing and loading "decomposed" entity export packages.
+//
+// A decomposed export root has this layout:
+//
+//   <root>/
+//     Packages/
+//       <package_name>/         e.g. "Polaris_LOD0_TEX2"
+//         scene.json
+//         palettes.json
+//         liveries.json
+//     Data/
+//       Objects/.../*.glb
+//       Objects/.../*.materials.json
+//       Objects/.../*.png
+//       Objects/.../*.dds        (projector / gobo textures)
+//
+// The JSON contract is dynamic (built from `serde_json::json!` in
+// `starbreaker_3d::decomposed`), so these commands return raw
+// `serde_json::Value` instead of typed structs. Re-deriving Rust types
+// here would duplicate the contract and rot the moment a field is added.
+// The frontend reads fields it needs and ignores the rest.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use starbreaker_common::Progress;
+use starbreaker_datacore::database::Database;
+use starbreaker_datacore::loadout::{EntityIndex, resolve_loadout_indexed};
+use starbreaker_datacore::types::Record;
+use starbreaker_p4k::MappedP4k;
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+/// Maximum file size we are willing to read into the frontend in one shot.
+/// 256 MiB. Decomposed mesh GLBs are typically a few MiB; texture PNGs are
+/// at most a few MiB at mip 2; DDS gobos are tiny. This cap exists to fail
+/// fast if the frontend is pointed at the wrong file.
+const MAX_DECOMPOSED_READ_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Resolve a frontend-supplied path to an absolute, normalized PathBuf.
+///
+/// We normalize separators so the frontend can pass either forward or
+/// backslashes. We do NOT enforce a sandbox on the path here — the
+/// frontend explicitly opens a directory the user picked, and reads files
+/// underneath it. Tauri capabilities still gate which IPC commands the
+/// frontend can call at all.
+fn normalize_path(path: &str) -> PathBuf {
+    PathBuf::from(path.replace('\\', "/"))
+}
+
+/// Read a file under the decomposed export root and return its bytes.
+/// Used for GLB meshes, PNG textures, and DDS gobo textures so the frontend
+/// does not need a tauri-plugin-fs scope.
+#[tauri::command]
+pub fn read_decomposed_file(path: String) -> Result<Vec<u8>, AppError> {
+    let abs = normalize_path(&path);
+    let metadata = std::fs::metadata(&abs)?;
+    if !metadata.is_file() {
+        return Err(AppError::Internal(format!(
+            "decomposed read target is not a file: {}",
+            abs.display()
+        )));
+    }
+    if metadata.len() > MAX_DECOMPOSED_READ_BYTES {
+        return Err(AppError::Internal(format!(
+            "decomposed file '{}' is {} bytes (over {}-byte cap)",
+            abs.display(),
+            metadata.len(),
+            MAX_DECOMPOSED_READ_BYTES,
+        )));
+    }
+    Ok(std::fs::read(&abs)?)
+}
+
+/// Read a JSON file (scene.json / palettes.json / liveries.json /
+/// *.materials.json) and return it as a parsed value. The frontend
+/// inspects fields it knows about and ignores the rest.
+#[tauri::command]
+pub fn load_decomposed_json(path: String) -> Result<serde_json::Value, AppError> {
+    let abs = normalize_path(&path);
+    let bytes = std::fs::read(&abs)?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Internal(format!("invalid JSON in '{}': {e}", abs.display())))?;
+    Ok(value)
+}
+
+/// Convenience wrapper: load `scene.json` from a package directory.
+/// `package_path` may be either the package directory itself
+/// (`.../Packages/Polaris_LOD0_TEX2`) or the path to `scene.json`.
+#[tauri::command]
+pub fn load_decomposed_scene(package_path: String) -> Result<serde_json::Value, AppError> {
+    let abs = normalize_path(&package_path);
+    let scene_path = if abs
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case("scene.json"))
+        .unwrap_or(false)
+    {
+        abs
+    } else {
+        abs.join("scene.json")
+    };
+    load_decomposed_json(scene_path.to_string_lossy().into_owned())
+}
+
+/// Convenience wrapper: load `palettes.json` from a package directory.
+/// Returns `Value::Null` if the file is absent (palette-less exports).
+#[tauri::command]
+pub fn load_decomposed_palettes(package_path: String) -> Result<serde_json::Value, AppError> {
+    let abs = normalize_path(&package_path);
+    let palettes_path = abs.join("palettes.json");
+    if !palettes_path.exists() {
+        return Ok(serde_json::Value::Null);
+    }
+    load_decomposed_json(palettes_path.to_string_lossy().into_owned())
+}
+
+/// Convenience wrapper: load `liveries.json` from a package directory.
+/// Returns `Value::Null` if the file is absent.
+#[tauri::command]
+pub fn load_decomposed_liveries(package_path: String) -> Result<serde_json::Value, AppError> {
+    let abs = normalize_path(&package_path);
+    let liveries_path = abs.join("liveries.json");
+    if !liveries_path.exists() {
+        return Ok(serde_json::Value::Null);
+    }
+    load_decomposed_json(liveries_path.to_string_lossy().into_owned())
+}
+
+/// A single discovered decomposed package.
+#[derive(Serialize)]
+pub struct DecomposedPackageInfo {
+    /// Absolute path to the package directory under `Packages/`.
+    pub package_dir: String,
+    /// Absolute path to the export root containing `Packages/` and `Data/`.
+    pub export_root: String,
+    /// The package name (e.g. `Polaris_LOD0_TEX2`).
+    pub package_name: String,
+    /// Whether `scene.json` exists inside the package directory.
+    pub has_scene_manifest: bool,
+}
+
+/// List decomposed packages found under a root.
+///
+/// Accepts:
+///   - an export root (directory containing `Packages/`)
+///   - a `Packages/` directory directly
+///   - a single package directory (returns just that package)
+#[tauri::command]
+pub fn list_decomposed_packages(root: String) -> Result<Vec<DecomposedPackageInfo>, AppError> {
+    let abs = normalize_path(&root);
+    if !abs.exists() {
+        return Err(AppError::Internal(format!(
+            "decomposed root '{}' does not exist",
+            abs.display()
+        )));
+    }
+
+    // Single-package case: caller passed the package directory itself.
+    if abs.join("scene.json").exists() {
+        let package_name = abs
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("(unknown)")
+            .to_string();
+        let export_root = derive_export_root(&abs);
+        return Ok(vec![DecomposedPackageInfo {
+            package_dir: abs.to_string_lossy().into_owned(),
+            export_root,
+            package_name,
+            has_scene_manifest: true,
+        }]);
+    }
+
+    // Directory case: find the `Packages/` directory.
+    let packages_dir = if abs
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case("Packages"))
+        .unwrap_or(false)
+    {
+        abs.clone()
+    } else {
+        abs.join("Packages")
+    };
+
+    if !packages_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let export_root = packages_dir
+        .parent()
+        .map(|parent| parent.to_string_lossy().into_owned())
+        .unwrap_or_else(|| abs.to_string_lossy().into_owned());
+
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&packages_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let package_name = entry
+            .file_name()
+            .to_str()
+            .map(|name| name.to_string())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned());
+        let has_scene_manifest = path.join("scene.json").is_file();
+        out.push(DecomposedPackageInfo {
+            package_dir: path.to_string_lossy().into_owned(),
+            export_root: export_root.clone(),
+            package_name,
+            has_scene_manifest,
+        });
+    }
+    out.sort_by(|a, b| a.package_name.cmp(&b.package_name));
+    Ok(out)
+}
+
+/// Walk up from a package directory to find the export root (the parent
+/// of `Packages/`). Falls back to the package directory itself if the
+/// expected layout is absent.
+fn derive_export_root(package_dir: &Path) -> String {
+    if let Some(parent) = package_dir.parent()
+        && parent
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.eq_ignore_ascii_case("Packages"))
+            .unwrap_or(false)
+        && let Some(grandparent) = parent.parent()
+    {
+        return grandparent.to_string_lossy().into_owned();
+    }
+    package_dir.to_string_lossy().into_owned()
+}
+
+// ── Scene Viewer self-service exporter ─────────────────────────────────
+//
+// The Scene Viewer browses ships/vehicles by name, hits a per-user cache
+// keyed on (entity_name, export options that affect output), and exports
+// missing entries via the same `assemble_glb_with_loadout_with_progress`
+// API the CLI and 3D Export tab use. The cache lives under the Tauri
+// `app_local_data_dir` so it survives app restarts.
+//
+// Layout:
+//   <app_local_data_dir>/
+//     decomposed_cache/
+//       <entity_name>__lod<N>_mip<M>_<materials>/
+//         Packages/<package_name>/{scene,palettes,liveries}.json
+//         Data/Objects/.../
+//
+// Cache validity: a directory entry is "cache hit" if its `Packages/`
+// subdir contains a package directory with a `scene.json` inside. The
+// option-derived suffix on the parent dir is the cache key — change any
+// option that affects output (LOD, mip, materials, attachments,
+// interior, lights, nodraw) and you'll get a different cache slot.
+
+/// Frontend-facing export options for the Scene Viewer. Mirrors the
+/// fields of `starbreaker_3d::ExportOptions` that affect output, plus
+/// the texture format we always render (GLB) and material kind we
+/// always emit (Decomposed). Other CLI knobs (threads, format, kind)
+/// are fixed to viewer-appropriate defaults inside the command handler.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SceneExportOpts {
+    pub lod: u32,
+    pub mip: u32,
+    /// "none" | "colors" | "textures" | "all"
+    pub material_mode: String,
+    pub include_attachments: bool,
+    pub include_interior: bool,
+    pub include_lights: bool,
+    pub include_nodraw: bool,
+}
+
+impl Default for SceneExportOpts {
+    fn default() -> Self {
+        // Match the CLI defaults so most users never need to tweak these.
+        Self {
+            lod: 1,
+            mip: 2,
+            material_mode: "textures".to_string(),
+            include_attachments: true,
+            include_interior: true,
+            include_lights: true,
+            include_nodraw: false,
+        }
+    }
+}
+
+impl SceneExportOpts {
+    /// Sanitized material mode token used both for `MaterialMode` and the
+    /// cache key. Unknown values fall back to "textures" (mirrors CLI).
+    fn material_mode_token(&self) -> &str {
+        match self.material_mode.to_lowercase().as_str() {
+            "none" => "none",
+            "colors" => "colors",
+            "all" => "all",
+            _ => "textures",
+        }
+    }
+
+    fn to_export_options(&self) -> starbreaker_3d::ExportOptions {
+        let material_mode = match self.material_mode_token() {
+            "none" => starbreaker_3d::MaterialMode::None,
+            "colors" => starbreaker_3d::MaterialMode::Colors,
+            "all" => starbreaker_3d::MaterialMode::All,
+            _ => starbreaker_3d::MaterialMode::Textures,
+        };
+        starbreaker_3d::ExportOptions {
+            kind: starbreaker_3d::ExportKind::Decomposed,
+            format: starbreaker_3d::ExportFormat::Glb,
+            material_mode,
+            include_attachments: self.include_attachments,
+            include_interior: self.include_interior,
+            include_lights: self.include_lights,
+            include_nodraw: self.include_nodraw,
+            include_shields: false,
+            texture_mip: self.mip,
+            lod_level: self.lod,
+        }
+    }
+
+    /// Suffix appended to the entity name in the cache directory.
+    /// Encodes every option that affects the output bytes, plus the
+    /// `_v<N>` contract-version segment. Bumping
+    /// `starbreaker_3d::DECOMPOSED_CONTRACT_VERSION` shifts every cache
+    /// slot to a new directory name, so old slots are orphaned (still on
+    /// disk, just unreachable) until cleared by the user or pruned by
+    /// `prune_stale_cache` on app start.
+    fn cache_suffix(&self) -> String {
+        cache_suffix_for(self, starbreaker_3d::DECOMPOSED_CONTRACT_VERSION)
+    }
+}
+
+/// Standalone form of `SceneExportOpts::cache_suffix` so tests can pin
+/// against a specific contract version without depending on the
+/// currently-shipping value of `DECOMPOSED_CONTRACT_VERSION`.
+fn cache_suffix_for(opts: &SceneExportOpts, version: u32) -> String {
+    let attach = if opts.include_attachments { "1" } else { "0" };
+    let interior = if opts.include_interior { "1" } else { "0" };
+    let lights = if opts.include_lights { "1" } else { "0" };
+    let nodraw = if opts.include_nodraw { "1" } else { "0" };
+    format!(
+        "lod{}_mip{}_{}_a{}_i{}_l{}_n{}_v{}",
+        opts.lod,
+        opts.mip,
+        opts.material_mode_token(),
+        attach,
+        interior,
+        lights,
+        nodraw,
+        version,
+    )
+}
+
+#[derive(Clone, Serialize)]
+pub struct SceneEntityDto {
+    /// DataCore entity name (the export argument).
+    pub entity_name: String,
+    /// Localized display name when available, otherwise None.
+    pub display_name: Option<String>,
+    /// Category bucket, currently "Ships" or "Ground Vehicles".
+    pub category: String,
+    /// True if a previous export with the same options is on disk.
+    pub cached: bool,
+}
+
+#[derive(Clone, Serialize)]
+pub struct SceneExportProgress {
+    pub fraction: f32,
+    pub stage: String,
+    pub entity_name: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct SceneExportDone {
+    pub entity_name: String,
+    pub package_dir: Option<String>,
+    pub error: Option<String>,
+}
+
+fn scene_cache_root(app: &AppHandle) -> Result<PathBuf, AppError> {
+    let local = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_local_data_dir unavailable: {e}")))?;
+    Ok(local.join("decomposed_cache"))
+}
+
+fn scene_cache_dir(app: &AppHandle, entity_name: &str, opts: &SceneExportOpts) -> Result<PathBuf, AppError> {
+    let safe_name = sanitize_cache_segment(entity_name);
+    let suffix = opts.cache_suffix();
+    Ok(scene_cache_root(app)?.join(format!("{safe_name}__{suffix}")))
+}
+
+/// Find the package directory inside an export root, or None if absent.
+fn find_package_with_scene(export_root: &Path) -> Option<PathBuf> {
+    let packages = export_root.join("Packages");
+    if !packages.is_dir() {
+        return None;
+    }
+    let entries = std::fs::read_dir(&packages).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.join("scene.json").is_file() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Replace characters that are awkward in filesystem paths. Keeps the
+/// entity name human-readable (no hashing) so cache dirs are scrubbable
+/// by hand.
+fn sanitize_cache_segment(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-' | '.' => out.push(ch),
+            ' ' => out.push('_'),
+            _ => out.push('_'),
+        }
+    }
+    if out.is_empty() {
+        "Entity".to_string()
+    } else {
+        out
+    }
+}
+
+/// Decomposed exporter package-name format: `<EXPORT_NAME>_LOD<n>_TEX<n>`.
+/// Used to know which package directory we'll write under `Packages/`.
+fn predicted_package_name(entity_name: &str, opts: &SceneExportOpts) -> String {
+    let display = sanitize_export_name(&strip_record_prefix(entity_name));
+    format!("{display}_LOD{}_TEX{}", opts.lod, opts.mip)
+}
+
+fn strip_record_prefix(name: &str) -> String {
+    let trimmed = name.trim_matches('"');
+    trimmed
+        .rsplit('.')
+        .next()
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+fn sanitize_export_name(name: &str) -> String {
+    let mut cleaned = String::new();
+    let mut last_was_space = false;
+    for ch in name.chars() {
+        if ch.is_alphanumeric() {
+            cleaned.push(ch);
+            last_was_space = false;
+        } else if ch.is_whitespace() || matches!(ch, '_' | '-') {
+            if !cleaned.is_empty() && !last_was_space {
+                cleaned.push(' ');
+                last_was_space = true;
+            }
+        }
+    }
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        "Export".to_string()
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// List ships and vehicles available for scene viewing. Marks any
+/// entity that already has a cached export with the given default opts
+/// so the UI can render a "cached" badge without a second round-trip.
+///
+/// `opts` is optional. When None, cache_status is computed against
+/// `SceneExportOpts::default()`.
+#[tauri::command]
+pub async fn list_scene_entities(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    opts: Option<SceneExportOpts>,
+) -> Result<Vec<SceneEntityDto>, AppError> {
+    let opts = opts.unwrap_or_default();
+    let dcb_bytes = {
+        let guard = state.dcb_bytes.lock();
+        guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("DataCore not loaded".into()))?
+            .clone()
+    };
+    let loc = {
+        let guard = state.localization.lock();
+        guard.clone()
+    };
+    let cache_root = scene_cache_root(&app)?;
+
+    tokio::task::spawn_blocking(move || {
+        let db = Database::from_bytes(&dcb_bytes)?;
+
+        use starbreaker_datacore::QueryResultExt;
+        use starbreaker_datacore::query::value::Value;
+
+        let loc_compiled = db.compile_rooted::<Value>(
+            "EntityClassDefinition.Components[SAttachableComponentParams].AttachDef.Localization.Name",
+        ).optional()?;
+        let inclusion_compiled = db.compile_rooted::<Value>(
+            "EntityClassDefinition.StaticEntityClassData[EAEntityDataParams].inclusionMode",
+        ).optional()?;
+
+        let mut out: Vec<SceneEntityDto> = Vec::new();
+        for record in db.records_by_type_name("EntityClassDefinition") {
+            if !db.is_main_record(record) {
+                continue;
+            }
+            let file_path = db.resolve_string(record.file_name_offset).to_lowercase();
+            let category = if file_path.contains("entities/spaceships") {
+                "Ships"
+            } else if file_path.contains("entities/groundvehicles") {
+                "Ground Vehicles"
+            } else {
+                continue;
+            };
+
+            // Skip non-player variants — same rule as the 3D Export tab.
+            let is_npc_or_internal = inclusion_compiled.as_ref()
+                .and_then(|c| db.query_single::<Value>(c, record).ok().flatten())
+                .is_some_and(|v| matches!(v, Value::Enum(s) if s != "ReadyToInclude"));
+            if is_npc_or_internal {
+                continue;
+            }
+
+            let entity_name = db.resolve_string2(record.name_offset).to_string();
+            let display_name = loc_compiled.as_ref()
+                .and_then(|c| db.query_single::<Value>(c, record).ok().flatten())
+                .and_then(|v| match v {
+                    Value::String(s) | Value::Locale(s) => Some(s.to_string()),
+                    _ => None,
+                })
+                .filter(|s| !s.is_empty() && s != "@LOC_UNINITIALIZED" && s != "@LOC_EMPTY")
+                .and_then(|key| {
+                    let stripped = key.strip_prefix('@').unwrap_or(&key);
+                    loc.get(&stripped.to_lowercase()).cloned()
+                });
+
+            let safe = sanitize_cache_segment(&entity_name);
+            let cache_dir = cache_root.join(format!("{safe}__{}", opts.cache_suffix()));
+            let cached = find_package_with_scene(&cache_dir).is_some();
+
+            out.push(SceneEntityDto {
+                entity_name,
+                display_name,
+                category: category.to_string(),
+                cached,
+            });
+        }
+
+        let sort_key = |e: &SceneEntityDto| {
+            e.display_name.clone().unwrap_or_else(|| e.entity_name.clone())
+        };
+        out.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)));
+        Ok::<_, AppError>(out)
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("task join error: {e}")))?
+}
+
+/// Return the cache directory that `start_scene_export` would write to
+/// for a given (entity, opts) pair. Frontend uses this both to render
+/// the cache status and to mount the viewer when a cache hit exists.
+#[tauri::command]
+pub fn get_scene_cache_path(
+    app: AppHandle,
+    entity_name: String,
+    opts: SceneExportOpts,
+) -> Result<SceneCachePath, AppError> {
+    let export_root = scene_cache_dir(&app, &entity_name, &opts)?;
+    let package_dir = find_package_with_scene(&export_root);
+    Ok(SceneCachePath {
+        export_root: export_root.to_string_lossy().into_owned(),
+        package_dir: package_dir.map(|p| p.to_string_lossy().into_owned()),
+        cached: package_dir_predicate(&export_root, entity_name.as_str(), &opts),
+    })
+}
+
+/// True when the cache slot already holds a usable scene.json. This is
+/// the same predicate as `find_package_with_scene().is_some()` but
+/// expressed as a helper so the meaning is named at the call site.
+fn package_dir_predicate(export_root: &Path, _entity_name: &str, _opts: &SceneExportOpts) -> bool {
+    find_package_with_scene(export_root).is_some()
+}
+
+#[derive(Serialize)]
+pub struct SceneCachePath {
+    pub export_root: String,
+    /// None when no scene.json has been written yet.
+    pub package_dir: Option<String>,
+    pub cached: bool,
+}
+
+/// Delete the on-disk cache for a single (entity, opts) pair. The
+/// `_LOD0_TEX0` style suffix on the package dir means changing options
+/// gives a different cache slot, so this only nukes the slot the
+/// frontend was about to re-export into.
+#[tauri::command]
+pub fn clear_scene_cache(
+    app: AppHandle,
+    entity_name: String,
+    opts: SceneExportOpts,
+) -> Result<(), AppError> {
+    let dir = scene_cache_dir(&app, &entity_name, &opts)?;
+    if dir.is_dir() {
+        std::fs::remove_dir_all(&dir).map_err(|e| {
+            AppError::Internal(format!("failed to clear cache '{}': {e}", dir.display()))
+        })?;
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+pub struct ClearAllResult {
+    /// Number of cache entries (top-level directories under
+    /// `decomposed_cache/`) that were removed.
+    pub entries_removed: u32,
+    /// Total bytes freed across all removed entries (best-effort: sums
+    /// the sizes seen during the pre-delete walk).
+    pub bytes_freed: u64,
+}
+
+/// Wipe every entry under the per-user `decomposed_cache/` directory.
+///
+/// Defensive contract:
+/// - Only deletes immediate children of the cache root; never follows
+///   symlinks out, never accepts arbitrary paths from the caller.
+/// - The cache root itself is recreated empty after the wipe so the
+///   next export does not have to materialize it.
+/// - Per-entry failures do not abort the whole pass; they are counted
+///   but the loop continues so a single locked file does not strand
+///   the rest of the cache.
+#[tauri::command]
+pub fn clear_all_scene_cache(app: AppHandle) -> Result<ClearAllResult, AppError> {
+    let root = scene_cache_root(&app)?;
+    if !root.is_dir() {
+        return Ok(ClearAllResult {
+            entries_removed: 0,
+            bytes_freed: 0,
+        });
+    }
+
+    let mut entries_removed: u32 = 0;
+    let mut bytes_freed: u64 = 0;
+
+    for entry in std::fs::read_dir(&root)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        // Symlink defence: never traverse out of the cache root via a
+        // symlinked entry. `symlink_metadata` reports the link itself,
+        // not the target.
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            // Remove the link itself but never follow it.
+            if std::fs::remove_file(&path).is_ok() {
+                entries_removed += 1;
+            }
+            continue;
+        }
+        if meta.is_dir() {
+            bytes_freed = bytes_freed.saturating_add(directory_size(&path));
+            if std::fs::remove_dir_all(&path).is_ok() {
+                entries_removed += 1;
+            }
+        } else if meta.is_file() {
+            bytes_freed = bytes_freed.saturating_add(meta.len());
+            if std::fs::remove_file(&path).is_ok() {
+                entries_removed += 1;
+            }
+        }
+    }
+
+    // Recreate the cache root empty so subsequent exports don't have to.
+    let _ = std::fs::create_dir_all(&root);
+
+    Ok(ClearAllResult {
+        entries_removed,
+        bytes_freed,
+    })
+}
+
+#[derive(Serialize)]
+pub struct CacheStats {
+    /// Number of top-level entries (one per cached entity+opts slot).
+    pub entry_count: u32,
+    /// Total bytes used on disk across every cached slot.
+    pub total_bytes: u64,
+    /// Absolute path to the cache root, useful for "show in
+    /// explorer" affordances.
+    pub cache_root: String,
+}
+
+/// Walk `decomposed_cache/` and return entry count and total size.
+/// Cheap enough to call on every UI refresh: a typical cache has under
+/// 50 top-level entries; the walk is one stat per file.
+#[tauri::command]
+pub fn cache_stats(app: AppHandle) -> Result<CacheStats, AppError> {
+    let root = scene_cache_root(&app)?;
+    if !root.is_dir() {
+        return Ok(CacheStats {
+            entry_count: 0,
+            total_bytes: 0,
+            cache_root: root.to_string_lossy().into_owned(),
+        });
+    }
+
+    let mut entry_count: u32 = 0;
+    let mut total_bytes: u64 = 0;
+
+    for entry in std::fs::read_dir(&root)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let meta = match std::fs::symlink_metadata(entry.path()) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            // Count the link, but don't traverse it.
+            entry_count += 1;
+            continue;
+        }
+        if meta.is_dir() {
+            entry_count += 1;
+            total_bytes = total_bytes.saturating_add(directory_size(&entry.path()));
+        } else if meta.is_file() {
+            entry_count += 1;
+            total_bytes = total_bytes.saturating_add(meta.len());
+        }
+    }
+
+    Ok(CacheStats {
+        entry_count,
+        total_bytes,
+        cache_root: root.to_string_lossy().into_owned(),
+    })
+}
+
+#[derive(Serialize)]
+pub struct PruneStaleResult {
+    /// Number of cache slots removed because their `_v<N>` segment did
+    /// not match `current_version`, plus any entries whose name lacked
+    /// a recognizable `_v<N>` segment entirely (legacy / unversioned).
+    pub entries_removed: u32,
+    /// Bytes freed by the prune.
+    pub bytes_freed: u64,
+}
+
+/// Remove cache slots whose contract-version segment does not match
+/// `current_version`. Optional housekeeping the frontend can call from
+/// `useEffect` on mount so old slots don't hang around indefinitely
+/// after a contract bump.
+///
+/// Pruning rule: any top-level entry whose name does not end in
+/// `_v<current_version>` is removed. Entries from prior tool versions
+/// that pre-date the version stamp won't have a `_v<N>` segment and
+/// will also be pruned, which is the desired effect — they were
+/// rendered unreachable by the introduction of the version segment.
+#[tauri::command]
+pub fn prune_stale_cache(
+    app: AppHandle,
+    current_version: u32,
+) -> Result<PruneStaleResult, AppError> {
+    let root = scene_cache_root(&app)?;
+    if !root.is_dir() {
+        return Ok(PruneStaleResult {
+            entries_removed: 0,
+            bytes_freed: 0,
+        });
+    }
+
+    let expected_suffix = format!("_v{current_version}");
+    let mut entries_removed: u32 = 0;
+    let mut bytes_freed: u64 = 0;
+
+    for entry in std::fs::read_dir(&root)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if name.ends_with(&expected_suffix) {
+            continue;
+        }
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            if std::fs::remove_file(&path).is_ok() {
+                entries_removed += 1;
+            }
+            continue;
+        }
+        if meta.is_dir() {
+            bytes_freed = bytes_freed.saturating_add(directory_size(&path));
+            if std::fs::remove_dir_all(&path).is_ok() {
+                entries_removed += 1;
+            }
+        } else if meta.is_file() {
+            bytes_freed = bytes_freed.saturating_add(meta.len());
+            if std::fs::remove_file(&path).is_ok() {
+                entries_removed += 1;
+            }
+        }
+    }
+
+    Ok(PruneStaleResult {
+        entries_removed,
+        bytes_freed,
+    })
+}
+
+/// Sum file sizes under a directory tree. Symlinks encountered during
+/// the walk are counted by their link size, not their target — so a
+/// link out of the cache cannot inflate the reported total via the
+/// target's size, and cannot cause us to traverse outside the cache
+/// root. Errors during the walk are swallowed because the result is
+/// used for display, not correctness.
+fn directory_size(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<PathBuf> = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let meta = match std::fs::symlink_metadata(&p) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if meta.file_type().is_symlink() {
+                // Skip — never traverse links during the walk.
+                continue;
+            }
+            if meta.is_dir() {
+                stack.push(p);
+            } else if meta.is_file() {
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    total
+}
+
+/// Find the EntityClassDefinition record for an exact entity name, or
+/// fall back to the shortest case-insensitive substring match (mirrors
+/// CLI's `find_candidates`).
+fn resolve_entity_record<'a>(db: &'a Database, name: &str) -> Result<&'a Record, AppError> {
+    if let Some(rec) = db.records_by_type_name("EntityClassDefinition")
+        .filter(|r| db.is_main_record(r))
+        .find(|r| db.resolve_string2(r.name_offset) == name)
+    {
+        return Ok(rec);
+    }
+    let lower = name.to_lowercase();
+    let mut candidates: Vec<&Record> = db.records_by_type_name("EntityClassDefinition")
+        .filter(|r| db.is_main_record(r))
+        .filter(|r| db.resolve_string2(r.name_offset).to_lowercase().contains(&lower))
+        .collect();
+    candidates.sort_by_key(|r| db.resolve_string2(r.name_offset).len());
+    candidates
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::Internal(format!("entity '{name}' not found in DataCore")))
+}
+
+/// Write the decomposed export to `<export_root>/Packages/<pkg>` and
+/// `<export_root>/Data/...`. This is the cache write path; subsequent
+/// calls with the same (entity, opts) skip the export entirely.
+fn write_scene_export(
+    export_root: &Path,
+    files: &[starbreaker_3d::ExportedFile],
+    package_name: &str,
+) -> Result<(), AppError> {
+    // Wipe just the package directory so material sidecars from a previous
+    // run can't bleed into a new export. Data/* assets are reused (cheap).
+    let package_root = export_root.join("Packages").join(package_name);
+    if package_root.exists() {
+        std::fs::remove_dir_all(&package_root).map_err(|e| {
+            AppError::Internal(format!(
+                "failed to clear stale package dir '{}': {e}",
+                package_root.display(),
+            ))
+        })?;
+    }
+    std::fs::create_dir_all(&package_root)?;
+
+    for file in files {
+        let path = export_root.join(&file.relative_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, &file.bytes)?;
+    }
+    Ok(())
+}
+
+async fn pump_scene_progress(
+    app: AppHandle,
+    entity_name: String,
+    progress: Arc<Progress>,
+    done: Arc<AtomicBool>,
+) {
+    // Hard cap displayed progress at 0.99 until the export task signals
+    // completion. The internal Progress value is bounded at 1.0 by
+    // Progress::report's clamp, but stale completion writes from one
+    // phase have caused the UI to flash >100% in the past. Capping here
+    // means the bar can never overshoot, and we deliberately render a
+    // "Finishing..." stage when we hit the ceiling so the user knows
+    // the run is still alive at the cap.
+    loop {
+        let is_done = done.load(Ordering::Relaxed);
+        let (raw_fraction, raw_stage) = progress.get();
+        let (fraction, stage) = if is_done {
+            (1.0_f32, raw_stage)
+        } else if raw_fraction >= 0.99 {
+            (
+                0.99_f32,
+                if raw_stage.is_empty() {
+                    "Finishing...".to_string()
+                } else {
+                    raw_stage
+                },
+            )
+        } else {
+            (raw_fraction.clamp(0.0, 0.99), raw_stage)
+        };
+        let _ = app.emit(
+            "scene-export-progress",
+            SceneExportProgress {
+                fraction,
+                stage,
+                entity_name: entity_name.clone(),
+            },
+        );
+        if is_done {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Run the decomposed exporter for a single entity in-process. Writes
+/// to the cache slot for the given options and emits progress on
+/// `scene-export-progress`. Always emits a single `scene-export-done`
+/// when the task finishes (success or failure).
+#[tauri::command]
+pub async fn start_scene_export(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    entity_name: String,
+    opts: SceneExportOpts,
+) -> Result<(), AppError> {
+    state.scene_export_cancel.store(false, Ordering::SeqCst);
+
+    let p4k = {
+        let guard = state.p4k.lock();
+        guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?
+            .clone()
+    };
+    let dcb_bytes = {
+        let guard = state.dcb_bytes.lock();
+        guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("DataCore not loaded".into()))?
+            .clone()
+    };
+    let cancel = state.scene_export_cancel.clone();
+    let export_root = scene_cache_dir(&app, &entity_name, &opts)?;
+    let predicted_package = predicted_package_name(&entity_name, &opts);
+
+    let progress = Arc::new(Progress::new());
+    let done_flag = Arc::new(AtomicBool::new(false));
+    tauri::async_runtime::spawn(pump_scene_progress(
+        app.clone(),
+        entity_name.clone(),
+        progress.clone(),
+        done_flag.clone(),
+    ));
+
+    let app_for_done = app.clone();
+    let entity_for_done = entity_name.clone();
+    tokio::task::spawn_blocking(move || {
+        let result = run_scene_export_blocking(
+            &p4k,
+            &dcb_bytes,
+            &entity_name,
+            &export_root,
+            &predicted_package,
+            &opts,
+            &progress,
+            &cancel,
+        );
+        progress.report(1.0, "Done");
+        done_flag.store(true, Ordering::Relaxed);
+        let _ = app_for_done.emit(
+            "scene-export-done",
+            match result {
+                Ok(pkg) => SceneExportDone {
+                    entity_name: entity_for_done,
+                    package_dir: Some(pkg.to_string_lossy().into_owned()),
+                    error: None,
+                },
+                Err(e) => SceneExportDone {
+                    entity_name: entity_for_done,
+                    package_dir: None,
+                    error: Some(e.to_string()),
+                },
+            },
+        );
+    });
+
+    Ok(())
+}
+
+/// Cancel the in-flight scene export, if any. Cancellation is checked
+/// before each entity's resolve step, so the current export may still
+/// finish writing files before stopping.
+#[tauri::command]
+pub fn cancel_scene_export(state: State<'_, AppState>) {
+    state.scene_export_cancel.store(true, Ordering::SeqCst);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_scene_export_blocking(
+    p4k: &MappedP4k,
+    dcb_bytes: &[u8],
+    entity_name: &str,
+    export_root: &Path,
+    predicted_package: &str,
+    opts: &SceneExportOpts,
+    progress: &Progress,
+    cancel: &AtomicBool,
+) -> Result<PathBuf, AppError> {
+    if cancel.load(Ordering::Relaxed) {
+        return Err(AppError::Internal("export cancelled".into()));
+    }
+
+    progress.report(0.02, "Loading DataCore");
+    let db = Database::from_bytes(dcb_bytes)?;
+
+    progress.report(0.05, "Resolving entity");
+    let record = resolve_entity_record(&db, entity_name)?;
+
+    if cancel.load(Ordering::Relaxed) {
+        return Err(AppError::Internal("export cancelled".into()));
+    }
+
+    progress.report(0.10, "Resolving loadout");
+    let idx = EntityIndex::new(&db);
+    let tree = resolve_loadout_indexed(&idx, record);
+
+    let export_opts = opts.to_export_options();
+    progress.report(0.20, "Assembling scene");
+
+    let result = starbreaker_3d::assemble_glb_with_loadout_with_progress(
+        &db,
+        p4k,
+        record,
+        &tree,
+        &export_opts,
+        Some(progress),
+        None,
+    )?;
+
+    let decomposed = result
+        .decomposed
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("scene export returned no decomposed files".into()))?;
+
+    progress.report(0.92, "Writing package");
+    write_scene_export(export_root, &decomposed.files, predicted_package)?;
+
+    let package_dir = find_package_with_scene(export_root).ok_or_else(|| {
+        AppError::Internal(format!(
+            "scene export wrote files but no scene.json found under '{}'",
+            export_root.display()
+        ))
+    })?;
+
+    progress.report(0.99, "Finalizing");
+    Ok(package_dir)
+}
+
+#[cfg(test)]
+mod scene_tests {
+    use super::*;
+
+    #[test]
+    fn cache_suffix_changes_with_each_relevant_option() {
+        let base = SceneExportOpts::default();
+        let suffix_default = base.cache_suffix();
+        let mut alt = base.clone();
+        alt.lod = 2;
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.mip = 4;
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.material_mode = "colors".into();
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.include_attachments = false;
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.include_interior = false;
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.include_lights = false;
+        assert_ne!(suffix_default, alt.cache_suffix());
+        let mut alt = base.clone();
+        alt.include_nodraw = true;
+        assert_ne!(suffix_default, alt.cache_suffix());
+    }
+
+    #[test]
+    fn cache_suffix_is_stable_for_unknown_material_mode() {
+        // Unknown material values fall back to "textures" both for the
+        // export options and the cache key. Two unknown values must
+        // produce the same cache slot.
+        let mut a = SceneExportOpts::default();
+        a.material_mode = "garbage".into();
+        let mut b = SceneExportOpts::default();
+        b.material_mode = "alsobad".into();
+        assert_eq!(a.cache_suffix(), b.cache_suffix());
+    }
+
+    #[test]
+    fn sanitize_cache_segment_strips_path_chars() {
+        assert_eq!(sanitize_cache_segment("ARGO_MOLE"), "ARGO_MOLE");
+        assert_eq!(sanitize_cache_segment("RSI Polaris"), "RSI_Polaris");
+        assert_eq!(sanitize_cache_segment("name/with\\stuff"), "name_with_stuff");
+    }
+
+    #[test]
+    fn predicted_package_name_matches_decomposed_layout() {
+        let opts = SceneExportOpts::default();
+        let name = predicted_package_name("RSI_Polaris", &opts);
+        // Default lod=1, mip=2 → matches "..._LOD1_TEX2".
+        assert_eq!(name, "RSI Polaris_LOD1_TEX2");
+    }
+
+    #[test]
+    fn cache_suffix_distinguishes_fast_preview_from_full() {
+        // Fast preview (no interiors) must not collide with the full
+        // export's cache slot. The `_i0` vs `_i1` segment in the
+        // suffix is what makes this true.
+        let mut full = SceneExportOpts::default();
+        full.include_interior = true;
+        let mut fast = SceneExportOpts::default();
+        fast.include_interior = false;
+        assert!(full.cache_suffix().contains("_i1_"));
+        assert!(fast.cache_suffix().contains("_i0_"));
+        assert_ne!(full.cache_suffix(), fast.cache_suffix());
+    }
+
+    #[test]
+    fn cache_suffix_carries_contract_version_segment() {
+        // Bumping the contract version must shift every cache slot to a
+        // new directory name so old slots become unreachable. The
+        // `_v<N>` segment at the tail is the mechanism.
+        let opts = SceneExportOpts::default();
+        let v1 = cache_suffix_for(&opts, 1);
+        let v2 = cache_suffix_for(&opts, 2);
+        assert!(v1.ends_with("_v1"), "expected v1 suffix tail, got {v1}");
+        assert!(v2.ends_with("_v2"), "expected v2 suffix tail, got {v2}");
+        assert_ne!(v1, v2);
+    }
+
+    #[test]
+    fn cache_suffix_matches_current_contract_version() {
+        // The runtime suffix must end in the current contract version.
+        // If this test fails after a CONTRACT_VERSION bump, that's
+        // expected — both numbers move together.
+        let opts = SceneExportOpts::default();
+        let runtime = opts.cache_suffix();
+        let expected_tail = format!("_v{}", starbreaker_3d::DECOMPOSED_CONTRACT_VERSION);
+        assert!(
+            runtime.ends_with(&expected_tail),
+            "runtime suffix {runtime} does not end in {expected_tail}",
+        );
+    }
+
+    #[test]
+    fn cache_suffix_for_is_deterministic_for_same_inputs() {
+        let opts = SceneExportOpts::default();
+        assert_eq!(cache_suffix_for(&opts, 1), cache_suffix_for(&opts, 1));
+        assert_eq!(cache_suffix_for(&opts, 7), cache_suffix_for(&opts, 7));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_handles_backslashes() {
+        let result = normalize_path("C:\\foo\\bar\\baz.glb");
+        assert_eq!(result, PathBuf::from("C:/foo/bar/baz.glb"));
+    }
+
+    #[test]
+    fn derive_export_root_finds_grandparent_of_packages() {
+        let pkg = PathBuf::from("/tmp/export/Packages/Polaris_LOD0_TEX2");
+        assert_eq!(derive_export_root(&pkg), "/tmp/export");
+    }
+
+    #[test]
+    fn derive_export_root_falls_back_when_no_packages_parent() {
+        let pkg = PathBuf::from("/tmp/standalone");
+        assert_eq!(derive_export_root(&pkg), "/tmp/standalone");
+    }
+}

--- a/app/src-tauri/src/decomposed_commands.rs
+++ b/app/src-tauri/src/decomposed_commands.rs
@@ -322,6 +322,13 @@ impl SceneExportOpts {
             include_shields: false,
             texture_mip: self.mip,
             lod_level: self.lod,
+            // Match the upstream defaults from `ExportOptions::default()`
+            // -- the scene viewer renders parked ships, so we want the
+            // landing-gear-extended pose baked in but no animation
+            // tracks emitted.
+            include_animations: false,
+            apply_default_animation_pose: true,
+            default_animation_tags: vec!["landing_gear_extend".to_string()],
         }
     }
 

--- a/app/src-tauri/src/decomposed_commands.rs
+++ b/app/src-tauri/src/decomposed_commands.rs
@@ -275,6 +275,18 @@ pub struct SceneExportOpts {
     pub include_interior: bool,
     pub include_lights: bool,
     pub include_nodraw: bool,
+    /// When true, the entity list returned by `list_scene_entities`
+    /// also includes records flagged `inclusionMode = "DoNotInclude"`
+    /// (and other non-`ReadyToInclude` values). These are CIG-internal
+    /// or in-development entities -- WIP capital ships, NPC variants,
+    /// derelicts, mission objectives. They are tagged `is_wip: true`
+    /// in the DTO so the UI can mark them. Defaults to false (current
+    /// behaviour: only ship the player-flyable roster).
+    ///
+    /// Does NOT participate in the export cache key -- this is purely
+    /// a list filter.
+    #[serde(default)]
+    pub include_wip: bool,
 }
 
 impl Default for SceneExportOpts {
@@ -288,6 +300,7 @@ impl Default for SceneExportOpts {
             include_interior: true,
             include_lights: true,
             include_nodraw: false,
+            include_wip: false,
         }
     }
 }
@@ -375,6 +388,13 @@ pub struct SceneEntityDto {
     pub category: String,
     /// True if a previous export with the same options is on disk.
     pub cached: bool,
+    /// True when this entity's `inclusionMode != "ReadyToInclude"` --
+    /// it only appears in the list because the caller passed
+    /// `include_wip = true`. The frontend renders a [WIP] badge so
+    /// users know the entity is not officially flyable; export still
+    /// works and may produce a partial mesh / placeholder textures.
+    #[serde(default)]
+    pub is_wip: bool,
 }
 
 #[derive(Clone, Serialize)]
@@ -531,11 +551,20 @@ pub async fn list_scene_entities(
                 continue;
             };
 
-            // Skip non-player variants — same rule as the 3D Export tab.
-            let is_npc_or_internal = inclusion_compiled.as_ref()
-                .and_then(|c| db.query_single::<Value>(c, record).ok().flatten())
-                .is_some_and(|v| matches!(v, Value::Enum(s) if s != "ReadyToInclude"));
-            if is_npc_or_internal {
+            // Skip non-player variants by default. When `include_wip`
+            // is set, keep them but flag with `is_wip = true` so the
+            // UI can render a [WIP] badge. The filter still drops
+            // records with no `EAEntityDataParams` at all (those are
+            // CIG-internal entities that pre-date the inclusion-mode
+            // tagging system) -- the `Some` arm only fires when the
+            // record carries an explicit non-`ReadyToInclude` value.
+            let inclusion_value = inclusion_compiled.as_ref()
+                .and_then(|c| db.query_single::<Value>(c, record).ok().flatten());
+            let is_wip = matches!(
+                &inclusion_value,
+                Some(Value::Enum(s)) if *s != "ReadyToInclude"
+            );
+            if is_wip && !opts.include_wip {
                 continue;
             }
 
@@ -561,6 +590,7 @@ pub async fn list_scene_entities(
                 display_name,
                 category: category.to_string(),
                 cached,
+                is_wip,
             });
         }
 

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod datacore_commands;
 mod decomposed_commands;
 mod error;
+mod scene_commands;
 mod state;
 mod ui_sink;
 
@@ -266,6 +267,11 @@ fn main() {
             decomposed_commands::prune_stale_cache,
             commands::write_diag_file,
             commands::list_diag_dir,
+            scene_commands::load_scene_to_gltf,
+            scene_commands::read_scene_glb,
+            scene_commands::enumerate_scenes,
+            scene_commands::list_socpak_dir_cmd,
+            scene_commands::list_all_socpaks_cmd,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod audio_commands;
 mod commands;
 mod datacore_commands;
+mod decomposed_commands;
 mod error;
 mod state;
 mod ui_sink;
@@ -170,7 +171,13 @@ fn main() {
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(log::LevelFilter::Info)
-                .target(tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview))
+                .max_file_size(50_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+                // Webview target removed: it routes Rust logs back to the JS
+                // console via attachConsole, where forwardConsole re-captures
+                // them and sends them back to Rust, creating an infinite loop.
+                // Use Stdout (terminal during `tauri dev`) and LogDir (file)
+                // for log inspection instead of DevTools.
                 .target(tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout))
                 .target(tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }))
                 .build(),
@@ -243,6 +250,20 @@ fn main() {
             commands::extract_p4k_file,
             commands::read_p4k_file,
             commands::extract_p4k_folder,
+            decomposed_commands::read_decomposed_file,
+            decomposed_commands::load_decomposed_json,
+            decomposed_commands::load_decomposed_scene,
+            decomposed_commands::load_decomposed_palettes,
+            decomposed_commands::load_decomposed_liveries,
+            decomposed_commands::list_decomposed_packages,
+            decomposed_commands::list_scene_entities,
+            decomposed_commands::start_scene_export,
+            decomposed_commands::cancel_scene_export,
+            decomposed_commands::get_scene_cache_path,
+            decomposed_commands::clear_scene_cache,
+            decomposed_commands::clear_all_scene_cache,
+            decomposed_commands::cache_stats,
+            decomposed_commands::prune_stale_cache,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -264,6 +264,8 @@ fn main() {
             decomposed_commands::clear_all_scene_cache,
             decomposed_commands::cache_stats,
             decomposed_commands::prune_stale_cache,
+            commands::write_diag_file,
+            commands::list_diag_dir,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/app/src-tauri/src/scene_commands.rs
+++ b/app/src-tauri/src/scene_commands.rs
@@ -1,0 +1,1077 @@
+// Tauri commands for SOC-based "scene" exports (top-level socpaks like
+// the Executive Hangar). The scene exporter walks a socpak graph,
+// resolves every brush mesh to a CGF on disk, and emits a single `.glb`
+// containing one mesh per unique CGF plus one node per placement plus
+// `KHR_lights_punctual` entries for every light entity.
+//
+// The output is consumed by the Maps tab — this iteration stops at
+// "we can write a glTF, and the existing GLB loader can ingest it"; the
+// frontend Three.js wiring lands in the next iteration.
+//
+// Cache layout (mirrors the decomposed-export cache, separate slot):
+//
+//   <app_local_data_dir>/
+//     scene_cache/
+//       <socpak_hash>__<contract>/
+//         scene.glb
+//         manifest.json
+//
+// The cache key is a hash of the socpak path + the contract version. A
+// contract bump shifts every cache slot.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use starbreaker_3d::soc;
+use starbreaker_3d::soc::{SceneCatalogEntry, SocpakDirEntry, SocpakDirEntryKind};
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+/// Bump when the SOC scene contract changes (mesh / placement / light
+/// schema, glTF emitter behaviour). Old cache slots carrying a
+/// different version stay on disk but are unreachable until pruned.
+///
+/// v2 (B2): cache key now folds in the loaded p4k's mtime + size so a
+/// channel switch (HOTFIX <-> TECH-PREVIEW) or a post-update p4k bump
+/// invalidates stale entries automatically; manifest now carries
+/// `materials_resolved` / `materials_default` counters and emits
+/// `scene-load-progress` events while building.
+///
+/// v3 (C2): emitter caps the light count at the renderer-friendly
+/// default and drops the embedded placeholder PNG for textured
+/// materials. Any v2 cache slot is unsafe to reuse — it carries the
+/// thousands-of-lights GLB that crashes the WebGL shader compiler.
+const SCENE_GLB_CONTRACT_VERSION: u32 = 3;
+
+/// Bump when the scene-catalog enumeration algorithm changes (filter
+/// constants, name-derivation rules, source kinds, etc.). Old
+/// catalog cache JSONs stamped with a different version are
+/// re-enumerated; they stay on disk until pruned. v1 (C3): graph
+/// in-degree-zero roots under `Data/ObjectContainers/` with the
+/// 100 KB minimum-size and `test|tmp|backup` name filters.
+const SCENE_CATALOG_CONTRACT_VERSION: u32 = 1;
+
+/// Search roots the catalog walks by default. Socpaks live almost
+/// exclusively under `Data\ObjectContainers\` -- broadening the
+/// search to the whole archive picks up nothing of interest and
+/// wastes seconds on every cold enumeration.
+const DEFAULT_CATALOG_SEARCH_ROOTS: &[&str] = &["Data/ObjectContainers/"];
+
+/// Maximum recursion depth for the socpak walk. Three is enough for the
+/// observed hangar / dungeon / module hierarchies; deeper levels can
+/// override it through the `max_depth` argument.
+const DEFAULT_MAX_DEPTH: u32 = 4;
+
+/// Response payload for [`load_scene_to_gltf`]. Plain types so the
+/// frontend can deserialise without a shared type contract.
+#[derive(Debug, Clone, Serialize)]
+pub struct LoadSceneResponse {
+    /// Absolute path of the emitted `.glb` on disk.
+    pub glb_path: String,
+    /// Absolute path of the manifest JSON written next to the GLB.
+    pub manifest_path: String,
+    /// True when the slot was already present and the command did not
+    /// re-emit. Useful for the frontend to choose between "loading..."
+    /// and "ready" UI states.
+    pub cache_hit: bool,
+    /// Mesh and placement counts in the emitted GLB.
+    pub mesh_count: u32,
+    pub placement_count: u32,
+    /// Lights kept in the emitted GLB. Capped to a renderer-friendly
+    /// budget so the WebGL fragment shader does not exceed
+    /// `MAX_FRAGMENT_UNIFORM_VECTORS`.
+    pub light_count: u32,
+    /// Lights present in the source scene but skipped because the cap
+    /// was reached. `lights_dropped + light_count` equals the total
+    /// number of lights the SOC parser found.
+    pub lights_dropped: u32,
+    /// World-space AABB of the brush placements, when at least one
+    /// brush resolved. CryEngine Z-up.
+    pub aabb_min: Option<[f32; 3]>,
+    pub aabb_max: Option<[f32; 3]>,
+    /// Bytes of the emitted GLB on disk. Useful for "show file size in
+    /// the loading dialog" affordances.
+    pub glb_bytes: u64,
+    /// How many brush placements were dropped because their mesh failed
+    /// to resolve. Surfacing this on the UI side helps spot a sudden
+    /// regression in mesh-loading coverage.
+    pub dropped_placements: u32,
+    /// How many unique mesh paths failed to resolve in the underlying
+    /// p4k.
+    pub failed_mesh_paths: u32,
+    /// Unique meshes whose MTL file resolved successfully.
+    pub materials_resolved: u32,
+    /// Unique meshes that fell back to the neutral default material
+    /// because no MTL was found.
+    pub materials_default: u32,
+}
+
+/// Payload emitted on the `scene-load-progress` event. Phases progress
+/// monotonically through `compose -> resolve -> emit -> cache_write`.
+/// The frontend reads `(current, total)` for the active phase and
+/// renders a determinate bar.
+#[derive(Debug, Clone, Serialize)]
+pub struct SceneLoadProgress {
+    pub phase: &'static str,
+    pub current: u32,
+    pub total: u32,
+    /// Free-form status line for the loading dialog. Empty string when
+    /// the phase progress alone is informative enough.
+    pub message: String,
+}
+
+/// Read a GLB file from disk and return the bytes. The frontend uses
+/// this to fetch the cached scene GLB into a `Uint8Array` it can hand
+/// directly to GLTFLoader.parse, avoiding any need for an asset:
+/// protocol capability. The path must be an absolute path to a file
+/// inside our app-local-data scene cache root; we reject paths that
+/// escape the cache to keep this from becoming a generic file-read
+/// primitive.
+#[tauri::command]
+pub async fn read_scene_glb(
+    app: AppHandle,
+    glb_path: String,
+) -> Result<Vec<u8>, AppError> {
+    let cache_root = scene_glb_cache_root(&app)?;
+    let cache_root_canon = std::fs::canonicalize(&cache_root).unwrap_or(cache_root);
+    let candidate = std::path::PathBuf::from(&glb_path);
+    let candidate_canon = std::fs::canonicalize(&candidate)
+        .map_err(|e| AppError::Internal(format!("scene glb canonicalize: {e}")))?;
+    if !candidate_canon.starts_with(&cache_root_canon) {
+        return Err(AppError::Internal(format!(
+            "refusing to read glb outside cache root: {}",
+            candidate_canon.display()
+        )));
+    }
+    tokio::task::spawn_blocking(move || std::fs::read(&candidate_canon).map_err(AppError::Io))
+        .await
+        .map_err(|e| AppError::Internal(format!("read_scene_glb join: {e}")))?
+}
+
+/// Build a renderable scene for the given socpak and emit it as a GLB
+/// on disk. Returns the cache path of the GLB plus a small summary.
+/// Called by the frontend's Maps tab when the user opens a scene.
+#[tauri::command]
+pub async fn load_scene_to_gltf(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    socpak_path: String,
+    max_depth: Option<u32>,
+) -> Result<LoadSceneResponse, AppError> {
+    let (p4k, p4k_path) = {
+        let guard = state.p4k.lock();
+        let arc = guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?
+            .clone();
+        let path = arc.path().to_string_lossy().into_owned();
+        (arc, path)
+    };
+    let cache_root = scene_glb_cache_root(&app)?;
+    std::fs::create_dir_all(&cache_root)?;
+
+    let depth = max_depth.unwrap_or(DEFAULT_MAX_DEPTH);
+    // Fold the loaded p4k's mtime + size into the cache key so channel
+    // swaps (HOTFIX <-> TECH-PREVIEW) or post-update file replacement
+    // invalidate stale slots without forcing a manual purge. Defaults to
+    // 0/0 when the metadata read fails, which still produces a stable
+    // key that just happens to ignore identity (unavoidable: better to
+    // serve a slot than refuse to render).
+    let p4k_id = p4k_identity(&p4k_path).unwrap_or_default();
+    let cache_dir = scene_glb_cache_dir(&cache_root, &socpak_path, depth, &p4k_id);
+    let glb_path = cache_dir.join("scene.glb");
+    let manifest_path = cache_dir.join("manifest.json");
+
+    if glb_path.is_file() && manifest_path.is_file() {
+        if let Ok(text) = std::fs::read_to_string(&manifest_path)
+            && let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
+        {
+            return Ok(response_from_cached_manifest(
+                &glb_path,
+                &manifest_path,
+                &value,
+            ));
+        }
+    }
+
+    let socpak_path_for_blocking = socpak_path.clone();
+    let cache_dir_for_blocking = cache_dir.clone();
+    let glb_path_for_blocking = glb_path.clone();
+    let manifest_path_for_blocking = manifest_path.clone();
+    let app_for_blocking = app.clone();
+
+    tokio::task::spawn_blocking(move || {
+        std::fs::create_dir_all(&cache_dir_for_blocking)?;
+
+        // Compose phase. Indeterminate (zone count is not known up
+        // front), so we report 0/0 once before kicking off and let the
+        // resolve phase replace it with a proper bar.
+        emit_progress(&app_for_blocking, "compose", 0, 0, "Composing zones...");
+        let scene = soc::compose_from_root(&p4k, &socpak_path_for_blocking, depth)
+            .map_err(|e| AppError::Internal(format!("compose_from_root: {e}")))?;
+        emit_progress(
+            &app_for_blocking,
+            "compose",
+            scene.zones.len() as u32,
+            scene.zones.len() as u32,
+            &format!(
+                "Composed {} zones ({} brushes)",
+                scene.zones.len(),
+                scene.zones.iter().map(|z| z.brushes.len()).sum::<usize>()
+            ),
+        );
+
+        // Resolve phase. ~10 Hz throttle: track the last-emitted
+        // timestamp and suppress events that arrive sooner than 100ms
+        // after the previous one. Final tick is forced through.
+        let last_emit_ms = Arc::new(AtomicU64::new(0));
+        let resolve_start = Instant::now();
+        let app_resolve = app_for_blocking.clone();
+        let renderable = {
+            let last_emit_ms = last_emit_ms.clone();
+            let mut on_progress = |current: usize, total: usize| {
+                let now_ms = resolve_start.elapsed().as_millis() as u64;
+                let prev = last_emit_ms.load(Ordering::Relaxed);
+                let is_final = current == total && total > 0;
+                if !is_final && now_ms.saturating_sub(prev) < 100 {
+                    return;
+                }
+                last_emit_ms.store(now_ms, Ordering::Relaxed);
+                emit_progress(
+                    &app_resolve,
+                    "resolve",
+                    current as u32,
+                    total as u32,
+                    &format!("Resolving meshes {current}/{total}"),
+                );
+            };
+            soc::resolve_scene_with_progress(&p4k, &scene, &mut on_progress)
+        };
+
+        // Emit phase. The glTF emitter is a single linear pass; we
+        // report start + end so the bar advances without trying to
+        // instrument the bytecode walker.
+        emit_progress(
+            &app_for_blocking,
+            "emit",
+            0,
+            renderable.meshes.len() as u32,
+            "Emitting glTF...",
+        );
+        let (glb_bytes, summary) = soc::emit_glb(&renderable)
+            .map_err(|e| AppError::Internal(format!("emit_glb: {e}")))?;
+        emit_progress(
+            &app_for_blocking,
+            "emit",
+            renderable.meshes.len() as u32,
+            renderable.meshes.len() as u32,
+            &format!(
+                "Emitted {} bytes ({} meshes)",
+                glb_bytes.len(),
+                renderable.meshes.len()
+            ),
+        );
+
+        // Cache write.
+        emit_progress(
+            &app_for_blocking,
+            "cache_write",
+            0,
+            1,
+            "Writing cache...",
+        );
+        std::fs::write(&glb_path_for_blocking, &glb_bytes)?;
+
+        let manifest = build_manifest(
+            &socpak_path_for_blocking,
+            depth,
+            &summary,
+            renderable.dropped_placements,
+            renderable.failed_mesh_paths,
+            renderable.materials_resolved,
+            renderable.materials_default,
+            glb_bytes.len() as u64,
+            &p4k_id,
+        );
+        std::fs::write(
+            &manifest_path_for_blocking,
+            serde_json::to_string_pretty(&manifest)
+                .map_err(|e| AppError::Internal(format!("manifest serialize: {e}")))?,
+        )?;
+        emit_progress(
+            &app_for_blocking,
+            "cache_write",
+            1,
+            1,
+            "Cache written",
+        );
+
+        let response = LoadSceneResponse {
+            glb_path: glb_path_for_blocking.to_string_lossy().into_owned(),
+            manifest_path: manifest_path_for_blocking.to_string_lossy().into_owned(),
+            cache_hit: false,
+            mesh_count: summary.mesh_count,
+            placement_count: summary.placement_count,
+            light_count: summary.light_count,
+            lights_dropped: summary.lights_dropped,
+            aabb_min: summary.aabb_min,
+            aabb_max: summary.aabb_max,
+            glb_bytes: glb_bytes.len() as u64,
+            dropped_placements: renderable.dropped_placements,
+            failed_mesh_paths: renderable.failed_mesh_paths,
+            materials_resolved: renderable.materials_resolved,
+            materials_default: renderable.materials_default,
+        };
+        Ok::<LoadSceneResponse, AppError>(response)
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("scene task join: {e}")))?
+}
+
+/// Emit a `scene-load-progress` event. Failures are swallowed: if the
+/// frontend's listener has unmounted, we still want the build to
+/// continue.
+fn emit_progress(
+    app: &AppHandle,
+    phase: &'static str,
+    current: u32,
+    total: u32,
+    message: &str,
+) {
+    let _ = app.emit(
+        "scene-load-progress",
+        SceneLoadProgress {
+            phase,
+            current,
+            total,
+            message: message.to_string(),
+        },
+    );
+}
+
+/// Stable-ish identity for a p4k file: `(mtime_unix_secs, size_bytes)`.
+/// Folded into the cache key so channel switches and post-update file
+/// replacement invalidate stale slots automatically.
+#[derive(Debug, Default, Clone, Copy)]
+struct P4kIdentity {
+    mtime_secs: i64,
+    size_bytes: u64,
+}
+
+fn p4k_identity(path: &str) -> Option<P4kIdentity> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    Some(P4kIdentity {
+        mtime_secs: mtime,
+        size_bytes: meta.len(),
+    })
+}
+
+fn response_from_cached_manifest(
+    glb_path: &std::path::Path,
+    manifest_path: &std::path::Path,
+    value: &serde_json::Value,
+) -> LoadSceneResponse {
+    let glb_bytes = std::fs::metadata(glb_path).map(|m| m.len()).unwrap_or(0);
+    let mesh_count = value
+        .get("mesh_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let placement_count = value
+        .get("placement_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let light_count = value
+        .get("light_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let lights_dropped = value
+        .get("lights_dropped")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let dropped_placements = value
+        .get("dropped_placements")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let failed_mesh_paths = value
+        .get("failed_mesh_paths")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let materials_resolved = value
+        .get("materials_resolved")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let materials_default = value
+        .get("materials_default")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let aabb_min = value.get("aabb_min").and_then(parse_vec3);
+    let aabb_max = value.get("aabb_max").and_then(parse_vec3);
+    LoadSceneResponse {
+        glb_path: glb_path.to_string_lossy().into_owned(),
+        manifest_path: manifest_path.to_string_lossy().into_owned(),
+        cache_hit: true,
+        mesh_count,
+        placement_count,
+        light_count,
+        lights_dropped,
+        aabb_min,
+        aabb_max,
+        glb_bytes,
+        dropped_placements,
+        failed_mesh_paths,
+        materials_resolved,
+        materials_default,
+    }
+}
+
+fn parse_vec3(value: &serde_json::Value) -> Option<[f32; 3]> {
+    let arr = value.as_array()?;
+    if arr.len() != 3 {
+        return None;
+    }
+    Some([
+        arr[0].as_f64()? as f32,
+        arr[1].as_f64()? as f32,
+        arr[2].as_f64()? as f32,
+    ])
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_manifest(
+    socpak_path: &str,
+    max_depth: u32,
+    summary: &soc::GlbEmitSummary,
+    dropped_placements: u32,
+    failed_mesh_paths: u32,
+    materials_resolved: u32,
+    materials_default: u32,
+    glb_bytes: u64,
+    p4k_id: &P4kIdentity,
+) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "contract_version".into(),
+        serde_json::json!(SCENE_GLB_CONTRACT_VERSION),
+    );
+    map.insert("socpak_path".into(), serde_json::json!(socpak_path));
+    map.insert("max_depth".into(), serde_json::json!(max_depth));
+    map.insert("mesh_count".into(), serde_json::json!(summary.mesh_count));
+    map.insert(
+        "placement_count".into(),
+        serde_json::json!(summary.placement_count),
+    );
+    map.insert("light_count".into(), serde_json::json!(summary.light_count));
+    map.insert(
+        "lights_dropped".into(),
+        serde_json::json!(summary.lights_dropped),
+    );
+    map.insert(
+        "material_count".into(),
+        serde_json::json!(summary.material_count),
+    );
+    map.insert(
+        "texture_count".into(),
+        serde_json::json!(summary.texture_count),
+    );
+    if let Some(mn) = summary.aabb_min {
+        map.insert("aabb_min".into(), serde_json::json!(mn));
+    }
+    if let Some(mx) = summary.aabb_max {
+        map.insert("aabb_max".into(), serde_json::json!(mx));
+    }
+    map.insert(
+        "dropped_placements".into(),
+        serde_json::json!(dropped_placements),
+    );
+    map.insert(
+        "failed_mesh_paths".into(),
+        serde_json::json!(failed_mesh_paths),
+    );
+    map.insert(
+        "materials_resolved".into(),
+        serde_json::json!(materials_resolved),
+    );
+    map.insert(
+        "materials_default".into(),
+        serde_json::json!(materials_default),
+    );
+    map.insert("glb_bytes".into(), serde_json::json!(glb_bytes));
+    map.insert(
+        "p4k_mtime_secs".into(),
+        serde_json::json!(p4k_id.mtime_secs),
+    );
+    map.insert(
+        "p4k_size_bytes".into(),
+        serde_json::json!(p4k_id.size_bytes),
+    );
+    serde_json::Value::Object(map)
+}
+
+fn scene_glb_cache_root(app: &AppHandle) -> Result<PathBuf, AppError> {
+    let local = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_local_data_dir unavailable: {e}")))?;
+    Ok(local.join("scene_cache"))
+}
+
+fn scene_glb_cache_dir(
+    cache_root: &std::path::Path,
+    socpak_path: &str,
+    max_depth: u32,
+    p4k_id: &P4kIdentity,
+) -> PathBuf {
+    let hash = stable_hash_socpak(socpak_path, max_depth, p4k_id);
+    let safe_tail = sanitize_socpak_tail(socpak_path);
+    cache_root.join(format!(
+        "{safe_tail}__d{max_depth}_{hash:016x}_v{SCENE_GLB_CONTRACT_VERSION}"
+    ))
+}
+
+/// Stable hash over the socpak path + max_depth + p4k identity so the
+/// cache key is deterministic across app restarts and invalidates when
+/// the underlying p4k file changes (channel switch, post-update). Uses
+/// the same `DefaultHasher` algorithm the rest of the codebase relies
+/// on for option fingerprints.
+fn stable_hash_socpak(socpak_path: &str, max_depth: u32, p4k_id: &P4kIdentity) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::hash::DefaultHasher::new();
+    socpak_path.to_ascii_lowercase().hash(&mut hasher);
+    max_depth.hash(&mut hasher);
+    p4k_id.mtime_secs.hash(&mut hasher);
+    p4k_id.size_bytes.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Take the file stem of a socpak path and sanitise it for filesystem
+/// use. Result is bounded at 64 ASCII chars so cache directory names
+/// stay manageable.
+fn sanitize_socpak_tail(socpak_path: &str) -> String {
+    let tail = socpak_path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(socpak_path);
+    let stem = tail.strip_suffix(".socpak").unwrap_or(tail);
+    let mut out = String::with_capacity(stem.len().min(64));
+    for ch in stem.chars().take(64) {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-' | '.' => out.push(ch),
+            ' ' => out.push('_'),
+            _ => out.push('_'),
+        }
+    }
+    if out.is_empty() {
+        "scene".into()
+    } else {
+        out
+    }
+}
+
+// ── Scene catalog (Maps tab list) ───────────────────────────────────────────
+//
+// The scene catalog enumerates every "scene root" socpak in the loaded
+// p4k. A root is a socpak that no other socpak references as a child.
+// Enumeration walks every socpak under
+// `DEFAULT_CATALOG_SEARCH_ROOTS`, builds a child-reference graph,
+// and returns the in-degree-zero nodes. Result is cached to disk so
+// the next call against the same p4k is a JSON read instead of a
+// fresh ~5-15s enumeration.
+
+/// JSON-shape mirror of `soc::SceneCatalogEntry`. We carry our own
+/// type rather than serialising the lib type directly so the
+/// `source_kind` field can ship as a snake-case string without
+/// `starbreaker-3d` taking a serde dependency.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct SceneCatalogEntryDto {
+    pub path: String,
+    pub display_name: String,
+    pub sub_zone_count: usize,
+    /// `"graph_root"` for the C3 implementation. Future variants
+    /// land alongside without a contract version bump.
+    pub source_kind: String,
+}
+
+impl From<SceneCatalogEntry> for SceneCatalogEntryDto {
+    fn from(value: SceneCatalogEntry) -> Self {
+        Self {
+            path: value.path,
+            display_name: value.display_name,
+            sub_zone_count: value.sub_zone_count,
+            source_kind: value.source_kind.as_snake_case().to_string(),
+        }
+    }
+}
+
+/// Cached on-disk representation. Bundles entries with the contract
+/// version so a stale slot from an older algorithm is detected on
+/// load and rebuilt.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+struct SceneCatalogCachePayload {
+    contract_version: u32,
+    p4k_path: String,
+    p4k_mtime_secs: i64,
+    p4k_size_bytes: u64,
+    entries: Vec<SceneCatalogEntryDto>,
+}
+
+/// Walk the loaded p4k and return the in-degree-zero scene roots.
+///
+/// `channel` is reserved for future use (HOTFIX / TECH-PREVIEW
+/// switching without re-loading). For now it is ignored and the
+/// command always operates against the currently-loaded p4k --
+/// surfacing a `Not loaded` error when no archive has been opened.
+#[tauri::command]
+pub async fn enumerate_scenes(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    #[allow(unused_variables)]
+    channel: Option<String>,
+) -> Result<Vec<SceneCatalogEntryDto>, AppError> {
+    let (p4k, p4k_path) = {
+        let guard = state.p4k.lock();
+        let arc = guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?
+            .clone();
+        let path = arc.path().to_string_lossy().into_owned();
+        (arc, path)
+    };
+
+    let p4k_id = p4k_identity(&p4k_path).unwrap_or_default();
+    let cache_root = scene_catalog_cache_root(&app)?;
+    std::fs::create_dir_all(&cache_root)?;
+    let cache_path = scene_catalog_cache_file(&cache_root, &p4k_path, &p4k_id);
+
+    if cache_path.is_file()
+        && let Ok(text) = std::fs::read_to_string(&cache_path)
+        && let Ok(payload) = serde_json::from_str::<SceneCatalogCachePayload>(&text)
+        && payload.contract_version == SCENE_CATALOG_CONTRACT_VERSION
+        && payload.p4k_mtime_secs == p4k_id.mtime_secs
+        && payload.p4k_size_bytes == p4k_id.size_bytes
+    {
+        return Ok(payload.entries);
+    }
+
+    let p4k_path_for_blocking = p4k_path.clone();
+    let cache_path_for_blocking = cache_path.clone();
+    let entries = tokio::task::spawn_blocking(move || -> Result<Vec<SceneCatalogEntryDto>, AppError> {
+        let raw = soc::enumerate_scene_roots(&p4k, DEFAULT_CATALOG_SEARCH_ROOTS)
+            .map_err(|e| AppError::Internal(format!("enumerate_scene_roots: {e}")))?;
+        let dtos: Vec<SceneCatalogEntryDto> =
+            raw.into_iter().map(SceneCatalogEntryDto::from).collect();
+
+        // Best-effort cache write. A serialise / write failure is
+        // logged but does not fail the command -- the user still
+        // gets the catalog, the next call just rebuilds it.
+        let payload = SceneCatalogCachePayload {
+            contract_version: SCENE_CATALOG_CONTRACT_VERSION,
+            p4k_path: p4k_path_for_blocking,
+            p4k_mtime_secs: p4k_id.mtime_secs,
+            p4k_size_bytes: p4k_id.size_bytes,
+            entries: dtos.clone(),
+        };
+        match serde_json::to_string(&payload) {
+            Ok(text) => {
+                if let Err(err) = std::fs::write(&cache_path_for_blocking, text) {
+                    log::warn!(
+                        "scene-catalog: failed to write cache to {}: {err}",
+                        cache_path_for_blocking.display()
+                    );
+                }
+            }
+            Err(err) => log::warn!("scene-catalog: failed to serialise cache: {err}"),
+        }
+        Ok(dtos)
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("scene catalog task join: {e}")))?;
+
+    entries
+}
+
+fn scene_catalog_cache_root(app: &AppHandle) -> Result<PathBuf, AppError> {
+    let local = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_local_data_dir unavailable: {e}")))?;
+    Ok(local.join("scene_catalog"))
+}
+
+/// One JSON file per (p4k path, mtime, size) tuple. Channel switches
+/// land in a different filename automatically; post-update file
+/// replacement lands in a different filename automatically. We do
+/// not delete stale slots -- they are cheap on disk and a future
+/// pruning pass can sweep them.
+fn scene_catalog_cache_file(
+    cache_root: &std::path::Path,
+    p4k_path: &str,
+    p4k_id: &P4kIdentity,
+) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::hash::DefaultHasher::new();
+    p4k_path.to_ascii_lowercase().hash(&mut hasher);
+    p4k_id.mtime_secs.hash(&mut hasher);
+    p4k_id.size_bytes.hash(&mut hasher);
+    let hash = hasher.finish();
+    cache_root.join(format!(
+        "catalog_{hash:016x}_v{SCENE_CATALOG_CONTRACT_VERSION}.json"
+    ))
+}
+
+// ── Lazy directory-tree listing (Maps tab) ─────────────────────────────────
+//
+// Replaces the eager `enumerate_scenes` traversal as the catalog
+// driver. The frontend asks for one prefix at a time; this command
+// returns its immediate children (subdirs + `.socpak` files) and the
+// frontend caches expanded branches client-side.
+
+/// JSON-shape mirror of `soc::SocpakDirEntry`. Carrying our own type
+/// keeps the underlying lib type free of a serde dependency and lets
+/// the `kind` field ship as a stable snake-case string the frontend can
+/// pattern-match without an enum bump.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct SocpakDirEntryDto {
+    pub path: String,
+    pub display_name: String,
+    /// `"directory"` or `"socpak_file"`.
+    pub kind: String,
+    pub size_or_count: u64,
+}
+
+impl From<SocpakDirEntry> for SocpakDirEntryDto {
+    fn from(value: SocpakDirEntry) -> Self {
+        Self {
+            path: value.path,
+            display_name: value.display_name,
+            kind: match value.kind {
+                SocpakDirEntryKind::Directory => "directory".into(),
+                SocpakDirEntryKind::SocpakFile => "socpak_file".into(),
+            },
+            size_or_count: value.size_or_count,
+        }
+    }
+}
+
+/// List the immediate children of a p4k directory prefix as
+/// directories + `.socpak` files, sorted (dirs first, both
+/// alphabetical). Used by the Maps tab tree to expand a branch on
+/// click without paying the cost of a full graph traversal.
+///
+/// `prefix` is a p4k-internal directory path. Trailing-separator and
+/// slash-flavour are normalised internally.
+#[tauri::command]
+pub async fn list_socpak_dir_cmd(
+    state: State<'_, AppState>,
+    prefix: String,
+) -> Result<Vec<SocpakDirEntryDto>, AppError> {
+    let p4k = {
+        let guard = state.p4k.lock();
+        guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?
+            .clone()
+    };
+
+    // The listing is fast enough (sub-millisecond on `Data\ObjectContainers\`,
+    // a few ms on the largest interior subtrees) that an uncached
+    // synchronous call inside the async runtime is fine. If a future
+    // prefix turns out to be expensive, we can lift this into
+    // `spawn_blocking`.
+    let entries = soc::list_socpak_dir(&p4k, &prefix);
+    Ok(entries.into_iter().map(SocpakDirEntryDto::from).collect())
+}
+
+// ── Global socpak path index (Maps tab "search everywhere") ────────────────
+//
+// `list_all_socpaks_cmd` is the cousin of `list_socpak_dir_cmd`: instead
+// of returning one branch's children, it returns every `.socpak` path in
+// the loaded p4k. Intended to seed the Maps tab's search box -- the lazy
+// tree's branch-by-branch filter cannot find a path under an unexpanded
+// directory, but this list can.
+//
+// Cache key: the loaded p4k's mtime + size, the same identity tuple
+// `load_scene_to_gltf` uses. A channel switch or post-update file
+// replacement automatically lands in a different cache slot. Cold call
+// against the live HOTFIX archive completes in a few hundred ms; a
+// cached call is a JSON read.
+
+/// Bump when the global-index payload shape or filter rules change.
+/// Today: single field (entries: Vec<String>) plus identity tuple.
+const SOCPAK_INDEX_CONTRACT_VERSION: u32 = 1;
+
+/// Default search roots for the global socpak index. Mirrors
+/// [`DEFAULT_CATALOG_SEARCH_ROOTS`] -- broadening past `Data\ObjectContainers\`
+/// returns nothing the Maps tab can sensibly load.
+const DEFAULT_INDEX_SEARCH_ROOTS: &[&str] = &["Data/ObjectContainers/"];
+
+/// On-disk cache payload for the global socpak path index. Carries the
+/// contract version + p4k identity so a stale slot from a different
+/// archive (or older algorithm) is detected and rebuilt.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+struct SocpakIndexCachePayload {
+    contract_version: u32,
+    p4k_path: String,
+    p4k_mtime_secs: i64,
+    p4k_size_bytes: u64,
+    entries: Vec<String>,
+}
+
+/// Walk every entry in the loaded p4k and return the path of every
+/// `.socpak` file under any of `search_roots` (defaults to
+/// `["Data/ObjectContainers/"]`). Returned paths are sorted
+/// alphabetically (case-insensitive). Cached on disk by p4k identity --
+/// the cold call is a few hundred ms, the cached call is a JSON read.
+#[tauri::command]
+pub async fn list_all_socpaks_cmd(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    search_roots: Option<Vec<String>>,
+) -> Result<Vec<String>, AppError> {
+    let (p4k, p4k_path) = {
+        let guard = state.p4k.lock();
+        let arc = guard
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?
+            .clone();
+        let path = arc.path().to_string_lossy().into_owned();
+        (arc, path)
+    };
+
+    let p4k_id = p4k_identity(&p4k_path).unwrap_or_default();
+    let cache_root = socpak_index_cache_root(&app)?;
+    std::fs::create_dir_all(&cache_root)?;
+
+    // The cache filename folds in the chosen search-root set so two
+    // callers with different roots do not stomp each other. Default
+    // callers always land in the same slot.
+    let roots_for_key: Vec<String> = match &search_roots {
+        Some(v) => v.clone(),
+        None => DEFAULT_INDEX_SEARCH_ROOTS.iter().map(|s| (*s).to_string()).collect(),
+    };
+    let cache_path = socpak_index_cache_file(&cache_root, &p4k_path, &p4k_id, &roots_for_key);
+
+    if cache_path.is_file()
+        && let Ok(text) = std::fs::read_to_string(&cache_path)
+        && let Ok(payload) = serde_json::from_str::<SocpakIndexCachePayload>(&text)
+        && payload.contract_version == SOCPAK_INDEX_CONTRACT_VERSION
+        && payload.p4k_mtime_secs == p4k_id.mtime_secs
+        && payload.p4k_size_bytes == p4k_id.size_bytes
+    {
+        return Ok(payload.entries);
+    }
+
+    // Cold path. Run the linear scan on a blocking task; even at a
+    // few hundred ms it would otherwise stall the Tauri runtime.
+    let p4k_path_for_blocking = p4k_path.clone();
+    let cache_path_for_blocking = cache_path.clone();
+    let entries = tokio::task::spawn_blocking(move || -> Result<Vec<String>, AppError> {
+        let roots: Vec<&str> = roots_for_key.iter().map(|s| s.as_str()).collect();
+        let entries = soc::list_all_socpaks(&p4k, &roots);
+
+        // Best-effort cache write. A serialise / write failure logs but
+        // does not fail the command -- the user still gets the index;
+        // the next call just rebuilds it.
+        let payload = SocpakIndexCachePayload {
+            contract_version: SOCPAK_INDEX_CONTRACT_VERSION,
+            p4k_path: p4k_path_for_blocking,
+            p4k_mtime_secs: p4k_id.mtime_secs,
+            p4k_size_bytes: p4k_id.size_bytes,
+            entries: entries.clone(),
+        };
+        match serde_json::to_string(&payload) {
+            Ok(text) => {
+                if let Err(err) = std::fs::write(&cache_path_for_blocking, text) {
+                    log::warn!(
+                        "socpak-index: failed to write cache to {}: {err}",
+                        cache_path_for_blocking.display()
+                    );
+                }
+            }
+            Err(err) => log::warn!("socpak-index: failed to serialise cache: {err}"),
+        }
+        Ok(entries)
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("socpak index task join: {e}")))?;
+
+    entries
+}
+
+fn socpak_index_cache_root(app: &AppHandle) -> Result<PathBuf, AppError> {
+    let local = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| AppError::Internal(format!("app_local_data_dir unavailable: {e}")))?;
+    Ok(local.join("scene_index"))
+}
+
+/// One JSON file per (p4k path, mtime, size, search_roots) tuple.
+/// Channel switches / post-update file replacement / different root
+/// sets each land in a different filename. Slots are not auto-pruned;
+/// they are cheap on disk.
+fn socpak_index_cache_file(
+    cache_root: &std::path::Path,
+    p4k_path: &str,
+    p4k_id: &P4kIdentity,
+    search_roots: &[String],
+) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::hash::DefaultHasher::new();
+    p4k_path.to_ascii_lowercase().hash(&mut hasher);
+    p4k_id.mtime_secs.hash(&mut hasher);
+    p4k_id.size_bytes.hash(&mut hasher);
+    // Order-sensitive on purpose: changing the order of search roots
+    // does not change the resulting set, but keeping the hash sensitive
+    // means the worst case is an extra cold rebuild, never a wrong cache
+    // hit.
+    for r in search_roots {
+        r.to_ascii_lowercase().hash(&mut hasher);
+    }
+    let hash = hasher.finish();
+    cache_root.join(format!(
+        "index_{hash:016x}_v{SOCPAK_INDEX_CONTRACT_VERSION}.json"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id() -> P4kIdentity {
+        P4kIdentity {
+            mtime_secs: 1_700_000_000,
+            size_bytes: 4096,
+        }
+    }
+
+    #[test]
+    fn cache_dir_distinguishes_socpaks() {
+        let root = std::path::Path::new("/cache");
+        let a = scene_glb_cache_dir(root, "Data\\foo\\a.socpak", 4, &id());
+        let b = scene_glb_cache_dir(root, "Data\\foo\\b.socpak", 4, &id());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_dir_distinguishes_max_depth() {
+        let root = std::path::Path::new("/cache");
+        let d3 = scene_glb_cache_dir(root, "Data\\foo\\a.socpak", 3, &id());
+        let d4 = scene_glb_cache_dir(root, "Data\\foo\\a.socpak", 4, &id());
+        assert_ne!(d3, d4);
+    }
+
+    #[test]
+    fn cache_dir_distinguishes_p4k_identity() {
+        let root = std::path::Path::new("/cache");
+        let a = scene_glb_cache_dir(
+            root,
+            "Data\\foo\\a.socpak",
+            4,
+            &P4kIdentity {
+                mtime_secs: 1_700_000_000,
+                size_bytes: 4096,
+            },
+        );
+        let b = scene_glb_cache_dir(
+            root,
+            "Data\\foo\\a.socpak",
+            4,
+            &P4kIdentity {
+                mtime_secs: 1_700_000_001,
+                size_bytes: 4096,
+            },
+        );
+        assert_ne!(a, b, "different p4k mtime should yield different slot");
+    }
+
+    #[test]
+    fn cache_dir_carries_contract_version() {
+        let root = std::path::Path::new("/cache");
+        let dir = scene_glb_cache_dir(root, "Data\\foo\\a.socpak", 4, &id());
+        let name = dir.file_name().and_then(|n| n.to_str()).unwrap();
+        assert!(
+            name.ends_with(&format!("_v{SCENE_GLB_CONTRACT_VERSION}")),
+            "cache dir name should end with the contract version: {name}"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_path_separators() {
+        assert_eq!(
+            sanitize_socpak_tail("Data\\foo bar/baz.socpak"),
+            "baz"
+        );
+    }
+
+    #[test]
+    fn socpak_index_cache_file_distinguishes_p4k_identity() {
+        let root = std::path::Path::new("/cache");
+        let roots: Vec<String> = vec!["Data/ObjectContainers/".into()];
+        let a = socpak_index_cache_file(root, "/tmp/HOTFIX/Data.p4k", &id(), &roots);
+        let b = socpak_index_cache_file(
+            root,
+            "/tmp/HOTFIX/Data.p4k",
+            &P4kIdentity {
+                mtime_secs: id().mtime_secs + 1,
+                size_bytes: id().size_bytes,
+            },
+            &roots,
+        );
+        assert_ne!(a, b, "different p4k mtime should produce a different slot");
+    }
+
+    #[test]
+    fn socpak_index_cache_file_distinguishes_p4k_path() {
+        let root = std::path::Path::new("/cache");
+        let roots: Vec<String> = vec!["Data/ObjectContainers/".into()];
+        let a = socpak_index_cache_file(root, "/tmp/HOTFIX/Data.p4k", &id(), &roots);
+        let b = socpak_index_cache_file(root, "/tmp/TECH-PREVIEW/Data.p4k", &id(), &roots);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn socpak_index_cache_file_distinguishes_search_roots() {
+        let root = std::path::Path::new("/cache");
+        let a = socpak_index_cache_file(
+            root,
+            "/tmp/HOTFIX/Data.p4k",
+            &id(),
+            &["Data/ObjectContainers/".to_string()],
+        );
+        let b = socpak_index_cache_file(
+            root,
+            "/tmp/HOTFIX/Data.p4k",
+            &id(),
+            &["Data/Other/".to_string()],
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn socpak_index_cache_file_carries_contract_version() {
+        let root = std::path::Path::new("/cache");
+        let path = socpak_index_cache_file(
+            root,
+            "/tmp/HOTFIX/Data.p4k",
+            &id(),
+            &["Data/ObjectContainers/".to_string()],
+        );
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap();
+        assert!(
+            name.ends_with(&format!("_v{SOCPAK_INDEX_CONTRACT_VERSION}.json")),
+            "cache file name should end with the contract version: {name}"
+        );
+    }
+}

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -12,6 +12,9 @@ pub struct AppState {
     pub p4k: Mutex<Option<Arc<MappedP4k>>>,
     pub dcb_bytes: Mutex<Option<Vec<u8>>>,
     pub export_cancel: Arc<AtomicBool>,
+    /// Cancel flag for the Scene Viewer's in-process exporter. Separate
+    /// from `export_cancel` so the two pipelines don't stomp each other.
+    pub scene_export_cancel: Arc<AtomicBool>,
     /// Localization strings from Data\Localization\english\global.ini.
     /// Keys are lowercase for case-insensitive lookup.
     pub localization: Mutex<HashMap<String, String>>,
@@ -31,6 +34,7 @@ impl AppState {
             p4k: Mutex::new(None),
             dcb_bytes: Mutex::new(None),
             export_cancel: Arc::new(AtomicBool::new(false)),
+            scene_export_cancel: Arc::new(AtomicBool::new(false)),
             localization: Mutex::new(HashMap::new()),
             record_index: Mutex::new(None),
             atl_index: Mutex::new(None),

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1280,
         "height": 800,
         "minWidth": 900,
-        "minHeight": 600
+        "minHeight": 600,
+        "additionalBrowserArgs": "--force-high-performance-gpu"
       }
     ],
     "security": {

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -21,7 +21,14 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "$APPLOCALDATA/scene_cache/**",
+          "$APPLOCALDATA\\scene_cache\\**"
+        ]
+      }
     }
   },
   "bundle": {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { P4kBrowser } from "./views/p4k-browser";
 import { DataCoreBrowser } from "./views/datacore-browser";
 import { ExportView } from "./views/export-view";
 import { AudioView } from "./views/audio-view";
+import { SceneView } from "./views/scene-view";
 import { getSystemTheme, onSystemThemeChanged } from "./lib/commands";
 import { applySystemTheme } from "./lib/theme";
 
@@ -35,6 +36,7 @@ function App() {
           {mode === "datacore" && <DataCoreBrowser />}
           {mode === "export" && <ExportView />}
           {mode === "audio" && <AudioView />}
+          {mode === "scene" && <SceneView />}
         </main>
       </div>
     </div>

--- a/app/src/components/__tests__/socpak-tree.test.ts
+++ b/app/src/components/__tests__/socpak-tree.test.ts
@@ -1,0 +1,200 @@
+// Pure-helper coverage for the SocpakTree component. Skips the React
+// rendering itself because the project's vitest setup runs in node mode
+// without jsdom or @testing-library, and adding either would violate
+// the no-new-deps constraint. The state-mutation helpers and the
+// search filter are the load-bearing pieces; if they are right, the
+// component only has wiring to get wrong.
+
+import { describe, expect, it } from "vitest";
+import {
+  GLOBAL_INDEX_RESULT_CAP,
+  filterGlobalIndex,
+  filterTreeChildren,
+  setBranchState,
+  toGlobalIndexHit,
+} from "../socpak-tree";
+import type { SocpakDirEntry } from "../../lib/commands";
+
+function dir(path: string, name: string, count = 0): SocpakDirEntry {
+  return {
+    path,
+    display_name: name,
+    kind: "directory",
+    size_or_count: count,
+  };
+}
+
+function leaf(path: string, name: string, size = 0): SocpakDirEntry {
+  return {
+    path,
+    display_name: name,
+    kind: "socpak_file",
+    size_or_count: size,
+  };
+}
+
+describe("filterTreeChildren", () => {
+  const sample: SocpakDirEntry[] = [
+    dir("Data\\OC\\PU\\", "PU", 5),
+    dir("Data\\OC\\Stations\\", "Stations", 3),
+    leaf("Data\\OC\\hangar.socpak", "hangar.socpak", 1024),
+    leaf("Data\\OC\\dungeon.socpak", "dungeon.socpak", 2048),
+  ];
+
+  it("returns the input unchanged when the query is empty", () => {
+    expect(filterTreeChildren(sample, "")).toBe(sample);
+    expect(filterTreeChildren(sample, "   ")).toBe(sample);
+  });
+
+  it("filters by display_name substring, case-insensitively", () => {
+    const result = filterTreeChildren(sample, "hangar");
+    expect(result).toHaveLength(1);
+    expect(result[0].display_name).toBe("hangar.socpak");
+  });
+
+  it("matches against directory names too", () => {
+    const result = filterTreeChildren(sample, "stat");
+    expect(result).toHaveLength(1);
+    expect(result[0].display_name).toBe("Stations");
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    const result = filterTreeChildren(sample, "no_such_name");
+    expect(result).toEqual([]);
+  });
+
+  it("trims whitespace before matching", () => {
+    const result = filterTreeChildren(sample, "  PU  ");
+    expect(result).toHaveLength(1);
+    expect(result[0].display_name).toBe("PU");
+  });
+});
+
+describe("setBranchState", () => {
+  it("returns a NEW Map (reference inequality) so React detects the change", () => {
+    const before = new Map();
+    const after = setBranchState(before, "p", {
+      status: "loaded",
+      expanded: true,
+      children: [],
+    });
+    expect(after).not.toBe(before);
+  });
+
+  it("inserts a new entry without mutating the input", () => {
+    const before = new Map();
+    setBranchState(before, "p", {
+      status: "loading",
+      expanded: true,
+    });
+    expect(before.size).toBe(0);
+  });
+
+  it("overwrites an existing entry at the same key", () => {
+    let state = new Map();
+    state = setBranchState(state, "p", {
+      status: "loading",
+      expanded: true,
+    });
+    state = setBranchState(state, "p", {
+      status: "loaded",
+      expanded: true,
+      children: [leaf("p\\a.socpak", "a.socpak", 10)],
+    });
+    const branch = state.get("p");
+    expect(branch?.status).toBe("loaded");
+    expect(branch?.children).toHaveLength(1);
+  });
+
+  it("preserves siblings at other keys", () => {
+    let state = new Map();
+    state = setBranchState(state, "p", { status: "loaded", expanded: true });
+    state = setBranchState(state, "q", { status: "loading", expanded: true });
+    state = setBranchState(state, "p", { status: "loaded", expanded: false });
+    expect(state.get("p")?.expanded).toBe(false);
+    expect(state.get("q")?.status).toBe("loading");
+  });
+});
+
+describe("toGlobalIndexHit", () => {
+  it("splits a Windows-flavoured path into name + parent", () => {
+    const hit = toGlobalIndexHit(
+      "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\hangar.socpak",
+    );
+    expect(hit.path).toBe(
+      "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\hangar.socpak",
+    );
+    expect(hit.display_name).toBe("hangar.socpak");
+    // Backslashes get normalised to forward slashes for legibility.
+    expect(hit.parent_display).toBe("Data/ObjectContainers/PU/loc/mod/pyro");
+  });
+
+  it("handles forward-slash paths", () => {
+    const hit = toGlobalIndexHit("Data/ObjectContainers/PU/foo.socpak");
+    expect(hit.display_name).toBe("foo.socpak");
+    expect(hit.parent_display).toBe("Data/ObjectContainers/PU");
+  });
+
+  it("returns the input as display_name when no separator is present", () => {
+    const hit = toGlobalIndexHit("flat.socpak");
+    expect(hit.display_name).toBe("flat.socpak");
+    expect(hit.parent_display).toBe("");
+  });
+});
+
+describe("filterGlobalIndex", () => {
+  const sample = [
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\station\\reststop\\executive_hangar.socpak",
+    "Data\\ObjectContainers\\PU\\loc\\mod\\stanton\\hangar.socpak",
+    "Data\\ObjectContainers\\Stations\\alpha\\dungeon.socpak",
+    "Data\\ObjectContainers\\Stations\\alpha\\nested\\dungeon_b.socpak",
+    "Data\\ObjectContainers\\PU\\misc\\pyro_other.socpak",
+  ];
+
+  it("returns an empty list when the query is empty", () => {
+    expect(filterGlobalIndex(sample, "")).toEqual([]);
+    expect(filterGlobalIndex(sample, "   ")).toEqual([]);
+  });
+
+  it("matches case-insensitive substring on the full path", () => {
+    // `pyro` matches both the directory name AND the filename
+    // `pyro_other.socpak`. Both should land in the result.
+    const hits = filterGlobalIndex(sample, "PYRO");
+    expect(hits.map((h) => h.display_name)).toEqual([
+      "executive_hangar.socpak",
+      "pyro_other.socpak",
+    ]);
+  });
+
+  it("matches against directory segments, not just filenames", () => {
+    // `Stations` is a parent directory; the lazy tree's
+    // display_name filter would never find these.
+    const hits = filterGlobalIndex(sample, "stations");
+    expect(hits).toHaveLength(2);
+    expect(hits[0].display_name).toBe("dungeon.socpak");
+    expect(hits[1].display_name).toBe("dungeon_b.socpak");
+  });
+
+  it("respects an explicit cap", () => {
+    const hits = filterGlobalIndex(sample, "socpak", 2);
+    expect(hits).toHaveLength(2);
+  });
+
+  it("returns at most GLOBAL_INDEX_RESULT_CAP hits by default", () => {
+    const big = Array.from(
+      { length: 500 },
+      (_, i) => `Data\\ObjectContainers\\PU\\zone_${i}.socpak`,
+    );
+    const hits = filterGlobalIndex(big, "zone");
+    expect(hits).toHaveLength(GLOBAL_INDEX_RESULT_CAP);
+  });
+
+  it("returns each hit with display_name + parent_display populated", () => {
+    const hits = filterGlobalIndex(sample, "executive");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].display_name).toBe("executive_hangar.socpak");
+    expect(hits[0].parent_display).toBe(
+      "Data/ObjectContainers/PU/loc/mod/pyro/station/reststop",
+    );
+  });
+});

--- a/app/src/components/flight-cam-hud.tsx
+++ b/app/src/components/flight-cam-hud.tsx
@@ -1,0 +1,62 @@
+// One-line readout for the flight camera state. Subscribes to the handle's
+// per-frame snapshots; the handle internally throttles to one fire per RAF
+// tick, so there is no extra throttling here.
+
+import { useEffect, useState } from "react";
+import * as THREE from "three";
+import type {
+  FlightCamHandle,
+  FlightCamState,
+  ProjectionMode,
+} from "../lib/flight-camera";
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+const PROJ_LABEL: Record<ProjectionMode, string> = {
+  perspective: "persp",
+  orthographic: "ortho",
+  oblique: "oblique",
+};
+
+function formatVec(v: THREE.Vector3): string {
+  return `${v.x.toFixed(1)}, ${v.y.toFixed(1)}, ${v.z.toFixed(1)}`;
+}
+
+interface Props {
+  handle: FlightCamHandle | null;
+}
+
+export function FlightCamHud({ handle }: Props) {
+  const [snapshot, setSnapshot] = useState<Readonly<FlightCamState> | null>(null);
+
+  useEffect(() => {
+    if (!handle) return;
+    const off = handle.subscribe((s) => setSnapshot(s));
+    return off;
+  }, [handle]);
+
+  if (!snapshot) return null;
+
+  const euler = new THREE.Euler().setFromQuaternion(snapshot.quat, "YXZ");
+  const yaw = (euler.y * RAD_TO_DEG).toFixed(0);
+  const pitch = (euler.x * RAD_TO_DEG).toFixed(0);
+  const roll = (euler.z * RAD_TO_DEG).toFixed(0);
+
+  return (
+    <div
+      className="absolute bottom-2 right-2 px-3 py-1.5 rounded-md bg-bg-alt/90 border border-border z-10 pointer-events-none"
+    >
+      <p className="text-[11px] text-text-sub font-mono whitespace-nowrap">
+        pos: {formatVec(snapshot.pos)}
+        {"   "}
+        yaw {yaw} deg pitch {pitch} deg roll {roll} deg
+        {"   "}
+        speed {snapshot.moveSpeed.toFixed(2)}x
+        {"   "}
+        fov {snapshot.fov.toFixed(0)} deg
+        {"   "}
+        proj {PROJ_LABEL[snapshot.projectionMode]}
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/flight-cam-hud.tsx
+++ b/app/src/components/flight-cam-hud.tsx
@@ -24,9 +24,15 @@ function formatVec(v: THREE.Vector3): string {
 
 interface Props {
   handle: FlightCamHandle | null;
+  /** When true, render only the inline readout `<p>` without the
+   *  absolute-positioned wrapper div. Used by `SceneViewer`'s combined
+   *  bottom-right panel, which provides its own layout chrome. Defaults
+   *  to false (legacy free-floating layout) so existing call sites and
+   *  tests stay unchanged. */
+  embedded?: boolean;
 }
 
-export function FlightCamHud({ handle }: Props) {
+export function FlightCamHud({ handle, embedded = false }: Props) {
   const [snapshot, setSnapshot] = useState<Readonly<FlightCamState> | null>(null);
 
   useEffect(() => {
@@ -42,21 +48,27 @@ export function FlightCamHud({ handle }: Props) {
   const pitch = (euler.x * RAD_TO_DEG).toFixed(0);
   const roll = (euler.z * RAD_TO_DEG).toFixed(0);
 
+  const readout = (
+    <p className="text-[11px] text-text-sub font-mono whitespace-nowrap">
+      pos: {formatVec(snapshot.pos)}
+      {"   "}
+      yaw {yaw} deg pitch {pitch} deg roll {roll} deg
+      {"   "}
+      speed {snapshot.moveSpeed.toFixed(2)}x
+      {"   "}
+      fov {snapshot.fov.toFixed(0)} deg
+      {"   "}
+      proj {PROJ_LABEL[snapshot.projectionMode]}
+    </p>
+  );
+
+  if (embedded) return readout;
+
   return (
     <div
       className="absolute bottom-2 right-2 px-3 py-1.5 rounded-md bg-bg-alt/90 border border-border z-10 pointer-events-none"
     >
-      <p className="text-[11px] text-text-sub font-mono whitespace-nowrap">
-        pos: {formatVec(snapshot.pos)}
-        {"   "}
-        yaw {yaw} deg pitch {pitch} deg roll {roll} deg
-        {"   "}
-        speed {snapshot.moveSpeed.toFixed(2)}x
-        {"   "}
-        fov {snapshot.fov.toFixed(0)} deg
-        {"   "}
-        proj {PROJ_LABEL[snapshot.projectionMode]}
-      </p>
+      {readout}
     </div>
   );
 }

--- a/app/src/components/help-panel.tsx
+++ b/app/src/components/help-panel.tsx
@@ -1,0 +1,146 @@
+// `?` button in the top-right toolbar strip. Click to drop a panel
+// listing every keyboard / mouse control the flight cam responds to.
+// Matches the SettingsPanel button-with-dropdown pattern so the two
+// read as a pair.
+//
+// The keymap is the source of truth; if `flight-camera.ts` adds or
+// changes a binding, update this file to match. Bindings live in:
+//   - flight-camera.ts: WASDQE movement, IJKL/UO look, Arrow orbit,
+//     [/] cart, Numpad +/- FoV, Numpad 0-5 view presets, P projection
+//     cycle, R reframe, H HUD toggle, mouse buttons, wheel speed.
+//   - scene-viewer.tsx (Ships): F9 screenshot capture.
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
+import type { ViewerSurfaceKind } from "./settings-panel";
+
+interface HelpPanelProps {
+  /** Surface controls vary slightly between Ships and Maps. F9 capture
+   *  is wired only on the Ships viewer today (SOC has a no-op stub),
+   *  so we annotate it instead of hiding it. */
+  kind: ViewerSurfaceKind;
+}
+
+interface ControlGroup {
+  title: string;
+  items: Array<{ keys: string; description: string; note?: string }>;
+}
+
+function buildGroups(kind: ViewerSurfaceKind): ControlGroup[] {
+  return [
+    {
+      title: "Move",
+      items: [
+        { keys: "W A S D", description: "Forward / left / back / right" },
+        { keys: "Q E", description: "Down / up" },
+        { keys: "[ ]", description: "Cart out / in (along look direction)" },
+      ],
+    },
+    {
+      title: "Look",
+      items: [
+        { keys: "I K", description: "Pitch up / down" },
+        { keys: "J L", description: "Yaw left / right" },
+        { keys: "U O", description: "Roll left / right" },
+      ],
+    },
+    {
+      title: "Orbit",
+      items: [
+        { keys: "Arrows", description: "Swing around the pivot point" },
+      ],
+    },
+    {
+      title: "Mouse",
+      items: [
+        { keys: "Left drag", description: "Pan in screen space" },
+        { keys: "Right drag", description: "Orbit around the pivot" },
+        { keys: "Middle drag", description: "Look without moving the pivot" },
+        { keys: "Wheel", description: "Adjust movement speed (not zoom)" },
+      ],
+    },
+    {
+      title: "View",
+      items: [
+        { keys: "R", description: "Reframe to default view" },
+        {
+          keys: "Numpad 0-5",
+          description:
+            "Preset views: 0 overhead / 1 perspective / 2 side / 3 fore / 4 aft / 5 perspective",
+        },
+        { keys: "P", description: "Cycle projection: perspective / ortho / oblique" },
+        { keys: "Numpad + -", description: "FoV up / down" },
+      ],
+    },
+    {
+      title: "UI",
+      items: [
+        { keys: "H", description: "Toggle the orange pivot orb" },
+        {
+          keys: "F9",
+          description: "Capture high-resolution screenshot",
+          note: kind === "soc" ? "Ships viewer only today" : undefined,
+        },
+      ],
+    },
+  ];
+}
+
+export function HelpPanel({ kind }: HelpPanelProps) {
+  const [open, setOpen] = useState(false);
+  const groups = buildGroups(kind);
+
+  return (
+    <div className="relative z-10">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub hover:text-text hover:bg-bg-alt shadow transition-colors cursor-pointer select-none"
+        title={open ? "Hide keyboard controls" : "Show keyboard controls"}
+        aria-label={open ? "Hide keyboard controls" : "Show keyboard controls"}
+      >
+        <HelpCircle size={14} strokeWidth={1.75} />
+        <span className="font-mono">?</span>
+        {open ? (
+          <ChevronDown size={12} strokeWidth={1.75} />
+        ) : (
+          <ChevronUp size={12} strokeWidth={1.75} />
+        )}
+      </button>
+      {open && (
+        <div
+          className="absolute top-full right-0 mt-1.5 w-[340px] max-h-[70vh] overflow-y-auto bg-bg-alt/95 border border-border rounded-md shadow-lg p-3 flex flex-col gap-3 backdrop-blur-sm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {groups.map((group) => (
+            <div key={group.title} className="flex flex-col gap-1">
+              <div className="text-[10px] uppercase tracking-wider text-text-faint font-medium">
+                {group.title}
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {group.items.map((item) => (
+                  <div
+                    key={item.keys}
+                    className="flex items-baseline gap-2 px-1 py-0.5 text-xs"
+                  >
+                    <span className="font-mono text-text shrink-0 w-[88px]">
+                      {item.keys}
+                    </span>
+                    <span className="text-text-sub flex-1">
+                      {item.description}
+                      {item.note && (
+                        <span className="text-text-faint italic">
+                          {" "}
+                          ({item.note})
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/help-panel.tsx
+++ b/app/src/components/help-panel.tsx
@@ -5,10 +5,12 @@
 //
 // The keymap is the source of truth; if `flight-camera.ts` adds or
 // changes a binding, update this file to match. Bindings live in:
-//   - flight-camera.ts: WASDQE movement, IJKL/UO look, Arrow orbit,
-//     [/] cart, Numpad +/- FoV, Numpad 0-5 view presets, P projection
-//     cycle, R reframe, H HUD toggle, mouse buttons, wheel speed.
-//   - scene-viewer.tsx (Ships): F9 screenshot capture.
+//   - flight-camera.ts: WASDQE translation, IJKL/UO rotation, Arrow
+//     orbit, [/] cart, Numpad +/- FoV, Numpad 0-5 view presets, P
+//     projection cycle, R reframe, H pivot-orb toggle, mouse buttons,
+//     wheel speed.
+//   - scene-viewer.tsx (Ships) + soc-scene-viewer.tsx (Maps):
+//     F9 screenshot capture.
 
 import { useState } from "react";
 import { ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
@@ -26,37 +28,38 @@ interface ControlGroup {
   items: Array<{ keys: string; description: string; note?: string }>;
 }
 
-function buildGroups(kind: ViewerSurfaceKind): ControlGroup[] {
+function buildGroups(_kind: ViewerSurfaceKind): ControlGroup[] {
   return [
     {
-      title: "Move",
+      title: "Translate camera (3 linear DOF)",
       items: [
-        { keys: "W A S D", description: "Forward / left / back / right" },
-        { keys: "Q E", description: "Down / up" },
-        { keys: "[ ]", description: "Cart out / in (along look direction)" },
+        { keys: "W S", description: "Translate fore / aft" },
+        { keys: "A D", description: "Translate port / starboard" },
+        { keys: "Q E", description: "Translate ventral / dorsal" },
+        { keys: "[ ]", description: "Dolly aft / fore (axial; pivot stays put)" },
       ],
     },
     {
-      title: "Look",
+      title: "Rotate camera (3 angular DOF)",
       items: [
         { keys: "I K", description: "Pitch up / down" },
-        { keys: "J L", description: "Yaw left / right" },
-        { keys: "U O", description: "Roll left / right" },
+        { keys: "J L", description: "Yaw port / starboard" },
+        { keys: "U O", description: "Roll port / starboard" },
       ],
     },
     {
-      title: "Orbit",
+      title: "Slew about pivot (2 angular DOF)",
       items: [
-        { keys: "Arrows", description: "Swing around the pivot point" },
+        { keys: "Arrows", description: "Pitch / yaw the camera around the fixed pivot" },
       ],
     },
     {
       title: "Mouse",
       items: [
-        { keys: "Left drag", description: "Pan in screen space" },
-        { keys: "Right drag", description: "Orbit around the pivot" },
-        { keys: "Middle drag", description: "Look without moving the pivot" },
-        { keys: "Wheel", description: "Adjust movement speed (not zoom)" },
+        { keys: "Left drag", description: "Translate in image plane (pan)" },
+        { keys: "Right drag", description: "Slew about pivot" },
+        { keys: "Middle drag", description: "Rotate camera in place (pivot follows)" },
+        { keys: "Wheel", description: "Adjust motion speed (not zoom)" },
       ],
     },
     {
@@ -76,11 +79,7 @@ function buildGroups(kind: ViewerSurfaceKind): ControlGroup[] {
       title: "UI",
       items: [
         { keys: "H", description: "Toggle the orange pivot orb" },
-        {
-          keys: "F9",
-          description: "Capture high-resolution screenshot",
-          note: kind === "soc" ? "Ships viewer only today" : undefined,
-        },
+        { keys: "F9", description: "Capture high-resolution screenshot" },
       ],
     },
   ];

--- a/app/src/components/material-inspector.tsx
+++ b/app/src/components/material-inspector.tsx
@@ -1,0 +1,641 @@
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import * as THREE from "three";
+import type { SubmaterialRecord } from "../lib/decomposed-loader";
+import { writeDiagFile, listDiagDir } from "../lib/commands";
+
+/** A single ray-hit row produced by the picker. The picker walks
+ *  the bindings list at click time and assembles one entry per mesh
+ *  intersected by the camera ray, sorted near-to-far. */
+export interface PickHit {
+  /** Hit ordering (0 = closest to camera). Preserved in the export
+   *  so the user can reason about occlusion: the front-most surface
+   *  is what they "saw" when they clicked, the rest are layered
+   *  behind it. */
+  hitIndex: number;
+  /** Distance from camera in scene units. */
+  distance: number;
+  /** The intersected mesh. Held by reference so the inspector can
+   *  reach `mesh.name`, `mesh.material`, `mesh.userData`, etc. */
+  mesh: THREE.Mesh;
+  /** Hit point in scene world-space coordinates (Star Citizen basis
+   *  if `applySCBasisToObject` was applied to the parent group). */
+  point: THREE.Vector3;
+  /** Resolved submaterial driving the mesh. Null when the mesh isn't
+   *  in `bindingsRef` (interior placeholders, ground plane). */
+  submaterial: SubmaterialRecord | null;
+  /** Sidecar path that owned `submaterial` at the time of the pick. */
+  sidecarKey: string | null;
+  /** Sidecar path the GLB material originally resolved against. Same
+   *  as `sidecarKey` unless a livery rebuild swapped the binding. */
+  defaultSidecarKey: string | null;
+}
+
+/** Directory where diagnostic JSON captures are saved. */
+const DIAG_SUBDIR = "diag";
+
+interface Props {
+  hits: PickHit[];
+  selectedHitIndex: number | null;
+  onSelectHit: (idx: number | null) => void;
+  onClose: () => void;
+  /** Slug derived from the loaded package name (e.g. "rsi_aurora_mk2").
+   *  Included in the saved filename. Falls back to "unknown". */
+  packageSlug?: string;
+  /** Active livery identifier. "nolivery" when none active. */
+  liveryState?: string;
+}
+
+/** Floating panel anchored top-left of the viewer. Shows the
+ *  ray-hit list and (when a hit is selected) a details drawer with the
+ *  full submaterial record + live Three.js material state. Both panels
+ *  expose Copy JSON and Save JSON buttons; key order is preserved across
+ *  serialization so the diffability of the dump is not lost to alpha
+ *  sort. */
+export function MaterialInspector({
+  hits,
+  selectedHitIndex,
+  onSelectHit,
+  onClose,
+  packageSlug = "unknown",
+  liveryState = "nolivery",
+}: Props){
+  const selected = useMemo(() => {
+    if (selectedHitIndex == null) return null;
+    return hits.find((h) => h.hitIndex === selectedHitIndex) ?? null;
+  }, [hits, selectedHitIndex]);
+
+  // Session-scoped counter for saved filenames. Persists across hits
+  // within a session; the user can rename files as needed.
+  const sessionCounterRef = useRef(0);
+  const [hitsConfirm, setHitsConfirm] = useState<string | null>(null);
+  const [detailConfirm, setDetailConfirm] = useState<string | null>(null);
+
+  const saveHitsJson = async () => {
+    const payload = {
+      kind: "starbreaker-viewer.ray-hits",
+      hit_count: hits.length,
+      hits: hits.map((h) => buildHitPayload(h, false)),
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const filename = await buildFilename(packageSlug, "ray_hits", liveryState);
+    try {
+      const absPath = await writeDiagFile(DIAG_SUBDIR, filename, json);
+      sessionCounterRef.current += 1;
+      setHitsConfirm(absPath);
+      // Copy path to clipboard as confirmation.
+      try { await navigator.clipboard.writeText(absPath); } catch { /* ignore */ }
+      setTimeout(() => setHitsConfirm(null), 2000);
+    } catch (err) {
+      console.error("[save-json] write_diag_file failed:", err);
+    }
+  };
+
+  const saveDetailJson = async (hit: PickHit) => {
+    const payload = {
+      kind: "starbreaker-viewer.hit-detail",
+      hit: buildHitPayload(hit, true),
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const meshName = hit.mesh.name ? slugify(hit.mesh.name) : "mesh";
+    const filename = await buildFilename(packageSlug, meshName, liveryState);
+    try {
+      const absPath = await writeDiagFile(DIAG_SUBDIR, filename, json);
+      sessionCounterRef.current += 1;
+      setDetailConfirm(absPath);
+      try { await navigator.clipboard.writeText(absPath); } catch { /* ignore */ }
+      setTimeout(() => setDetailConfirm(null), 2000);
+    } catch (err) {
+      console.error("[save-json] write_diag_file failed:", err);
+    }
+  };
+
+  if (hits.length === 0) return null;
+
+  return (
+    <div className="absolute top-2 left-2 z-20 flex flex-col gap-2 max-h-[85vh] w-[420px]">
+      {/* Hit list panel */}
+      <div className="rounded-md bg-bg-alt/95 border border-border shadow-lg flex flex-col min-h-0">
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+          <p className="text-xs font-mono text-text-sub">
+            Ray hits ({hits.length})
+          </p>
+          <div className="flex gap-1 items-center">
+            {hitsConfirm && (
+              <span className="text-[10px] text-success font-mono truncate max-w-[160px]" title={hitsConfirm}>
+                Saved
+              </span>
+            )}
+            <button
+              type="button"
+              className="text-[10px] px-2 py-0.5 rounded bg-bg/50 hover:bg-bg/80 text-text-sub border border-border"
+              onClick={() => copyHitsJson(hits)}
+              title="Copy ordered JSON of all ray hits to clipboard"
+            >
+              Copy JSON
+            </button>
+            <button
+              type="button"
+              className="text-[10px] px-2 py-0.5 rounded bg-bg/50 hover:bg-bg/80 text-text-sub border border-border"
+              onClick={saveHitsJson}
+              title={`Save ray hits JSON to ${DIAG_SUBDIR}`}
+            >
+              Save JSON
+            </button>
+            <button
+              type="button"
+              className="text-[10px] px-2 py-0.5 rounded bg-bg/50 hover:bg-bg/80 text-text-sub border border-border"
+              onClick={onClose}
+              title="Close inspector"
+            >
+              x
+            </button>
+          </div>
+        </div>
+        <div className="overflow-y-auto max-h-[35vh]">
+          {hits.map((h) => (
+            <button
+              type="button"
+              key={h.hitIndex}
+              onClick={() =>
+                onSelectHit(h.hitIndex === selectedHitIndex ? null : h.hitIndex)
+              }
+              className={`block w-full text-left px-3 py-1 font-mono text-[11px] border-b border-border/40 hover:bg-bg/40 ${
+                h.hitIndex === selectedHitIndex
+                  ? "bg-accent/10 text-text"
+                  : "text-text-sub"
+              }`}
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="text-text-dim w-6 text-right">
+                  {h.hitIndex}
+                </span>
+                <span className="text-text-dim w-16">
+                  {h.distance.toFixed(1)}u
+                </span>
+                <span className="truncate flex-1">
+                  {hitLabel(h)}
+                </span>
+              </div>
+              <div className="text-[10px] text-text-dim pl-8 truncate">
+                {h.submaterial?.shader_family ?? "-"} {" "}
+                {h.mesh.name || "(unnamed mesh)"}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+      {/* Details panel */}
+      {selected && (
+        <div className="rounded-md bg-bg-alt/95 border border-border shadow-lg flex flex-col min-h-0">
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+            <p className="text-xs font-mono text-text-sub truncate">
+              Detail #{selected.hitIndex}: {hitLabel(selected)}
+            </p>
+            <div className="flex gap-1 items-center shrink-0">
+              {detailConfirm && (
+                <span className="text-[10px] text-success font-mono" title={detailConfirm}>
+                  Saved
+                </span>
+              )}
+              <button
+                type="button"
+                className="text-[10px] px-2 py-0.5 rounded bg-bg/50 hover:bg-bg/80 text-text-sub border border-border"
+                onClick={() => copyDetailJson(selected)}
+                title="Copy full ordered JSON of this submaterial + material to clipboard"
+              >
+                Copy JSON
+              </button>
+              <button
+                type="button"
+                className="text-[10px] px-2 py-0.5 rounded bg-bg/50 hover:bg-bg/80 text-text-sub border border-border"
+                onClick={() => saveDetailJson(selected)}
+                title={`Save detail JSON to ${DIAG_SUBDIR}`}
+              >
+                Save JSON
+              </button>
+            </div>
+          </div>
+          <div className="overflow-y-auto max-h-[40vh] px-3 py-2 font-mono text-[11px] text-text-sub leading-snug">
+            <DetailBody hit={selected} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function hitLabel(hit: PickHit): string {
+  return (
+    hit.submaterial?.blender_material_name ??
+    hit.submaterial?.submaterial_name ??
+    hit.mesh.name ??
+    "(unbound)"
+  );
+}
+
+function DetailBody({ hit }: { hit: PickHit }) {
+  const sm = hit.submaterial;
+  const mat = hit.mesh.material as THREE.Material | THREE.Material[] | null;
+  const matSummary = summarizeThreeMaterial(mat);
+  return (
+    <div className="space-y-2">
+      <Section title="Mesh">
+        <Kv k="name" v={hit.mesh.name || "—"} />
+        <Kv k="distance" v={hit.distance.toFixed(2)} />
+        <Kv
+          k="point"
+          v={`(${hit.point.x.toFixed(1)}, ${hit.point.y.toFixed(1)}, ${hit.point.z.toFixed(1)})`}
+        />
+        <Kv
+          k="glbMaterialIndex"
+          v={String(hit.mesh.userData?.glbMaterialIndex ?? "—")}
+        />
+        <Kv
+          k="fallbackKind"
+          v={String(
+            (Array.isArray(hit.mesh.material)
+              ? hit.mesh.material[0]?.userData?.fallbackKind
+              : (hit.mesh.material as THREE.Material | null)?.userData
+                  ?.fallbackKind) ?? "—",
+          )}
+        />
+        <Kv k="active sidecar" v={hit.sidecarKey ?? "—"} />
+        <Kv k="default sidecar" v={hit.defaultSidecarKey ?? "—"} />
+      </Section>
+      {sm ? (
+        <>
+          <Section title="Submaterial">
+            <Kv k="submaterial_name" v={sm.submaterial_name ?? "—"} />
+            <Kv k="blender_material_name" v={sm.blender_material_name ?? "—"} />
+            <Kv k="index" v={String(sm.index ?? "—")} />
+            <Kv k="shader" v={String(sm.shader ?? "—")} />
+            <Kv k="shader_family" v={String(sm.shader_family ?? "—")} />
+          </Section>
+          {sm.decoded_feature_flags && (
+            <Section title="decoded_feature_flags">
+              {sm.decoded_feature_flags.tokens && (
+                <Kv k="tokens" v={sm.decoded_feature_flags.tokens.join(" ")} />
+              )}
+              {Object.entries(sm.decoded_feature_flags)
+                .filter(([k]) => k !== "tokens")
+                .map(([k, v]) => (
+                  <Kv key={k} k={k} v={String(v)} />
+                ))}
+            </Section>
+          )}
+          {sm.tint_palette && (
+            <Section title="tint_palette">
+              <Kv k="palette_id" v={sm.tint_palette.palette_id} />
+              <Kv
+                k="palette_source_name"
+                v={sm.tint_palette.palette_source_name ?? "—"}
+              />
+              <Kv
+                k="assigned_channel"
+                v={sm.tint_palette.assigned_channel ?? "(null — heuristic-eligible)"}
+              />
+              {sm.tint_palette.entries?.length ? (
+                <div className="mt-1 space-y-0.5">
+                  {sm.tint_palette.entries.map((e, i) => (
+                    <div key={i} className="text-[10px] text-text-dim pl-2">
+                      [{i}] {e.channel} · tint=
+                      {fmtTriplet(e.tint_color)} · spec=
+                      {e.spec_color ? fmtTriplet(e.spec_color) : "—"} · gloss=
+                      {e.glossiness?.toFixed(2) ?? "—"}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <Kv k="entries" v="(empty)" />
+              )}
+            </Section>
+          )}
+          {sm.palette_routing && (
+            <Section title="palette_routing">
+              <pre className="text-[10px] text-text-dim whitespace-pre-wrap break-all">
+                {JSON.stringify(sm.palette_routing, null, 2)}
+              </pre>
+            </Section>
+          )}
+          {sm.layer_manifest?.length ? (
+            <Section title={`layer_manifest (${sm.layer_manifest.length})`}>
+              <pre className="text-[10px] text-text-dim whitespace-pre-wrap break-all">
+                {JSON.stringify(sm.layer_manifest, null, 2)}
+              </pre>
+            </Section>
+          ) : null}
+          {sm.texture_slots?.length ? (
+            <Section title={`texture_slots (${sm.texture_slots.length})`}>
+              {sm.texture_slots.map((slot, i) => (
+                <div key={i} className="text-[10px] text-text-dim">
+                  [{i}] {slot.slot ?? "?"} · {slot.role ?? "?"}
+                  {slot.alpha_semantic ? ` · α=${slot.alpha_semantic}` : ""}
+                  {slot.export_path ? (
+                    <div className="pl-2 break-all">{slot.export_path}</div>
+                  ) : null}
+                </div>
+              ))}
+            </Section>
+          ) : null}
+          {sm.direct_textures?.length ? (
+            <Section title={`direct_textures (${sm.direct_textures.length})`}>
+              <pre className="text-[10px] text-text-dim whitespace-pre-wrap break-all">
+                {JSON.stringify(sm.direct_textures, null, 2)}
+              </pre>
+            </Section>
+          ) : null}
+        </>
+      ) : (
+        <Section title="Submaterial">
+          <p className="text-[10px] text-text-dim italic">
+            Mesh has no recorded MaterialBinding (interior, light, ground, or
+            unbound auxiliary geometry).
+          </p>
+        </Section>
+      )}
+      <Section title="Three.js material">
+        <pre className="text-[10px] text-text-dim whitespace-pre-wrap break-all">
+          {JSON.stringify(matSummary, null, 2)}
+        </pre>
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wide text-text-dim mb-0.5">
+        {title}
+      </p>
+      <div className="pl-1">{children}</div>
+    </div>
+  );
+}
+
+function Kv({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex gap-2 text-[11px]">
+      <span className="text-text-dim w-32 shrink-0">{k}</span>
+      <span className="text-text-sub break-all">{v}</span>
+    </div>
+  );
+}
+
+function fmtTriplet(t: readonly [number, number, number] | number[]): string {
+  if (!t || t.length < 3) return "—";
+  return `(${t[0].toFixed(2)}, ${t[1].toFixed(2)}, ${t[2].toFixed(2)})`;
+}
+
+/** Build a JSON-friendly summary of a Three.js material with insertion-
+ *  ordered fields. Includes only the properties relevant to the
+ *  CryEngine port: PBR scalars, the texture maps that were assigned,
+ *  ClearCoat/iridescence/sheen/transmission state. The texture maps
+ *  emit the source export path when available (we stash it in
+ *  userData during loadTexture) and fall back to "(no path tracked)"
+ *  otherwise. */
+function summarizeThreeMaterial(
+  mat: THREE.Material | THREE.Material[] | null,
+): Record<string, unknown> {
+  if (mat == null) return { type: "(none)" };
+  if (Array.isArray(mat)) {
+    return { type: "(array)", length: mat.length };
+  }
+  const out: Record<string, unknown> = {};
+  out.type = mat.type;
+  out.name = mat.name;
+  out.transparent = mat.transparent;
+  out.opacity = mat.opacity;
+  out.side = mat.side;
+  if ("color" in mat && mat.color instanceof THREE.Color) {
+    out.color = colorTriplet(mat.color);
+  }
+  if ("metalness" in mat) out.metalness = (mat as THREE.MeshStandardMaterial).metalness;
+  if ("roughness" in mat) out.roughness = (mat as THREE.MeshStandardMaterial).roughness;
+  if ("envMapIntensity" in mat) out.envMapIntensity = (mat as THREE.MeshStandardMaterial).envMapIntensity;
+  out.clearcoat = (mat as any).clearcoat ?? null;
+  out.clearcoatRoughness = (mat as any).clearcoatRoughness ?? null;
+  out.iridescence = (mat as any).iridescence ?? null;
+  out.sheen = (mat as any).sheen ?? null;
+  if ("emissive" in mat && (mat as THREE.MeshStandardMaterial).emissive instanceof THREE.Color) {
+    out.emissive = colorTriplet((mat as THREE.MeshStandardMaterial).emissive);
+    out.emissiveIntensity = (mat as THREE.MeshStandardMaterial).emissiveIntensity;
+  }
+  // Texture map references — emit role names with the source path if
+  // we tracked it, otherwise "(set)" so the user can see which slots
+  // were actually populated. The order here mirrors the assignment
+  // order in buildHardSurfaceMaterial so a JSON diff against another
+  // submaterial reads visually.
+  const matAsRecord = mat as unknown as Record<string, unknown>;
+  for (const key of [
+    "map",
+    "normalMap",
+    "roughnessMap",
+    "metalnessMap",
+    "emissiveMap",
+    "alphaMap",
+    "aoMap",
+    "displacementMap",
+  ] as const) {
+    const tex = matAsRecord[key];
+    if (tex instanceof THREE.Texture) {
+      out[key] = textureSummary(tex);
+    }
+  }
+  // ClearCoat / iridescence / sheen / transmission live on
+  // MeshPhysicalMaterial. Only emit the field when it's present and
+  // non-zero so the dump stays focused.
+  const phys = mat as THREE.MeshPhysicalMaterial;
+  if (typeof phys.clearcoat === "number" && phys.clearcoat > 0) {
+    out.clearcoat = phys.clearcoat;
+    out.clearcoatRoughness = phys.clearcoatRoughness;
+  }
+  if (typeof phys.iridescence === "number" && phys.iridescence > 0) {
+    out.iridescence = phys.iridescence;
+    out.iridescenceIOR = phys.iridescenceIOR;
+    out.iridescenceThicknessRange = phys.iridescenceThicknessRange;
+  }
+  if (typeof phys.sheen === "number" && phys.sheen > 0) {
+    out.sheen = phys.sheen;
+    out.sheenColor = colorTriplet(phys.sheenColor);
+    out.sheenRoughness = phys.sheenRoughness;
+  }
+  if (typeof phys.transmission === "number" && phys.transmission > 0) {
+    out.transmission = phys.transmission;
+    out.thickness = phys.thickness;
+    out.ior = phys.ior;
+  }
+  if (typeof phys.anisotropy === "number" && phys.anisotropy > 0) {
+    out.anisotropy = phys.anisotropy;
+    out.anisotropyRotation = phys.anisotropyRotation;
+  }
+  // userData snapshots whatever buildMaterial / scene-viewer stashed
+  // (glbMaterialIndex, gltfExtensions). Include verbatim — the user
+  // can grep it.
+  if (mat.userData && Object.keys(mat.userData).length > 0) {
+    out.userData = mat.userData;
+  }
+  return out;
+}
+
+function colorTriplet(c: THREE.Color): [number, number, number] {
+  return [c.r, c.g, c.b];
+}
+
+function textureSummary(tex: THREE.Texture): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (tex.name) out.name = tex.name;
+  if (tex.userData?.export_path) out.export_path = tex.userData.export_path;
+  out.colorSpace = tex.colorSpace;
+  out.wrapS = tex.wrapS;
+  out.wrapT = tex.wrapT;
+  out.repeat = [tex.repeat.x, tex.repeat.y];
+  out.offset = [tex.offset.x, tex.offset.y];
+  return out;
+}
+
+/** Replace non-alphanumeric chars with underscores and lowercase. */
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+}
+
+/**
+ * Build a filename for a diagnostic JSON capture.
+ * Format: {counter}-{ship_slug}-{geom_or_kind}-{state}.json
+ * Counter auto-increments from the highest existing counter in DIAG_SUBDIR.
+ */
+async function buildFilename(
+  shipSlug: string,
+  geomOrKind: string,
+  state: string,
+): Promise<string> {
+  let nextCounter = 1;
+  try {
+    const files = await listDiagDir(DIAG_SUBDIR);
+    for (const f of files) {
+      const m = f.match(/^(\d+)-/);
+      if (m) {
+        const n = parseInt(m[1], 10);
+        if (n >= nextCounter) nextCounter = n + 1;
+      }
+    }
+  } catch {
+    // If listing fails, start at 001.
+  }
+  const counterStr = String(nextCounter).padStart(3, "0");
+  const slug = slugify(shipSlug) || "unknown";
+  const geom = slugify(geomOrKind) || "hit";
+  const st = slugify(state) || "nolivery";
+  return `${counterStr}-${slug}-${geom}-${st}.json`;
+}
+
+/** Build the ordered JSON for the entire ray-hit list and copy it to
+ *  the clipboard. */
+async function copyHitsJson(hits: PickHit[]): Promise<void> {
+  const payload = {
+    kind: "starbreaker-viewer.ray-hits",
+    hit_count: hits.length,
+    hits: hits.map((h) => buildHitPayload(h, false)),
+  };
+  await writeClipboardJson(payload);
+}
+
+/** Build the ordered JSON for a single hit (full submaterial +
+ *  material details) and copy it to the clipboard. */
+async function copyDetailJson(hit: PickHit): Promise<void> {
+  const payload = {
+    kind: "starbreaker-viewer.hit-detail",
+    hit: buildHitPayload(hit, true),
+  };
+  await writeClipboardJson(payload);
+}
+
+/** Construct the ordered JSON object for a hit. Field order is
+ *  insertion order, which JSON.stringify preserves on plain objects
+ *  (for non-numeric string keys), so what you see in the export is
+ *  what the loader saw at pick time. */
+function buildHitPayload(
+  hit: PickHit,
+  full: boolean,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  out.hit_index = hit.hitIndex;
+  out.distance = hit.distance;
+  out.point = [hit.point.x, hit.point.y, hit.point.z];
+  out.mesh = {
+    name: hit.mesh.name,
+    glbMaterialIndex: hit.mesh.userData?.glbMaterialIndex,
+    geometry_uuid: hit.mesh.geometry?.uuid,
+    geometry_attributes: hit.mesh.geometry?.attributes
+      ? Object.keys(hit.mesh.geometry.attributes)
+      : [],
+  };
+  out.sidecar = {
+    active: hit.sidecarKey,
+    default: hit.defaultSidecarKey,
+    overridden: hit.sidecarKey !== hit.defaultSidecarKey,
+  };
+  if (full && hit.submaterial) {
+    out.submaterial = orderedSubmaterial(hit.submaterial);
+  } else if (hit.submaterial) {
+    out.submaterial_name = hit.submaterial.submaterial_name;
+    out.shader_family = hit.submaterial.shader_family;
+  }
+  if (full) {
+    out.three_material = summarizeThreeMaterial(hit.mesh.material);
+  }
+  return out;
+}
+
+/** Re-emit the submaterial record with field order that mirrors the
+ *  decomposed-export contract. JSON.stringify preserves insertion
+ *  order, so this produces a stable diff-friendly serialization
+ *  regardless of how the source object was constructed. Unknown extra
+ *  fields are appended last to avoid silently dropping anything the
+ *  Rust side added. */
+function orderedSubmaterial(
+  sm: SubmaterialRecord,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const ordered: (keyof SubmaterialRecord)[] = [
+    "index",
+    "submaterial_name",
+    "blender_material_name",
+    "shader",
+    "shader_family",
+    "decoded_feature_flags",
+    "tint_palette",
+    "palette_routing",
+    "layer_manifest",
+    "texture_slots",
+    "direct_textures",
+  ];
+  for (const k of ordered) {
+    if (sm[k] !== undefined) out[k as string] = sm[k];
+  }
+  for (const k of Object.keys(sm)) {
+    if (!(k in out)) out[k] = (sm as Record<string, unknown>)[k];
+  }
+  return out;
+}
+
+async function writeClipboardJson(payload: unknown): Promise<void> {
+  const json = JSON.stringify(payload, null, 2);
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(json);
+      console.info(`[picker] copied ${json.length} bytes of JSON to clipboard`);
+      return;
+    }
+  } catch (err) {
+    console.warn("[picker] clipboard write failed:", err);
+  }
+  // Fallback: log to console so the user can copy from there.
+  console.info("[picker] JSON payload (no clipboard available):\n" + json);
+}

--- a/app/src/components/nav-widget.tsx
+++ b/app/src/components/nav-widget.tsx
@@ -1,0 +1,364 @@
+// On-screen nav widget. Mirrors every keyboard-bound flight-cam
+// control as a tappable button so a mobile / remote session without
+// keyboard or wheel can still drive the camera fully.
+//
+// Movement-style buttons (translate / rotate / slew / dolly) hold the
+// underlying keypress for as long as the user keeps the button
+// pressed. They synthesize `keydown` on pointer-down and `keyup` on
+// pointer-up / cancel / leave, so the existing `flight-camera.ts`
+// per-frame loop (which reads `heldKeys`) doesn't need to know the
+// nav widget exists.
+//
+// One-shot buttons (R reframe, H pivot orb, P projection, F9 capture,
+// Numpad presets) synthesize a press-release pair on tap; the
+// `dispatchViewerHotkey` path fires once.
+//
+// Speed +/- and FoV +/- can't reuse the synthetic-events path because
+// the wheel listener lives on the renderer's canvas (not window). The
+// flight cam exposes `nudgeMoveSpeed(direction)` and
+// `nudgeFov(direction)` for those.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Camera,
+  Eye,
+  Focus,
+  Gamepad2,
+  Minus,
+  Plus,
+} from "lucide-react";
+import type { FlightCamHandle } from "../lib/flight-camera";
+
+interface NavWidgetProps {
+  flightCamHandle: FlightCamHandle | null;
+  /** When false, the widget renders only the toggle pill so the user
+   *  can opt in. Default false. */
+  initiallyOpen?: boolean;
+}
+
+/** Synthesize a window-level keyboard event so the existing flight-cam
+ *  listeners pick it up. The flight cam stores `e.code` in `heldKeys`
+ *  and the per-frame loop reads it; matches the behaviour of a real
+ *  keyboard press. `isTrusted` will be false on the synthetic event
+ *  but neither the flight-cam handler nor `dispatchViewerHotkey`
+ *  gates on that. */
+function fireKey(code: string, type: "keydown" | "keyup"): void {
+  const event = new KeyboardEvent(type, {
+    code,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+}
+
+/** Press-and-hold: down on pointer-down, up on pointer-up / cancel /
+ *  leave. The leave handler is critical for touch -- if a finger
+ *  slides off the button, the browser fires pointercancel only on
+ *  some platforms. We bind both to be safe. */
+function holdHandlers(code: string) {
+  return {
+    onPointerDown: (e: React.PointerEvent) => {
+      e.preventDefault();
+      // capture so a sliding finger keeps generating events targeted
+      // here, and we get a clean release notification.
+      e.currentTarget.setPointerCapture(e.pointerId);
+      fireKey(code, "keydown");
+    },
+    onPointerUp: (e: React.PointerEvent) => {
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // already released; not a problem.
+      }
+      fireKey(code, "keyup");
+    },
+    onPointerCancel: (e: React.PointerEvent) => {
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+      fireKey(code, "keyup");
+    },
+    onContextMenu: (e: React.MouseEvent) => {
+      // Long-press on touch devices fires a context menu by default;
+      // suppress so the user can hold buttons without surprise menus.
+      e.preventDefault();
+    },
+  };
+}
+
+/** One-shot tap: down + up, no held state. Suitable for hotkeys that
+ *  the dispatcher fires on keydown (R, H, P, F9, Numpad presets). */
+function tapHandlers(code: string) {
+  return {
+    onPointerDown: (e: React.PointerEvent) => {
+      e.preventDefault();
+    },
+    onPointerUp: () => {
+      fireKey(code, "keydown");
+      fireKey(code, "keyup");
+    },
+    onContextMenu: (e: React.MouseEvent) => {
+      e.preventDefault();
+    },
+  };
+}
+
+/** Visual style for a nav button. Two variants: `key` (light, default)
+ *  and `accent` (action). */
+function btnClass(variant: "key" | "accent" = "key"): string {
+  const base =
+    "flex items-center justify-center gap-1 select-none touch-none cursor-pointer transition-colors font-mono " +
+    "active:bg-accent/30 active:text-text";
+  if (variant === "accent") {
+    return `${base} px-2 py-1 rounded border border-accent/40 bg-accent/15 text-text text-[11px]`;
+  }
+  return `${base} w-9 h-9 rounded border border-border bg-bg/60 text-text-sub hover:bg-bg/80 hover:text-text text-[11px]`;
+}
+
+export function NavWidget({
+  flightCamHandle,
+  initiallyOpen = false,
+}: NavWidgetProps) {
+  const [open, setOpen] = useState(initiallyOpen);
+
+  // Speed and FoV use the FlightCamHandle methods directly rather than
+  // synthetic wheel/keydown events. The wheel listener lives on the
+  // renderer's canvas; window-level synthetic wheel events miss it.
+  const onSpeedFaster = useCallback(() => {
+    flightCamHandle?.nudgeMoveSpeed(1);
+  }, [flightCamHandle]);
+  const onSpeedSlower = useCallback(() => {
+    flightCamHandle?.nudgeMoveSpeed(-1);
+  }, [flightCamHandle]);
+  const onFovWider = useCallback(() => {
+    flightCamHandle?.nudgeFov(1);
+  }, [flightCamHandle]);
+  const onFovNarrower = useCallback(() => {
+    flightCamHandle?.nudgeFov(-1);
+  }, [flightCamHandle]);
+
+  // For "tap-style" speed/FoV buttons, build the same shape as
+  // `tapHandlers` so the hover styling matches.
+  const speedFasterHandlers = useMemo(
+    () => ({
+      onPointerUp: onSpeedFaster,
+      onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    }),
+    [onSpeedFaster],
+  );
+  const speedSlowerHandlers = useMemo(
+    () => ({
+      onPointerUp: onSpeedSlower,
+      onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    }),
+    [onSpeedSlower],
+  );
+  const fovWiderHandlers = useMemo(
+    () => ({
+      onPointerUp: onFovWider,
+      onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    }),
+    [onFovWider],
+  );
+  const fovNarrowerHandlers = useMemo(
+    () => ({
+      onPointerUp: onFovNarrower,
+      onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    }),
+    [onFovNarrower],
+  );
+
+  // Defensive cleanup: if the widget unmounts while a button is held,
+  // the captured pointer would otherwise stay captured and the keyup
+  // would never fire. Releasing all currently-held keys on unmount is
+  // a belt-and-braces guard.
+  useEffect(() => {
+    return () => {
+      // This is a soft guard; the more common case is the per-frame
+      // loop reads `heldKeys` and computes a non-zero delta forever
+      // until the user clicks something. Sending keyups for the full
+      // set is cheap.
+      for (const code of [
+        "KeyW",
+        "KeyA",
+        "KeyS",
+        "KeyD",
+        "KeyQ",
+        "KeyE",
+        "KeyI",
+        "KeyJ",
+        "KeyK",
+        "KeyL",
+        "KeyU",
+        "KeyO",
+        "ArrowUp",
+        "ArrowDown",
+        "ArrowLeft",
+        "ArrowRight",
+        "BracketLeft",
+        "BracketRight",
+      ]) {
+        fireKey(code, "keyup");
+      }
+    };
+  }, []);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Show on-screen nav widget"
+        aria-label="Show on-screen nav widget"
+        className="flex items-center gap-1.5 px-2 py-1 rounded border border-border bg-bg-alt/90 text-text-sub hover:bg-bg-alt hover:text-text text-[10px] font-mono shadow"
+      >
+        <Gamepad2 size={12} strokeWidth={1.75} />
+        nav
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-bg-alt/95 border border-border rounded-md shadow p-2 flex flex-col gap-2 backdrop-blur-sm select-none">
+      {/* Header with hide button. */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-wider text-text-faint font-medium flex items-center gap-1.5">
+          <Gamepad2 size={11} strokeWidth={1.75} />
+          On-screen nav
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          title="Hide on-screen nav widget"
+          aria-label="Hide on-screen nav widget"
+          className="text-[10px] px-1.5 py-0.5 rounded border border-border bg-bg/50 text-text-sub hover:bg-bg/80 hover:text-text font-mono shrink-0"
+        >
+          hide
+        </button>
+      </div>
+
+      {/* Translate (3 linear DOF) -- 3x2 grid of WASDQE. Layout puts
+          the up axis on top so the spatial mapping is intuitive. */}
+      <Section label="Translate">
+        <div className="grid grid-cols-3 gap-1">
+          <button {...holdHandlers("KeyQ")} title="Translate ventral (Q)" className={btnClass()}>Q</button>
+          <button {...holdHandlers("KeyW")} title="Translate fore (W)" className={btnClass()}>W</button>
+          <button {...holdHandlers("KeyE")} title="Translate dorsal (E)" className={btnClass()}>E</button>
+          <button {...holdHandlers("KeyA")} title="Translate port (A)" className={btnClass()}>A</button>
+          <button {...holdHandlers("KeyS")} title="Translate aft (S)" className={btnClass()}>S</button>
+          <button {...holdHandlers("KeyD")} title="Translate starboard (D)" className={btnClass()}>D</button>
+        </div>
+        <div className="grid grid-cols-2 gap-1 mt-1">
+          <button {...holdHandlers("BracketLeft")} title="Dolly aft ([)" className={btnClass()}>[</button>
+          <button {...holdHandlers("BracketRight")} title="Dolly fore (])" className={btnClass()}>]</button>
+        </div>
+      </Section>
+
+      {/* Rotate (3 angular DOF) -- IJKL/UO. */}
+      <Section label="Rotate">
+        <div className="grid grid-cols-3 gap-1">
+          <button {...holdHandlers("KeyU")} title="Roll port (U)" className={btnClass()}>U</button>
+          <button {...holdHandlers("KeyI")} title="Pitch up (I)" className={btnClass()}>I</button>
+          <button {...holdHandlers("KeyO")} title="Roll starboard (O)" className={btnClass()}>O</button>
+          <button {...holdHandlers("KeyJ")} title="Yaw port (J)" className={btnClass()}>J</button>
+          <button {...holdHandlers("KeyK")} title="Pitch down (K)" className={btnClass()}>K</button>
+          <button {...holdHandlers("KeyL")} title="Yaw starboard (L)" className={btnClass()}>L</button>
+        </div>
+      </Section>
+
+      {/* Slew (2 angular DOF) -- arrow keys. Cross layout so the spatial
+          mapping is obvious. */}
+      <Section label="Slew">
+        <div className="grid grid-cols-3 gap-1 w-fit mx-auto">
+          <span />
+          <button {...holdHandlers("ArrowUp")} title="Slew pitch up" className={btnClass()}>
+            <ArrowUp size={14} strokeWidth={2} />
+          </button>
+          <span />
+          <button {...holdHandlers("ArrowLeft")} title="Slew yaw port" className={btnClass()}>
+            <ArrowLeft size={14} strokeWidth={2} />
+          </button>
+          <button {...holdHandlers("ArrowDown")} title="Slew pitch down" className={btnClass()}>
+            <ArrowDown size={14} strokeWidth={2} />
+          </button>
+          <button {...holdHandlers("ArrowRight")} title="Slew yaw starboard" className={btnClass()}>
+            <ArrowRight size={14} strokeWidth={2} />
+          </button>
+        </div>
+      </Section>
+
+      {/* Speed and FoV. Each tap = one wheel tick / Numpad press. */}
+      <Section label="Speed / FoV">
+        <div className="flex items-center gap-1 text-[10px] text-text-sub">
+          <span className="w-9 shrink-0">Speed</span>
+          <button {...speedSlowerHandlers} title="Slower" className={btnClass()}>
+            <Minus size={14} strokeWidth={2} />
+          </button>
+          <button {...speedFasterHandlers} title="Faster" className={btnClass()}>
+            <Plus size={14} strokeWidth={2} />
+          </button>
+        </div>
+        <div className="flex items-center gap-1 text-[10px] text-text-sub mt-1">
+          <span className="w-9 shrink-0">FoV</span>
+          <button {...fovNarrowerHandlers} title="Narrower FoV" className={btnClass()}>
+            <Minus size={14} strokeWidth={2} />
+          </button>
+          <button {...fovWiderHandlers} title="Wider FoV" className={btnClass()}>
+            <Plus size={14} strokeWidth={2} />
+          </button>
+        </div>
+      </Section>
+
+      {/* View presets -- Numpad 0-5. */}
+      <Section label="View presets">
+        <div className="grid grid-cols-6 gap-1">
+          <button {...tapHandlers("Numpad0")} title="Overhead (Numpad 0)" className={btnClass()}>0</button>
+          <button {...tapHandlers("Numpad1")} title="Perspective 2 (Numpad 1)" className={btnClass()}>1</button>
+          <button {...tapHandlers("Numpad2")} title="Side (Numpad 2)" className={btnClass()}>2</button>
+          <button {...tapHandlers("Numpad3")} title="Fore (Numpad 3)" className={btnClass()}>3</button>
+          <button {...tapHandlers("Numpad4")} title="Aft (Numpad 4)" className={btnClass()}>4</button>
+          <button {...tapHandlers("Numpad5")} title="Perspective (Numpad 5)" className={btnClass()}>5</button>
+        </div>
+      </Section>
+
+      {/* Action row -- R reframe, H pivot orb, P projection cycle, F9
+          screenshot. Wider buttons so the icon + label fit. */}
+      <Section label="Actions">
+        <div className="grid grid-cols-2 gap-1">
+          <button {...tapHandlers("KeyR")} title="Reframe (R)" className={btnClass("accent")}>
+            <Focus size={12} strokeWidth={2} />
+            R reset
+          </button>
+          <button {...tapHandlers("KeyH")} title="Toggle pivot orb (H)" className={btnClass("accent")}>
+            <Eye size={12} strokeWidth={2} />
+            H orb
+          </button>
+          <button {...tapHandlers("KeyP")} title="Cycle projection (P)" className={btnClass("accent")}>
+            P proj
+          </button>
+          <button {...tapHandlers("F9")} title="Screenshot (F9)" className={btnClass("accent")}>
+            <Camera size={12} strokeWidth={2} />
+            F9
+          </button>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="text-[9px] uppercase tracking-wider text-text-faint font-medium">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/progress-overlay.tsx
+++ b/app/src/components/progress-overlay.tsx
@@ -1,0 +1,173 @@
+// A modal-style progress overlay that aggregates many sub-phases into
+// one bar. Both viewer surfaces (Ships export, SOC scene load) feed
+// into the same component shape so a long-running load has continuous
+// feedback from the moment the user clicks until the scene is fully
+// textured -- not a backend bar that disappears mid-load while the
+// frontend still has tens of seconds of work to do.
+//
+// The component is presentational. The phase array + aggregate fraction
+// are computed by `useProgressReporter` (sibling file) which the
+// parent route owns; both backend event handlers and the viewer
+// components write into one reporter, and that reporter feeds this
+// overlay.
+
+import { type ReactNode } from "react";
+
+export interface ProgressPhase {
+  /** Stable identifier; used by the reporter to update one phase
+   *  in-place without rebuilding the whole array. */
+  id: string;
+  /** Human label for the phase, e.g. "Composing scene" or
+   *  "Resolving textures". Shown when this phase is the active one. */
+  label: string;
+  /** Relative weight in the aggregate progress bar. A backend
+   *  compose+emit step that runs in ~10s carries less weight than the
+   *  texture-decode step that runs in ~50s; the weights make the
+   *  overall bar move at a steady visible pace rather than jumping. */
+  weight: number;
+  /** [0,1] within this phase, or null for an indeterminate / pending
+   *  phase. Null phases contribute zero to the aggregate fraction. */
+  fraction: number | null;
+  /** Optional sub-line shown beneath the phase label, e.g.
+   *  "412 / 1482 textures" or "Resolving brushes...". */
+  detail?: string;
+  status: "pending" | "active" | "complete";
+}
+
+export interface ProgressOverlayProps {
+  /** Top-line title of the operation, e.g. "Loading scene" or
+   *  "Exporting RSI Polaris". */
+  title: string;
+  /** Phases in display order; usually backend → fetch → decode. The
+   *  bar aggregates across all of them by weight. */
+  phases: ProgressPhase[];
+  /** Optional cancel handler. If provided, a Cancel button renders
+   *  beneath the bar. */
+  onCancel?: () => void;
+  /** Tooltip on the cancel button — context for what cancel actually
+   *  does (e.g. backend keeps running, vs. truly aborts). */
+  cancelTitle?: string;
+  /** Optional ReactNode rendered above the modal body. Use for
+   *  per-surface error chrome that should sit alongside the modal. */
+  children?: ReactNode;
+}
+
+/** Compute the aggregate fraction across all phases, weighted. Pending
+ *  phases contribute zero; complete phases contribute their full
+ *  weight; active phases contribute weight * fraction. */
+export function computeAggregateFraction(phases: ProgressPhase[]): number {
+  let totalWeight = 0;
+  let earned = 0;
+  for (const phase of phases) {
+    if (phase.weight <= 0) continue;
+    totalWeight += phase.weight;
+    if (phase.status === "complete") {
+      earned += phase.weight;
+    } else if (phase.status === "active") {
+      const frac =
+        typeof phase.fraction === "number" && phase.fraction >= 0
+          ? Math.min(phase.fraction, 1)
+          : 0;
+      earned += phase.weight * frac;
+    }
+  }
+  if (totalWeight === 0) return 0;
+  return Math.min(1, earned / totalWeight);
+}
+
+/** Pick the phase whose label + detail should be shown beneath the
+ *  aggregate bar. Prefers the first `active` phase; falls back to the
+ *  first non-`complete` phase; finally the last phase. */
+function pickActivePhase(phases: ProgressPhase[]): ProgressPhase | null {
+  if (phases.length === 0) return null;
+  for (const p of phases) {
+    if (p.status === "active") return p;
+  }
+  for (const p of phases) {
+    if (p.status !== "complete") return p;
+  }
+  return phases[phases.length - 1];
+}
+
+export function ProgressOverlay({
+  title,
+  phases,
+  onCancel,
+  cancelTitle,
+  children,
+}: ProgressOverlayProps) {
+  const aggregate = computeAggregateFraction(phases);
+  const active = pickActivePhase(phases);
+
+  return (
+    <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
+      {children}
+      <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
+        <h3 className="text-sm font-semibold text-text">{title}</h3>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="w-full bg-surface rounded-full h-2 overflow-hidden">
+            <div
+              className="bg-accent h-full rounded-full transition-all duration-300"
+              style={{ width: `${aggregate * 100}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-[11px] text-text-dim">
+            <span className="truncate">
+              {active?.detail ?? active?.label ?? "Working..."}
+            </span>
+            <span className="tabular-nums">
+              {Math.round(aggregate * 100)}%
+            </span>
+          </div>
+        </div>
+
+        {phases.length > 1 && (
+          <div className="flex flex-col gap-1 text-[10px] text-text-faint border-t border-border pt-2">
+            {phases.map((phase) => {
+              const dot =
+                phase.status === "complete"
+                  ? "bg-success/70"
+                  : phase.status === "active"
+                    ? "bg-accent"
+                    : "bg-border";
+              const text =
+                phase.status === "complete"
+                  ? "text-text-dim"
+                  : phase.status === "active"
+                    ? "text-text-sub"
+                    : "text-text-faint";
+              return (
+                <div
+                  key={phase.id}
+                  className={`flex items-center gap-2 ${text}`}
+                >
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full shrink-0 ${dot}`}
+                  />
+                  <span className="truncate">{phase.label}</span>
+                  {phase.status === "active" &&
+                    typeof phase.fraction === "number" && (
+                      <span className="ml-auto tabular-nums">
+                        {Math.round(phase.fraction * 100)}%
+                      </span>
+                    )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="w-full py-2 rounded-md text-xs font-medium bg-danger/15 text-danger hover:bg-danger/25 transition-colors cursor-pointer"
+            title={cancelTitle}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/projection-mode-picker.tsx
+++ b/app/src/components/projection-mode-picker.tsx
@@ -1,0 +1,61 @@
+// Dropdown for cycling the flight cam's projection mode. By default
+// renders as a free-floating top-right pill, but can be embedded in a
+// parent flex container by passing `embedded` to drop the absolute
+// positioning. Subscribes to the same flight-cam handle the HUD does
+// so it shows the live mode (e.g. when the user pressed P from the
+// canvas).
+
+import { useEffect, useState } from "react";
+import {
+  PROJECTION_MODES,
+  type FlightCamHandle,
+  type FlightCamState,
+  type ProjectionMode,
+} from "../lib/flight-camera";
+
+const LABELS: Record<ProjectionMode, string> = {
+  perspective: "persp",
+  orthographic: "ortho",
+  oblique: "oblique",
+};
+
+interface Props {
+  handle: FlightCamHandle | null;
+  /** When true, drops the absolute positioning so the picker can live
+   *  inside a parent flex row (e.g. the top-right toolbar). */
+  embedded?: boolean;
+}
+
+export function ProjectionModePicker({ handle, embedded = false }: Props) {
+  const [snapshot, setSnapshot] = useState<Readonly<FlightCamState> | null>(null);
+
+  useEffect(() => {
+    if (!handle) return;
+    const off = handle.subscribe((s) => setSnapshot(s));
+    return off;
+  }, [handle]);
+
+  if (!handle || !snapshot) return null;
+
+  const baseClasses =
+    "flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow";
+  const positioning = embedded ? "" : "absolute top-2 right-2 z-10";
+  const className = positioning ? `${positioning} ${baseClasses}` : baseClasses;
+
+  return (
+    <label className={className}>
+      <span className="text-text-faint">Projection</span>
+      <select
+        value={snapshot.projectionMode}
+        onChange={(e) => handle.setProjectionMode(e.target.value as ProjectionMode)}
+        className="bg-transparent outline-none text-text cursor-pointer"
+      >
+        {PROJECTION_MODES.map((m) => (
+          <option key={m} value={m} className="bg-bg-alt text-text">
+            {LABELS[m]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/app/src/components/projection-mode-picker.tsx
+++ b/app/src/components/projection-mode-picker.tsx
@@ -47,7 +47,12 @@ export function ProjectionModePicker({ handle, embedded = false }: Props) {
       <span className="text-text-faint">Projection</span>
       <select
         value={snapshot.projectionMode}
-        onChange={(e) => handle.setProjectionMode(e.target.value as ProjectionMode)}
+        // Blur after selection so arrow keys go back to orbiting the
+        // camera instead of cycling the dropdown options.
+        onChange={(e) => {
+          handle.setProjectionMode(e.target.value as ProjectionMode);
+          e.currentTarget.blur();
+        }}
         className="bg-transparent outline-none text-text cursor-pointer"
       >
         {PROJECTION_MODES.map((m) => (

--- a/app/src/components/scene-info-panel.tsx
+++ b/app/src/components/scene-info-panel.tsx
@@ -1,0 +1,99 @@
+// Bottom-right panel showing flight-cam HUD + per-surface stats.
+// Used by both Ships and SOC viewers so the chrome, position, and
+// hide/show behaviour stay in lockstep. Per-surface content slots in
+// via `children` (stat rows beneath the HUD divider) and `actions`
+// (a row of buttons rendered alongside the first stat row, e.g. the
+// Ships viewer's DBG fallback toggle).
+//
+// Hide/show is owned internally; the parent doesn't need to thread
+// state. Click the "hide" pill to collapse to a tiny "show stats"
+// re-expand affordance.
+
+import { useState, type ReactNode } from "react";
+import { FlightCamHud } from "./flight-cam-hud";
+import type { FlightCamHandle } from "../lib/flight-camera";
+
+export interface SceneInfoPanelProps {
+  flightCamHandle: FlightCamHandle | null;
+  /** Stat rows rendered beneath the flight-cam HUD divider. Should be
+   *  null/undefined when the surface has no stats yet (e.g. mid-load);
+   *  the divider and content area are then suppressed and the panel
+   *  shows just the HUD. */
+  children?: ReactNode;
+  /** Optional element rendered inline with the first stat row (right
+   *  side). Used by the Ships viewer for its DBG-fallback toggle. */
+  actions?: ReactNode;
+  /** Tooltip on the actions slot row. The Ships DBG toggle has a long
+   *  explanation; this prop just propagates it. */
+  actionsTitle?: string;
+  /** When true, the panel renders without its own absolute
+   *  positioning. The caller is expected to position it (e.g. inside
+   *  a bottom-right flex column alongside the NavWidget). When
+   *  false (default) the panel pins itself to bottom-2 right-2. */
+  embedded?: boolean;
+}
+
+export function SceneInfoPanel({
+  flightCamHandle,
+  children,
+  actions,
+  actionsTitle,
+  embedded = false,
+}: SceneInfoPanelProps) {
+  const [visible, setVisible] = useState(true);
+
+  const positioning = embedded ? "" : "absolute bottom-2 right-2 z-10";
+
+  if (!visible) {
+    const collapsedClass = embedded
+      ? "text-[10px] px-2 py-1 rounded border border-border bg-bg-alt/90 text-text-sub hover:bg-bg-alt hover:text-text font-mono shadow"
+      : `${positioning} text-[10px] px-2 py-1 rounded border border-border bg-bg-alt/90 text-text-sub hover:bg-bg-alt hover:text-text font-mono shadow`;
+    return (
+      <button
+        type="button"
+        onClick={() => setVisible(true)}
+        title="Show stats panel"
+        aria-label="Show stats panel"
+        className={collapsedClass}
+      >
+        show stats
+      </button>
+    );
+  }
+
+  const expandedClass = embedded
+    ? "max-w-md rounded-md bg-bg-alt/95 border border-border shadow"
+    : `${positioning} max-w-md rounded-md bg-bg-alt/95 border border-border shadow`;
+
+  return (
+    <div className={expandedClass}>
+      <div className="flex items-start justify-between gap-2 px-3 py-1.5">
+        <FlightCamHud handle={flightCamHandle} embedded />
+        <button
+          type="button"
+          onClick={() => setVisible(false)}
+          title="Hide stats panel"
+          aria-label="Hide stats panel"
+          className="text-[10px] px-1.5 py-0.5 rounded border border-border bg-bg/50 text-text-sub hover:bg-bg/80 hover:text-text font-mono shrink-0"
+        >
+          hide
+        </button>
+      </div>
+      {children && (
+        <div className="border-t border-border px-3 py-1.5">
+          {actions ? (
+            <div
+              className="flex items-center justify-between gap-2"
+              title={actionsTitle}
+            >
+              <div className="flex-1 min-w-0">{children}</div>
+              <div className="shrink-0">{actions}</div>
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -1,0 +1,1962 @@
+// Renders a decomposed export package using Three.js.
+//
+// Loads `scene.json` from the package directory, then for every scene
+// instance and interior placement fetches the referenced GLB mesh,
+// material sidecar, and textures via the `decomposed_*` Tauri commands
+// implemented in `src-tauri/src/decomposed_commands.rs`. Conversion logic
+// (matrices, lights, materials) lives in `lib/decomposed-loader.ts` so
+// this component stays presentational.
+//
+// Loading strategy:
+//   - The Three.js render loop is started once at mount and never blocks
+//     on loading. OrbitControls keeps responding to pan/zoom regardless
+//     of how many meshes are in flight.
+//   - Mesh / sidecar / texture fetches run in parallel through a small
+//     semaphore (`runWithLimit`) so we never have more than `MAX_CONCURRENT`
+//     IPC calls in flight. Each child resolves independently and is added
+//     to the scene as soon as its mesh is parsed — sidecars/textures stream
+//     in afterwards and self-update via `material.needsUpdate`.
+//   - Between heavy batches we yield to the event loop with a
+//     `requestAnimationFrame`-based microyield so input events have a
+//     chance to drain.
+//
+// Limitations of the POC:
+//   - Generic PBR fallback for all shader families. The Blender importer
+//     has shader-specific node graphs we do not replicate here.
+//   - No paint/livery palette substitution. Materials render with their
+//     authored textures only.
+//   - Lights use Three.js heuristics — exact Watt conversion is the
+//     Blender importer's job; we use a conservative scalar.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
+import {
+  DECOMPOSED_CONTRACT_VERSION,
+  loadDecomposedScene,
+  loadDecomposedJson,
+  loadDecomposedPaints,
+  readDecomposedFile,
+  type DecomposedPackageInfo,
+} from "../lib/commands";
+import {
+  applyDebugFallbackToMaterial,
+  applySCBasisToObject,
+  buildLight,
+  buildMaterial,
+  findSubmaterialIndexForGlbName,
+  getMaterialMetrics,
+  hologramMaterials,
+  materialCacheKey,
+  matrixFromOffsetEuler,
+  matrixFromRows,
+  resetMaterialMetrics,
+  resolveContractPath,
+  setDebugFallbackMode,
+  stripCryEngineZUp,
+  type LightRecord,
+  type MaterialBuildMetrics,
+  type MaterialSidecar,
+  type PaintVariant,
+  type PaintsManifest,
+  type RenderStyle,
+  type SceneInstance,
+  type SceneManifest,
+  type SubmaterialRecord,
+} from "../lib/decomposed-loader";
+
+/**
+ * Live diagnostic overrides applied to the scene after construction.
+ * Values are applied via scene traversal on every change; the triages
+ * in decomposed-loader.ts remain as the construction-time baseline.
+ * undefined means "do not override" (use whatever the material has).
+ */
+export interface DiagnosticSettings {
+  /** envMapIntensity override for all non-glass, non-hologram materials. */
+  envMapIntensity: number;
+  /** renderer.toneMappingExposure */
+  toneMappingExposure: number;
+  /** metalness override for HardSurface-family materials (not glass, not hologram). */
+  metalness: number;
+  /** roughness override, applied only when roughnessOverrideEnabled is true. */
+  roughness: number;
+  /** Whether the roughness slider is active. */
+  roughnessOverrideEnabled: boolean;
+  /** clearcoat override for MeshPhysicalMaterial (HardSurface path). */
+  clearcoat: number;
+  /** AmbientLight / HemisphereLight intensity. */
+  ambientIntensity: number;
+  /** DirectionalLight intensity (all directional lights in scene). */
+  directionalIntensity: number;
+  /** Camera-attached ("headlight") intensity, if one exists. */
+  headlightIntensity: number;
+  /** Multiplier on HSL saturation for every material.color (1.0 = unchanged). */
+  colorSaturation: number;
+}
+
+export const DEFAULT_DIAGNOSTIC_SETTINGS: DiagnosticSettings = {
+  envMapIntensity: 0,
+  toneMappingExposure: 0.85,
+  metalness: 0.4,
+  roughness: 0.5,
+  roughnessOverrideEnabled: false,
+  clearcoat: 0,
+  ambientIntensity: 0.3,
+  directionalIntensity: 0.6,
+  headlightIntensity: 1.0,
+  colorSaturation: 1.0,
+};
+
+interface Props {
+  packageInfo: DecomposedPackageInfo;
+  /** Presentation mode for materials. Switching rebuilds materials in
+   *  place without re-loading meshes or textures. */
+  renderStyle?: RenderStyle;
+  /** Show or hide the 1km neutral ground plane. Defaults to true. The
+   *  plane lives on `scene` (not `sceneRoot`) so it persists across
+   *  package switches; toggling visibility here just flips
+   *  `mesh.visible` on the existing geometry — no rebuild, no GC. */
+  showGroundPlane?: boolean;
+  /** Show or hide the GridHelper overlay. Defaults to true. */
+  showGrid?: boolean;
+  /** RGB color of the ground plane as [r, g, b] in 0-255 integer range. */
+  groundPlaneColor?: [number, number, number];
+  /** Selected paint/livery variant's `palette_id`, or null for the
+   *  default (as-baked) livery. Switching rebuilds exterior materials
+   *  in place — the swap loads the variant sidecar's textures on
+   *  demand but reuses cached meshes and per-package state. */
+  livery?: string | null;
+  /** Live diagnostic overrides swept by the Settings panel sliders.
+   *  Applied post-construction via scene traversal; the loader triages
+   *  remain as the baseline. Omit to use defaults. */
+  diagnostics?: DiagnosticSettings;
+  /** Fired once per scene load with the list of paint variants the
+   *  exporter wrote to `paints.json`. The list is per-ship and may be
+   *  empty; the parent renders a livery dropdown only when at least
+   *  one variant exists. */
+  onPaints?: (variants: PaintVariant[]) => void;
+  /** Display under the toolbar, optional. */
+  onStatus?: (text: string) => void;
+}
+
+/** Per-mesh binding so we can rebuild materials in place when the
+ *  user changes the render-style or the livery without re-fetching
+ *  meshes. Each mesh remembers both its currently-active submaterial
+ *  (the one driving its current Three.js material) and the original
+ *  on-disk submaterial it loaded as. The default record lets us
+ *  restore "no livery" without re-running the scene-load pipeline. */
+interface MaterialBinding {
+  mesh: THREE.Mesh;
+  /** Currently-active sidecar path. Equals `defaultSidecarKey` when
+   *  no livery is overriding this binding; equals the variant's
+   *  `exterior_material_sidecar` when one is. */
+  sidecarKey: string;
+  /** Currently-active submaterial record (drives style switching). */
+  submaterial: SubmaterialRecord;
+  /** The on-disk sidecar this mesh's GLB material was originally
+   *  resolved against. Used by the livery effect to identify exterior
+   *  bindings (those whose default key matches the entity's root
+   *  exterior sidecar) and to restore "no livery". */
+  defaultSidecarKey: string;
+  /** Original submaterial record, restored when the livery selection
+   *  returns to default. */
+  defaultSubmaterial: SubmaterialRecord;
+}
+
+/**
+ * Cap on simultaneous Tauri IPC reads. Tauri serialises Vec<u8> over a
+ * single IPC channel; pushing 2000+ requests at once stalls the channel
+ * and starves the WebGL renderer. 8 keeps the pipeline full without
+ * monopolising the bridge.
+ */
+const MAX_CONCURRENT = 8;
+
+/** Yield to the event loop so input events / OrbitControls can drain. */
+function microyield(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+interface LoadProgress {
+  loaded: number;
+  total: number;
+  current: string;
+}
+
+export function SceneViewer({
+  packageInfo,
+  renderStyle = "textured",
+  showGroundPlane = true,
+  showGrid = true,
+  groundPlaneColor = [128, 128, 128],
+  livery = null,
+  diagnostics = DEFAULT_DIAGNOSTIC_SETTINGS,
+  onPaints,
+  onStatus,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stateRef = useRef<{
+    renderer: THREE.WebGLRenderer;
+    scene: THREE.Scene;
+    camera: THREE.PerspectiveCamera;
+    controls: OrbitControls;
+    sceneRoot: THREE.Group;
+    groundMesh: THREE.Mesh;
+    gridHelper: THREE.GridHelper;
+    animId: number;
+  } | null>(null);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<LoadProgress | null>(null);
+  // Timestamp (performance.now()) recorded when the scene load starts,
+  // used by the first-frame effect to emit [perf] first-frame.
+  const loadStartRef = useRef<number>(0);
+  const [stats, setStats] = useState<{
+    instances: number;
+    interiors: number;
+    lights: number;
+    metrics: MaterialBuildMetrics;
+  } | null>(null);
+  const generationRef = useRef(0);
+  // Debug-fallback mode: when on, the loader recolours fallback /
+  // stand-in material paths into distinct neons so the user can
+  // visually identify which case is firing on each surface. Toggling
+  // triggers a material rebuild via the effect below; submaterials
+  // that resolved correctly stay normal-coloured either way.
+  const [debugFallbacks, setDebugFallbacks] = useState(false);
+  const activeDebugRef = useRef(false);
+
+  // Persistent caches scoped to the current scene load. The bindings
+  // list lets us rebuild materials in place when the render style
+  // changes; the texture cache lets a re-bind reuse already-decoded
+  // textures so the rebuild is fast.
+  const bindingsRef = useRef<MaterialBinding[]>([]);
+  const materialCacheRef = useRef<Map<string, THREE.Material>>(new Map());
+  const textureCacheRef = useRef<Map<string, Promise<THREE.Texture | null>>>(
+    new Map(),
+  );
+  // The active render style at the time of the last scene load, used by
+  // the rebuild effect to detect when a switch is needed.
+  const activeStyleRef = useRef<RenderStyle>(renderStyle);
+
+  // ── Livery state, scoped to the loaded package ──
+  //
+  // The livery rebuild needs to run AFTER the scene is fully loaded,
+  // so the texture-loader, sidecar-loader, and per-package texture
+  // cache must outlive a single scene-load `useEffect` invocation.
+  // We hold them in refs here so the livery effect (declared later)
+  // can pull them out without participating in the scene-load
+  // closure. All three are reset at the start of every scene load
+  // and fall back to no-op behaviour when null.
+  const loadTextureRef = useRef<
+    ((path: string) => Promise<THREE.Texture | null>) | null
+  >(null);
+  const loadSidecarRef = useRef<
+    ((path: string) => Promise<MaterialSidecar | null>) | null
+  >(null);
+  const paintVariantsRef = useRef<PaintVariant[]>([]);
+  /** Path of the entity's root-entity `material_sidecar`. A binding is
+   *  "exterior" iff its `defaultSidecarKey` matches this string —
+   *  paint-variant overrides only swap sidecars that already pointed at
+   *  the root exterior. Landing gears and other shared exterior parts
+   *  reference the same root sidecar by design, so they get re-painted
+   *  along with the hull. Null when scene.json had no root sidecar. */
+  const defaultExteriorSidecarRef = useRef<string | null>(null);
+  /** The active livery at the time of the last scene load / rebuild,
+   *  used by the livery effect to detect when a switch is needed and
+   *  avoid double-applying the same selection. */
+  const activeLiveryRef = useRef<string | null>(livery);
+  /** Mirror of the `livery` prop, kept current via the effect below.
+   *  Lets the scene-load closure read the latest value at the moment
+   *  it kicks the initial-livery apply (after paints.json lands), so
+   *  a user selection made between mount and paints-fetch still wins. */
+  const liveryPropRef = useRef<string | null>(livery);
+  useEffect(() => {
+    liveryPropRef.current = livery;
+  }, [livery]);
+
+  // -- Three.js bootstrap (runs once; render loop never blocks on loads) --
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: "high-performance",
+    });
+    renderer.setClearColor(0x101418);
+    // Three.js r183 defaults to LinearSRGBColorSpace output and NoToneMapping,
+    // which emits linear floats into a framebuffer the OS treats as sRGB.
+    // Result: dark, oversaturated, hue-shifted image, plus any HDR value above
+    // 1.0 clamps hard. Use sRGB output and ACES filmic tonemapping so scenes
+    // look like every other modern PBR viewer.
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    // Exposure tuned for ship exteriors lit by IBL + a single key light.
+    // 1.0 (the comfortable default) reads as "outdoors at noon" against
+    // the procedural RoomEnvironment, which blows out highlights on
+    // metallic hull paint and produces the blue/white rim visual the
+    // user reported. 0.85 brings overall luminance down ~15% so actual
+    // material colours read instead of IBL-saturated highlights.
+    renderer.toneMappingExposure = 0.85;
+    // High-DPI displays (4K / retina) push 2-3x the pixel count, which kills
+    // frame rate during pan with no visible benefit past ~1.5x. Clamp.
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      100000,
+    );
+    camera.position.set(60, 30, 60);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    // Damping is off: it caused post-release momentum (rotate/pan kept moving
+    // after mouseup) and forced the render loop to keep producing frames while
+    // the velocity decayed. Render-on-demand for the always-on animate loop is
+    // a separate follow-up (the loop at `animate()` still ticks every frame).
+    controls.enableDamping = false;
+
+    // Fallback lighting so the model is visible even before scene lights
+    // load. The IBL below provides most of the ambient/diffuse fill via
+    // `scene.environment`, so the hemisphere intensity is low — keeping
+    // it nonzero just hedges against an envmap that doesn't carry the
+    // sky/ground gradient we want.
+    const hemi = new THREE.HemisphereLight(0xb1bfd8, 0x202428, 0.3);
+    hemi.name = "fallback_hemi";
+    scene.add(hemi);
+    // Sky-direction key light. Positioned high and to one side so PBR
+    // surfaces show meaningful highlights and self-shadowing cues without
+    // any actual shadow-map cost. Intensity 0.6 reads as a moderate
+    // outdoor key — 1.5 (the prior value) overdrove the IBL and
+    // produced the white/blue/pink rim visual the user reported on
+    // Aurora hull paints.
+    const dir = new THREE.DirectionalLight(0xffffff, 0.6);
+    dir.position.set(50, 100, 25);
+    dir.name = "fallback_dir";
+    scene.add(dir);
+
+    // Image-based lighting. PMREMGenerator pre-filters a procedural
+    // RoomEnvironment scene into a mipmap chain that
+    // MeshStandardMaterial / MeshPhysicalMaterial sample for ambient
+    // reflection at every roughness. `scene.environment` opts every PBR
+    // material in automatically; we deliberately leave
+    // `scene.background` unset so the dark clearColor stays as the
+    // backdrop.
+    //
+    // Swap-out: to use a real HDRI later, replace the `fromScene` call
+    // with `pmremGenerator.fromEquirectangular(hdrTexture)` -- the
+    // downstream wiring (`scene.environment = ...`) is identical, so
+    // changing the source is a one-line edit. RGBELoader from
+    // `three/addons/loaders/RGBELoader.js` reads `.hdr` files in the
+    // format that produces the right input for `fromEquirectangular`.
+    const pmremGenerator = new THREE.PMREMGenerator(renderer);
+    const roomEnv = new RoomEnvironment();
+    const envTexture = pmremGenerator.fromScene(roomEnv, 0.04).texture;
+    scene.environment = envTexture;
+    // RoomEnvironment is bright by default — its built-in lights are
+    // sized for "Three.js demo room" lighting, not "outdoors." On
+    // metallic hull paint with the ACES tone map, full intensity
+    // dominates the actual material colour and reads as a mirror
+    // reflecting the procedural sky. 0.5 keeps the ambient fill but
+    // halves the specular reflection that was washing out paints.
+    scene.environmentIntensity = 0.5;
+
+    // Ground plane. Sits 100m below world origin, 1km square, neutral
+    // matte. Receives shadows in case we wire shadow mapping later. Added
+    // to `scene` (not `sceneRoot`) so it persists across package switches
+    // — sceneRoot is cleared on every load — and is therefore excluded
+    // from the camera-fit bounds calculation in `fitCamera`, which walks
+    // sceneRoot only.
+    const groundGeometry = new THREE.PlaneGeometry(1000, 1000);
+    const groundMaterial = new THREE.MeshStandardMaterial({
+      color: 0x808080,
+      roughness: 0.9,
+      metalness: 0.0,
+    });
+    const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+    ground.name = "ground_plane";
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -100;
+    ground.receiveShadow = true;
+    // Apply the initial visibility from props. The dedicated effect below
+    // keeps it in sync as the prop changes; setting it here too avoids a
+    // one-frame flash of the plane when the user mounts the viewer with
+    // ground hidden.
+    ground.visible = showGroundPlane;
+    scene.add(ground);
+
+    // Helpers
+    const grid = new THREE.GridHelper(200, 40, 0x444444, 0x222222);
+    grid.name = "grid_helper";
+    grid.visible = showGrid;
+    scene.add(grid);
+    const axes = new THREE.AxesHelper(5);
+    scene.add(axes);
+
+    const sceneRoot = new THREE.Group();
+    sceneRoot.name = "decomposed_root";
+    // Apply the Z-up -> Y-up basis change once at the scene root.
+    // Loaded GLBs are normalised to raw CryEngine Z-up basis at parse
+    // time (see `stripCryEngineZUp` in decomposed-loader.ts) so all
+    // inter-mesh transforms in scene.json compose consistently in
+    // CryEngine basis before this final rotation flips the whole scene
+    // into Three.js Y-up.
+    applySCBasisToObject(sceneRoot);
+    scene.add(sceneRoot);
+
+    let animId = 0;
+    // Perf instrumentation. Logged every 2s; grep `[perf]` in the console.
+    // Strip when render-on-demand lands.
+    const PERF_LOG_INTERVAL_MS = 2000;
+    const perfWindow: { frameMs: number; renderMs: number; controlsMs: number }[] = [];
+    let lastFrameTs = performance.now();
+    let lastLogTs = lastFrameTs;
+    // Renderer GPU info: use UNMASKED_VENDOR/RENDERER via WEBGL_debug_renderer_info
+    // so we can verify the webview is actually using the dGPU and not iGPU.
+    const gl = renderer.getContext();
+    const dbgInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    const gpuVendor = dbgInfo ? gl.getParameter(dbgInfo.UNMASKED_VENDOR_WEBGL) : "unknown";
+    const gpuRenderer = dbgInfo ? gl.getParameter(dbgInfo.UNMASKED_RENDERER_WEBGL) : "unknown";
+    console.log(
+      `[perf] init three=${THREE.REVISION} ship=${packageInfo.package_name} gpu_vendor=${gpuVendor} gpu_renderer=${gpuRenderer}`,
+    );
+    const animate = () => {
+      animId = requestAnimationFrame(animate);
+      const frameStart = performance.now();
+      const frameMs = frameStart - lastFrameTs;
+      lastFrameTs = frameStart;
+
+      const ctrlStart = performance.now();
+      controls.update();
+      const ctrlEnd = performance.now();
+
+      // Tick hologram materials' `time` uniform so the scanline /
+      // shimmer animation runs. The `hologramMaterials` array is
+      // populated by `buildHologramMaterial` per package load; we
+      // assume it's append-only and walk it directly.
+      const elapsedSec = frameStart * 0.001;
+      for (let i = 0; i < hologramMaterials.length; i += 1) {
+        const u = hologramMaterials[i].uniforms.time;
+        if (u) u.value = elapsedSec;
+      }
+
+      renderer.render(scene, camera);
+      const renderEnd = performance.now();
+
+      perfWindow.push({
+        frameMs,
+        renderMs: renderEnd - ctrlEnd,
+        controlsMs: ctrlEnd - ctrlStart,
+      });
+
+      if (renderEnd - lastLogTs >= PERF_LOG_INTERVAL_MS) {
+        const n = perfWindow.length;
+        if (n > 0) {
+          let sumFrame = 0, sumRender = 0, sumControls = 0, maxRender = 0;
+          for (const s of perfWindow) {
+            sumFrame += s.frameMs;
+            sumRender += s.renderMs;
+            sumControls += s.controlsMs;
+            if (s.renderMs > maxRender) maxRender = s.renderMs;
+          }
+          const avgFrame = sumFrame / n;
+          const fps = avgFrame > 0 ? 1000 / avgFrame : 0;
+          const info = renderer.info;
+          const mem = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory;
+          const heap = mem ? ` heap=${Math.round(mem.usedJSHeapSize / 1024 / 1024)}MB` : "";
+          console.log(
+            `[perf] fps=${fps.toFixed(1)} frame_avg=${avgFrame.toFixed(2)}ms ` +
+              `render_avg=${(sumRender / n).toFixed(2)}ms render_max=${maxRender.toFixed(2)}ms ` +
+              `controls_avg=${(sumControls / n).toFixed(3)}ms ` +
+              `draw_calls=${info.render.calls} tris=${info.render.triangles} ` +
+              `textures=${info.memory.textures} geometries=${info.memory.geometries} ` +
+              `programs=${info.programs?.length ?? 0}${heap} samples=${n}`,
+          );
+        }
+        perfWindow.length = 0;
+        lastLogTs = renderEnd;
+      }
+    };
+    animate();
+
+    stateRef.current = {
+      renderer,
+      scene,
+      camera,
+      controls,
+      sceneRoot,
+      groundMesh: ground,
+      gridHelper: grid,
+      animId,
+    };
+
+    const ro = new ResizeObserver(() => {
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    });
+    ro.observe(container);
+
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(animId);
+      controls.dispose();
+      // Release the IBL render target and the ground mesh's geometry /
+      // material; created once at init so they live as long as the
+      // renderer does.
+      pmremGenerator.dispose();
+      envTexture.dispose();
+      groundGeometry.dispose();
+      groundMaterial.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+      stateRef.current = null;
+    };
+  }, []);
+
+  // Rebuild exterior bindings against either the variant's substitute
+  // sidecar (`palette_id !== null && variant.exterior_material_sidecar`)
+  // or the original on-disk sidecar (default). Walks every recorded
+  // binding once: bindings whose `defaultSidecarKey` doesn't match the
+  // entity's root exterior sidecar are skipped (they're shared
+  // components, decals, interiors — not paint-bearing). Submaterial
+  // matching falls back through `submaterial_name` then `index` so the
+  // variant sidecar can be authored against the same MTL roster as the
+  // default with minor reordering.
+  //
+  // Stable identity (empty deps) — reads only refs and pure helpers.
+  // The load effect captures this for its initial-livery apply path.
+  const applyLiveryRebuild = useCallback(
+    async (nextLivery: string | null): Promise<void> => {
+      const bindings = bindingsRef.current;
+      if (bindings.length === 0) {
+        activeLiveryRef.current = nextLivery;
+        return;
+      }
+      const exteriorKey = defaultExteriorSidecarRef.current;
+      if (!exteriorKey) {
+        // No root exterior sidecar means there's nothing this view can
+        // paint differently. Surface the no-op cleanly.
+        activeLiveryRef.current = nextLivery;
+        return;
+      }
+      const loadSidecar = loadSidecarRef.current;
+      const loadTexture = loadTextureRef.current;
+      if (!loadSidecar || !loadTexture) {
+        // Scene load hasn't published the loaders yet. The trailing
+        // initial-livery apply at the tail of the load effect, or the
+        // user's next selection, will retry.
+        return;
+      }
+
+      // Resolve the variant. A null livery means restore default.
+      const variant: PaintVariant | null = nextLivery
+        ? paintVariantsRef.current.find((v) => v.palette_id === nextLivery) ?? null
+        : null;
+      const overridePath = variant?.exterior_material_sidecar ?? null;
+
+      // Pre-load the override sidecar once. Sidecar fetches are
+      // deduped per-package via `loadSidecarRef`, so subsequent
+      // re-applications of the same livery are free.
+      const overrideSidecar: MaterialSidecar | null = overridePath
+        ? await loadSidecar(overridePath)
+        : null;
+      if (overridePath && !overrideSidecar) {
+        console.warn(
+          "[scene-viewer] livery override sidecar failed to load:",
+          overridePath,
+        );
+      }
+
+      // Per-rebuild material cache keyed by `materialCacheKey`. Two
+      // exterior meshes that resolve to the same submaterial share a
+      // freshly-built material so draw-call count and shader-program
+      // count don't multiply with mesh count.
+      const style = activeStyleRef.current;
+      const newCache = new Map<string, THREE.Material>();
+      const usedKeys = new Set<string>();
+      let exteriorBindings = 0;
+      let overridden = 0;
+
+      for (const binding of bindings) {
+        if (binding.defaultSidecarKey !== exteriorKey) {
+          // Non-exterior binding (interior, hardpoint child with its
+          // own sidecar, etc.). Leave it alone.
+          const key = materialCacheKey(binding.submaterial, style);
+          usedKeys.add(key);
+          newCache.set(key, binding.mesh.material as THREE.Material);
+          continue;
+        }
+        exteriorBindings += 1;
+
+        // Pick the submaterial record this binding should now use.
+        // Override sidecar takes precedence; falls back to default
+        // when the override doesn't carry a matching entry (the
+        // variant authored a different roster) or when the user
+        // restored "Default".
+        let target: SubmaterialRecord = binding.defaultSubmaterial;
+        let activeSidecarKey = binding.defaultSidecarKey;
+        if (overrideSidecar?.submaterials?.length) {
+          const submats = overrideSidecar.submaterials;
+          const defaultName = binding.defaultSubmaterial.submaterial_name;
+          let idx = -1;
+          if (defaultName) {
+            idx = submats.findIndex((sm) => sm.submaterial_name === defaultName);
+          }
+          if (idx < 0 && typeof binding.defaultSubmaterial.index === "number") {
+            // Index fallback for variants that renamed but preserved
+            // positional alignment with the default sidecar's roster.
+            const defaultIdx = binding.defaultSubmaterial.index;
+            idx = submats.findIndex((sm) => sm.index === defaultIdx);
+          }
+          if (idx >= 0) {
+            target = submats[idx];
+            activeSidecarKey = overridePath ?? binding.defaultSidecarKey;
+            overridden += 1;
+          }
+        }
+
+        const cacheKey = materialCacheKey(target, style);
+        let material = newCache.get(cacheKey);
+        if (!material) {
+          const built = buildMaterial(target, loadTexture, style);
+          material = built.material;
+          newCache.set(cacheKey, material);
+        }
+        binding.mesh.material = material;
+        binding.submaterial = target;
+        binding.sidecarKey = activeSidecarKey;
+        usedKeys.add(cacheKey);
+      }
+
+      // Dispose materials from the prior cache that no longer have a
+      // referrer. We can't blanket-dispose the whole previous cache:
+      // non-exterior bindings still reference their entries verbatim
+      // (we copied them into `newCache` above), so disposing those
+      // would leave naked GPU handles on the live meshes.
+      for (const [key, mat] of materialCacheRef.current) {
+        if (!usedKeys.has(key)) mat.dispose();
+      }
+      materialCacheRef.current = newCache;
+      activeLiveryRef.current = nextLivery;
+
+      console.info(
+        `[scene-viewer] livery rebuild: variant=${variant?.palette_id ?? "default"} ` +
+          `exteriorBindings=${exteriorBindings} overridden=${overridden}`,
+      );
+    },
+    [],
+  );
+
+  // -- Scene load on packageInfo change --
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    const gen = ++generationRef.current;
+    loadStartRef.current = performance.now();
+    setLoading(true);
+    setError(null);
+    setStats(null);
+    setProgress(null);
+    resetMaterialMetrics();
+
+    // Clear previous scene. The basis rotation lives on the sceneRoot
+    // itself, not its children, so clearing children preserves it.
+    clearObject(state.sceneRoot);
+    // Drop bindings now so a stale render-style switch arriving before
+    // the new scene loads doesn't try to re-bind disposed meshes.
+    bindingsRef.current = [];
+    // Dispose any materials cached from the previous scene before we
+    // overwrite the reference; meshes that referenced them have been
+    // disposed by clearObject above.
+    for (const old of materialCacheRef.current.values()) {
+      old.dispose();
+    }
+    materialCacheRef.current = new Map();
+    // Reset livery state — the new package has its own paint variants
+    // and exterior sidecar. The loadTexture / loadSidecar refs are
+    // re-populated below once the per-package loaders are constructed.
+    loadTextureRef.current = null;
+    loadSidecarRef.current = null;
+    paintVariantsRef.current = [];
+    defaultExteriorSidecarRef.current = null;
+    activeLiveryRef.current = livery;
+    onPaints?.([]);
+
+    void (async () => {
+      // Phase-timing marks. Cleared at the start of each load so marks
+      // from a prior run don't pollute the final summary.
+      const perfBase = `load:${packageInfo.package_name}`;
+      performance.clearMarks(perfBase + ":start");
+      performance.mark(perfBase + ":start");
+      const perfT0 = performance.now();
+
+      try {
+        onStatus?.("Loading scene.json...");
+        const manifest = (await loadDecomposedScene(packageInfo.package_dir)) as SceneManifest;
+        if (gen !== generationRef.current) return;
+        const perfAfterScene = performance.now();
+
+        // Refuse stale exports up front. The loader assumes contract v2
+        // semantics (GLB material.extras.submat_index, MtlName-first
+        // sidecar resolution). Pre-v2 exports lack the engine-truth
+        // submaterial cross-reference and bind GLB materials to whatever
+        // sidecar the writer happened to emit -- which on
+        // wrong-sidecar-bug entities (gimbal mounts, KLWE laser repeaters,
+        // shared component meshes) is a different MTL than the GLB's
+        // material names came from. Without this gate, the symptom is a
+        // flood of "[decomposed-loader] no sidecar submaterial matches GLB
+        // material ..." warnings and a whitebox scene that no amount of
+        // shader / material work in the loader can fix. A version mismatch
+        // is data-staleness, not a bug to paper over -- surface it loudly
+        // so the user re-exports.
+        const manifestContract = manifest.contract_version ?? 0;
+        if (manifestContract !== DECOMPOSED_CONTRACT_VERSION) {
+          throw new Error(
+            `Stale export: scene.json contract_version=${manifestContract}, ` +
+              `loader expects v${DECOMPOSED_CONTRACT_VERSION}. ` +
+              `Re-export this entity (Scene Viewer toolbar -> RotateCw on the row, ` +
+              `or 'Clear all' to wipe and restart) so the GLB writer emits ` +
+              `extras.submat_index and the sidecar resolves via the engine-truth ` +
+              `MtlName chunk. Loading older packages would silently bind GLB ` +
+              `materials to the wrong sidecar's submaterials and render a ` +
+              `whitebox scene.`,
+          );
+        }
+
+        const exportRoot = packageInfo.export_root;
+        const gltfLoader = new GLTFLoader();
+        const meshCache = new Map<string, Promise<THREE.Group>>();
+        const sidecarCache = new Map<string, Promise<MaterialSidecar | null>>();
+        // Reset persistent caches for the new scene load.
+        bindingsRef.current = [];
+        materialCacheRef.current = new Map<string, THREE.Material>();
+        textureCacheRef.current = new Map<string, Promise<THREE.Texture | null>>();
+        // Drop holograms from the previous package so the animate loop
+        // doesn't tick orphan ShaderMaterials that point at disposed
+        // resources. The new package will repopulate as its hologram
+        // materials are built.
+        hologramMaterials.length = 0;
+        const textureCache = textureCacheRef.current;
+        activeStyleRef.current = renderStyle;
+
+        // ---- Loaders (cached, deduped) ----
+
+        const loadMesh = (contractPath: string): Promise<THREE.Group> => {
+          const cached = meshCache.get(contractPath);
+          if (cached) return cached.then((g) => g.clone());
+          const promise = readDecomposedFile(
+            resolveContractPath(exportRoot, contractPath),
+          ).then(
+            (buf) =>
+              new Promise<THREE.Group>((resolve, reject) => {
+                gltfLoader.parse(
+                  buf,
+                  "",
+                  // Strip the GLB-level CryEngine_Z_up wrapper so the
+                  // returned tree is in raw CryEngine basis. The
+                  // sceneRoot applies the single basis change for the
+                  // whole assembled scene.
+                  (gltf) => {
+                    stripCryEngineZUp(gltf.scene);
+                    // CryEngine packs damage / wear / dirt masks into the
+                    // mesh COLOR_0 attribute, NOT actual vertex colours.
+                    // GLTFLoader auto-enables `vertexColors: true` on every
+                    // material whose primitive carries COLOR_0, which then
+                    // multiplies the material colour by those mask values
+                    // per-fragment. The result is bright magenta / red
+                    // splotches wherever a mask channel is non-zero. Strip
+                    // the attribute and disable the flag on every material.
+                    stripMaskVertexColors(gltf.scene);
+                    resolve(gltf.scene);
+                  },
+                  (err) => reject(err),
+                );
+              }),
+          );
+          meshCache.set(contractPath, promise);
+          return promise.then((g) => g.clone());
+        };
+
+        const loadSidecar = (contractPath: string): Promise<MaterialSidecar | null> => {
+          const cached = sidecarCache.get(contractPath);
+          if (cached) return cached;
+          const promise = loadDecomposedJson(
+            resolveContractPath(exportRoot, contractPath),
+          ).then((v) => v as MaterialSidecar | null).catch(() => null);
+          sidecarCache.set(contractPath, promise);
+          return promise;
+        };
+
+        const loadTexture = (contractPath: string): Promise<THREE.Texture | null> => {
+          const cached = textureCache.get(contractPath);
+          if (cached) return cached;
+          const promise = (async (): Promise<THREE.Texture | null> => {
+            try {
+              const buf = await readDecomposedFile(
+                resolveContractPath(exportRoot, contractPath),
+              );
+              const mime = guessMime(contractPath);
+              if (mime === "application/octet-stream") {
+                // DDS / KTX / unknown — TextureLoader can't handle these
+                // generically. Skip rather than spawn a doomed decode.
+                return null;
+              }
+              const blob = new Blob([buf], { type: mime });
+              // createImageBitmap offloads PNG/JPEG decode to a worker
+              // thread, so it doesn't block the renderer.
+              if (typeof createImageBitmap === "function") {
+                const bitmap = await createImageBitmap(blob);
+                const texture = new THREE.Texture(bitmap as unknown as HTMLImageElement);
+                texture.needsUpdate = true;
+                return texture;
+              }
+              // Fallback: synchronous Image() decode on main thread.
+              const url = URL.createObjectURL(blob);
+              try {
+                return await new Promise<THREE.Texture>((resolve, reject) => {
+                  new THREE.TextureLoader().load(
+                    url,
+                    (tex) => resolve(tex),
+                    undefined,
+                    (err) => reject(err),
+                  );
+                });
+              } finally {
+                URL.revokeObjectURL(url);
+              }
+            } catch (err) {
+              console.warn("[scene-viewer] texture load failed:", contractPath, err);
+              return null;
+            }
+          })();
+          textureCache.set(contractPath, promise);
+          return promise;
+        };
+
+        // Publish the per-package loaders so the livery effect (declared
+        // outside this useEffect) can re-fetch the variant sidecar and
+        // its textures using the same caches the initial load populated.
+        loadTextureRef.current = loadTexture;
+        loadSidecarRef.current = loadSidecar;
+        // Record the entity's root exterior sidecar. The livery override
+        // only swaps bindings whose default sidecar matches this — that
+        // covers the hull plus shared exterior parts (landing gears on
+        // the Mustang, etc.) that intentionally reference the same
+        // sidecar in the as-baked export.
+        defaultExteriorSidecarRef.current =
+          manifest.root_entity?.material_sidecar ?? null;
+
+        // ---- Material binding (fire-and-forget; textures self-update) ----
+        //
+        // Texture loads run as Promise.allSettled in the background and
+        // re-bind via material.needsUpdate when they resolve. We do not
+        // await them before adding the mesh to the scene; the mesh will
+        // render with the fallback PBR material until its textures land.
+        const applySidecarMaterials = async (
+          group: THREE.Group,
+          sidecarKey: string,
+          sidecar: MaterialSidecar | null,
+        ): Promise<Promise<void>[]> => {
+          if (!sidecar?.submaterials || sidecar.submaterials.length === 0) {
+            return [];
+          }
+          const style = activeStyleRef.current;
+          const submats = sidecar.submaterials;
+          const newTexturePromises: Promise<void>[] = [];
+
+          // Build (or reuse from cache) one material per submaterial. Two
+          // instances of the same submaterial share one material and one
+          // shader program, which matters when a scene mounts hundreds of
+          // hardpoint copies of the same component.
+          const materials: THREE.Material[] = submats.map((sm) => {
+            const cacheKey = materialCacheKey(sm, style);
+            const cached = materialCacheRef.current.get(cacheKey);
+            if (cached) return cached;
+            const built = buildMaterial(sm, loadTexture, style);
+            materialCacheRef.current.set(cacheKey, built.material);
+            for (const p of built.texturePromises) newTexturePromises.push(p);
+            return built.material;
+          });
+
+          // Bind materials by reading the engine-truth submaterial index
+          // the Rust GLB writer emits as `material.extras.submat_index`.
+          // GLTFLoader merges extras directly into `material.userData`
+          // via `Object.assign(material.userData, extras)`, so the value
+          // lands at `userData.submat_index` — a single property lookup,
+          // no name parsing, no fallback ladder. Names diverge across
+          // naming spaces (MTL-source vs Blender-semantic, `_mtl_` vs
+          // `:` vs bare-name) and Three.js may clone-and-suffix names
+          // for uniqueness — none of that matters because we go straight
+          // to the index.
+          //
+          // Falls back to name-matching for older cached exports written
+          // before the `submat_index` extra existed (pre contract v2);
+          // those slots are auto-orphaned by `pruneStaleCache` on app
+          // mount, so this fallback only kicks in during the brief
+          // window where a stale GLB is processed before the new export
+          // overwrites it.
+          group.traverse((child) => {
+            if (!(child instanceof THREE.Mesh)) return;
+            const childMat = child.material as THREE.Material | undefined;
+            if (!childMat) return;
+            const submatIndex = childMat.userData?.submat_index;
+            let idx =
+              typeof submatIndex === "number" && submatIndex >= 0 && submatIndex < submats.length
+                ? submatIndex
+                : -1;
+            if (idx < 0) {
+              idx = findSubmaterialIndexForGlbName(childMat.name ?? "", submats);
+            }
+            if (idx >= 0) {
+              child.material = materials[idx];
+              // Skip meshes whose activation_state is inactive (e.g.
+              // stencil-float decals authored as opt-in geometry).
+              if (submats[idx].activation_state?.state === "inactive") {
+                child.visible = false;
+              }
+              bindingsRef.current.push({
+                mesh: child,
+                sidecarKey,
+                submaterial: submats[idx],
+                // The initial load is "no livery active" -- current and
+                // default coincide. The livery effect updates the active
+                // pair and consults `defaultSidecarKey` to identify
+                // which bindings are exterior candidates.
+                defaultSidecarKey: sidecarKey,
+                defaultSubmaterial: submats[idx],
+              });
+            }
+          });
+          return newTexturePromises;
+        };
+
+        // ---- Build a flat unit-of-work list, then run with a semaphore ----
+        //
+        // Children are attached to their parent's named bone (matched by
+        // `parent_node_name` against any Object3D within the parent's
+        // loaded mesh group). Because mesh loads run concurrently, a
+        // child may be ready before its parent. We resolve this with a
+        // per-entity Promise registry: each unit publishes its loaded
+        // group via `entityResolver`, and child units await
+        // `entityWaiters.get(parent_entity_name)` before attaching.
+        // Multi-level (grandchild) attachments work because every loaded
+        // mesh — root or child — registers itself.
+
+        type MeshUnit = {
+          label: string;
+          meshAsset: string;
+          sidecar?: string | null;
+          /** Entity name used as the key when other units look up this one
+           * as their parent. Empty for unkeyed units (e.g. interiors). */
+          entityName: string;
+          /**
+           * How to attach the loaded group. `static` parents straight
+           * into a known group with an optional transform. `bone` waits
+           * for the parent entity to load, then matches a named bone
+           * inside it; on failure it falls back to the scene root.
+           */
+          attach:
+            | { kind: "static"; parent: THREE.Group; transform?: THREE.Matrix4 }
+            | {
+                kind: "bone";
+                parentEntity: string;
+                /** Human-readable parent label for diagnostics. The
+                 *  `parentEntity` field is the registry key (e.g.
+                 *  `id:23`) which is opaque on its own; `parentLabel`
+                 *  carries the authored entity name so warnings remain
+                 *  readable. */
+                parentLabel: string;
+                parentNodeName: string;
+                /** Local matrix to apply once attached. */
+                transform?: THREE.Matrix4;
+                /**
+                 * If true, the local_transform_sc was computed by the
+                 * exporter as a *root-attached* transform (it includes
+                 * the parent bone's world translation). On bone-resolved
+                 * attach we must still place this at scene root, not
+                 * inside the bone, or the translation gets composed
+                 * with the bone's own world transform.
+                 */
+                rootAttachedTransform: boolean;
+              };
+        };
+
+        const units: MeshUnit[] = [];
+
+        // Per-entity-name registry. Producers `resolve` once their group
+        // is loaded; consumers `await` the matching promise before
+        // attaching themselves. We use one Deferred per entity.
+        type Deferred<T> = { promise: Promise<T>; resolve: (v: T) => void };
+        const makeDeferred = <T,>(): Deferred<T> => {
+          let resolve!: (v: T) => void;
+          const promise = new Promise<T>((r) => {
+            resolve = r;
+          });
+          return { promise, resolve };
+        };
+        const entityResolvers = new Map<string, Deferred<THREE.Group>>();
+        const ensureResolver = (key: string): Deferred<THREE.Group> => {
+          let d = entityResolvers.get(key);
+          if (!d) {
+            d = makeDeferred<THREE.Group>();
+            entityResolvers.set(key, d);
+          }
+          return d;
+        };
+
+        // Build registry keys. Producers and consumers must agree on
+        // the same derivation. We prefer the unique per-export
+        // `instance_id` (added with the contract's instance-id field)
+        // over `entity_name`, because two scene instances can share the
+        // same authored entity name (e.g. paired weapon mounts) and a
+        // name-keyed registry would collapse them into one slot —
+        // attaching every child to whichever sibling won the registry
+        // race. When `instance_id` is absent (older exports), we fall
+        // back to the entity name and warn so the operator knows
+        // disambiguation is best-effort. The `id:` / `name:` prefix
+        // keeps the two key spaces from colliding.
+        let warnedLegacyKeyForExport = false;
+        const instanceKey = (id: number | undefined, name: string | undefined): string => {
+          if (typeof id === "number" && Number.isFinite(id)) {
+            return `id:${id}`;
+          }
+          if (!warnedLegacyKeyForExport) {
+            warnedLegacyKeyForExport = true;
+            console.warn(
+              "[scene-viewer] scene.json lacks `instance_id` on one or more " +
+                "entries; falling back to entity_name-based attach matching. " +
+                "Re-export to enable disambiguation of paired siblings.",
+            );
+          }
+          return `name:${name ?? ""}`;
+        };
+
+        // Root entity
+        const root = manifest.root_entity;
+        if (root?.mesh_asset) {
+          const rootName = root.entity_name ?? "root";
+          // Root reserves instance_id 0 in the contract; pre-fill so
+          // children that reference parent_instance_id = 0 resolve
+          // even when older exports omit the explicit field on root.
+          const rootKey = instanceKey(root.instance_id ?? 0, rootName);
+          ensureResolver(rootKey); // pre-create so children can await
+          units.push({
+            label: rootName,
+            meshAsset: root.mesh_asset,
+            sidecar: root.material_sidecar,
+            entityName: rootKey,
+            attach: { kind: "static", parent: state.sceneRoot },
+          });
+        }
+
+        // Children
+        const children = manifest.children ?? [];
+        for (const child of children) {
+          if (!child.mesh_asset) continue;
+          const childName = child.entity_name ?? "child";
+          const childKey = instanceKey(child.instance_id, childName);
+          const parentEntity = child.parent_entity_name ?? "";
+          const parentNodeName = child.parent_node_name ?? "";
+          // Resolve the parent registry key. When the export carries
+          // `parent_instance_id` we use that directly; otherwise we
+          // fall back to the parent's entity name (best-effort, with
+          // the same caveat as above for collision-prone names).
+          const parentKey = instanceKey(child.parent_instance_id, parentEntity);
+          // Pre-create the child's resolver so grandchildren can await it.
+          ensureResolver(childKey);
+          // Only attempt bone-attach when we actually have both a parent
+          // entity (or instance id) and a target bone name. Otherwise
+          // fall back to root.
+          const transform = instanceTransform(child);
+          const hasParent =
+            typeof child.parent_instance_id === "number" || parentEntity.length > 0;
+          if (hasParent && parentNodeName) {
+            ensureResolver(parentKey); // make sure the slot exists
+            const noRotation = child.no_rotation === true;
+            // Human-readable label for the parent. Prefer the authored
+            // entity name; fall back to the bare key. Used only for
+            // diagnostic warnings — the registry lookup uses parentKey.
+            const parentLabel = parentEntity.length > 0 ? parentEntity : parentKey;
+            units.push({
+              label: childName,
+              meshAsset: child.mesh_asset,
+              sidecar: child.material_sidecar,
+              entityName: childKey,
+              attach: {
+                kind: "bone",
+                parentEntity: parentKey,
+                parentLabel,
+                parentNodeName,
+                transform,
+                rootAttachedTransform: noRotation,
+              },
+            });
+          } else {
+            units.push({
+              label: childName,
+              meshAsset: child.mesh_asset,
+              sidecar: child.material_sidecar,
+              entityName: childKey,
+              attach: { kind: "static", parent: state.sceneRoot, transform },
+            });
+          }
+        }
+
+        // Interiors + their placements + lights. Interior containers do
+        // not participate in bone-attach: they are CGF instances placed
+        // by container/placement transforms, not by named-bone lookup.
+        let totalLights = 0;
+        const interiors = manifest.interiors ?? [];
+        for (const interior of interiors) {
+          const interiorGroup = new THREE.Group();
+          interiorGroup.name = interior.name ?? "interior";
+          if (interior.container_transform) {
+            const m = matrixFromRows(interior.container_transform);
+            interiorGroup.matrixAutoUpdate = false;
+            interiorGroup.matrix.copy(m);
+          }
+          state.sceneRoot.add(interiorGroup);
+
+          // Lights are cheap (no IO); add them up front so something is
+          // visible while meshes stream in.
+          for (const lightRecord of interior.lights ?? []) {
+            const light = buildLight(lightRecord as LightRecord);
+            if (!light) continue;
+            interiorGroup.add(light);
+            if (light instanceof THREE.SpotLight && light.target) {
+              interiorGroup.add(light.target);
+            }
+            totalLights += 1;
+          }
+
+          for (const placement of interior.placements ?? []) {
+            if (!placement.mesh_asset) continue;
+            units.push({
+              label: placement.cgf_path ?? interior.name ?? "placement",
+              meshAsset: placement.mesh_asset,
+              sidecar: placement.material_sidecar,
+              entityName: "",
+              attach: {
+                kind: "static",
+                parent: interiorGroup,
+                transform: placement.transform
+                  ? matrixFromRows(placement.transform)
+                  : undefined,
+              },
+            });
+          }
+        }
+
+        if (gen !== generationRef.current) return;
+
+        // Resolve any registry slots that no unit will produce. This
+        // happens when a child references a `parent_entity_name` that is
+        // not present in the export (orphan reference). Without this,
+        // the child would await its parent's promise forever.
+        const producedKeys = new Set<string>();
+        for (const u of units) {
+          if (u.entityName) producedKeys.add(u.entityName);
+        }
+        const orphanKeys: string[] = [];
+        for (const [key, def] of entityResolvers) {
+          if (!producedKeys.has(key)) {
+            // No producer; resolve with an empty placeholder so any
+            // dependent child treats the bone lookup as "missing" and
+            // falls back to scene root attachment.
+            def.resolve(new THREE.Group());
+            orphanKeys.push(key);
+          }
+        }
+
+        // Registry summary diagnostic. Helps debug attach pairing without
+        // having to instrument by hand. Logged once per scene load at
+        // info level so it's visible but not spammy. When orphans exist,
+        // upgrade to warn so the operator notices.
+        const registrySummary = {
+          units: units.length,
+          producers: producedKeys.size,
+          resolvers: entityResolvers.size,
+          orphans: orphanKeys,
+        };
+        if (orphanKeys.length > 0) {
+          console.warn("[scene-viewer] registry summary:", registrySummary);
+        } else {
+          console.info("[scene-viewer] registry summary:", registrySummary);
+        }
+
+        const perfAfterManifest = performance.now();
+
+        const total = units.length;
+        let loadedCount = 0;
+        let instanceCount = 0;
+        // Track all in-flight texture promises so we can wait for
+        // visual completion before declaring the load done. Failures in
+        // individual textures don't fail the load (allSettled).
+        const textureWork: Promise<unknown>[] = [];
+        // Frame the camera the first time we have something on screen.
+        let framedOnce = false;
+
+        setProgress({ loaded: 0, total, current: "" });
+
+        const runUnit = async (unit: MeshUnit): Promise<void> => {
+          if (gen !== generationRef.current) return;
+          let publishedGroup: THREE.Group | null = null;
+          try {
+            const group = await loadMesh(unit.meshAsset);
+            if (gen !== generationRef.current) return;
+            group.name = unit.label;
+
+            // Resolve the attachment target. For bone-attach units this
+            // may need to wait for the parent mesh to load. We do the
+            // wait BEFORE applying any transform / adding to the scene
+            // because the local transform interpretation depends on
+            // whether we land on the bone or the fallback root.
+            let attachParent: THREE.Object3D = state.sceneRoot;
+            let attachTransform: THREE.Matrix4 | undefined;
+            if (unit.attach.kind === "static") {
+              attachParent = unit.attach.parent;
+              attachTransform = unit.attach.transform;
+            } else {
+              const parentDef = entityResolvers.get(unit.attach.parentEntity);
+              if (!parentDef) {
+                // Defensive: the unit-build pass calls
+                // `ensureResolver(parentKey)` for every bone-attach
+                // unit, so this should never fire. If it does, the
+                // registry derivation has drifted between producer and
+                // consumer — log loudly so the mismatch surfaces.
+                console.warn(
+                  "[scene-viewer] no parent resolver registered for key '%s' " +
+                    "(parent label '%s'); attaching child '%s' to scene root",
+                  unit.attach.parentEntity,
+                  unit.attach.parentLabel,
+                  unit.label,
+                );
+              }
+              const parentGroup = parentDef ? await parentDef.promise : null;
+              if (gen !== generationRef.current) return;
+              const bone =
+                parentGroup && unit.attach.parentNodeName
+                  ? findNodeByName(parentGroup, unit.attach.parentNodeName)
+                  : null;
+              if (bone) {
+                attachParent = bone;
+                // local_transform_sc is bone-relative; apply it directly.
+                attachTransform = unit.attach.transform;
+              } else {
+                // No matching bone — fall back to scene root. The
+                // exporter's `local_transform_sc` already encodes the
+                // appropriate world placement in this case (either
+                // identity if it was a pure bone-attached child whose
+                // bone could not be found, or the resolved root-attached
+                // matrix when no_rotation=true). We still warn so the
+                // operator can spot missing bones.
+                if (parentGroup && unit.attach.parentNodeName) {
+                  console.warn(
+                    "[scene-viewer] no bone '%s' on parent '%s' (key %s) for child '%s'; attaching to scene root",
+                    unit.attach.parentNodeName,
+                    unit.attach.parentLabel,
+                    unit.attach.parentEntity,
+                    unit.label,
+                  );
+                }
+                attachParent = state.sceneRoot;
+                attachTransform = unit.attach.transform;
+              }
+              // When the exporter resolved this child's transform as a
+              // root-attached matrix (no_rotation=true), the matrix
+              // already includes the bone's world translation. In that
+              // case, even if we found the bone, we should NOT compose
+              // with the bone's transform — re-route to scene root.
+              if (bone && unit.attach.rootAttachedTransform) {
+                attachParent = state.sceneRoot;
+              }
+            }
+
+            if (attachTransform) {
+              group.matrixAutoUpdate = false;
+              group.matrix.copy(attachTransform);
+            }
+            attachParent.add(group);
+            instanceCount += 1;
+            publishedGroup = group;
+
+            // Frame once we have at least one mesh attached so the user
+            // sees something instead of empty space.
+            if (!framedOnce) {
+              framedOnce = true;
+              state.sceneRoot.updateMatrixWorld(true);
+              fitCamera(state.camera, state.controls, state.sceneRoot);
+            }
+
+            // Sidecar + textures run in parallel with the next mesh.
+            if (unit.sidecar) {
+              const sidecarKey = unit.sidecar;
+              const sidecarPromise = loadSidecar(sidecarKey).then(
+                async (sidecar) => {
+                  if (gen !== generationRef.current) return;
+                  const texPromises = await applySidecarMaterials(group, sidecarKey, sidecar);
+                  if (texPromises.length > 0) {
+                    textureWork.push(
+                      Promise.allSettled(texPromises),
+                    );
+                  }
+                },
+              );
+              textureWork.push(sidecarPromise);
+            }
+          } catch (err) {
+            console.warn(
+              "[scene-viewer] mesh load failed:",
+              unit.label,
+              unit.meshAsset,
+              err,
+            );
+          } finally {
+            // Publish (or null-publish) so anyone awaiting this entity
+            // unblocks regardless of whether the load succeeded.
+            if (unit.entityName) {
+              const def = entityResolvers.get(unit.entityName);
+              if (def) {
+                // Resolve with the group if we have one; otherwise an
+                // empty placeholder so dependents don't await forever.
+                def.resolve(publishedGroup ?? new THREE.Group());
+              }
+            }
+            loadedCount += 1;
+            setProgress({
+              loaded: loadedCount,
+              total,
+              current: unit.label,
+            });
+          }
+        };
+
+        // Run the unit list with bounded concurrency. Yield every batch
+        // so the event loop drains.
+        await runWithLimit(units, MAX_CONCURRENT, runUnit, async () => {
+          await microyield();
+        });
+
+        if (gen !== generationRef.current) return;
+        const perfAfterGlb = performance.now();
+
+        // Wait for any remaining sidecar / texture work to finish before
+        // we mark the load complete. We don't add new geometry from these,
+        // so the user can already pan around the assembled scene.
+        await Promise.allSettled(textureWork);
+
+        if (gen !== generationRef.current) return;
+        const perfAfterTextures = performance.now();
+
+        // Final camera frame in case streaming added geometry well outside
+        // the initial bounds.
+        state.sceneRoot.updateMatrixWorld(true);
+        if (!framedOnce) {
+          fitCamera(state.camera, state.controls, state.sceneRoot);
+        }
+
+        // Emit a single summary line with all phase deltas so the bottleneck
+        // is visible in app.log without DevTools. Field meanings:
+        //   scene_json  = load_decomposed_scene IPC round-trip (Rust JSON read + serialize)
+        //   manifest    = TS-side unit-list build from parsed manifest (sync, should be <10ms)
+        //   glb         = all GLB IPC reads + Three.js parse (the big parallel phase)
+        //   textures    = remaining sidecar/texture IPC reads + createImageBitmap decode
+        //   total       = wall time from scene-load useEffect trigger to texture settle
+        const dScene    = (perfAfterScene    - perfT0).toFixed(0);
+        const dManifest = (perfAfterManifest - perfAfterScene).toFixed(0);
+        const dGlb      = (perfAfterGlb      - perfAfterManifest).toFixed(0);
+        const dTextures = (perfAfterTextures  - perfAfterGlb).toFixed(0);
+        const dTotal    = (perfAfterTextures  - perfT0).toFixed(0);
+        console.info(
+          `[perf] load ${packageInfo.package_name}: ` +
+          `scene_json=${dScene}ms manifest=${dManifest}ms ` +
+          `glb=${dGlb}ms textures=${dTextures}ms total=${dTotal}ms ` +
+          `units=${units.length}`,
+        );
+
+        setLoading(false);
+        setProgress(null);
+        setStats({
+          instances: instanceCount,
+          interiors: interiors.length,
+          lights: totalLights,
+          metrics: getMaterialMetrics(),
+        });
+        onStatus?.(
+          `${packageInfo.package_name}: ${instanceCount} parts, ${interiors.length} interiors, ${totalLights} lights`,
+        );
+
+        // Fetch paint variants and surface them to the parent. This is
+        // fire-and-forget — paints.json is small (under a few KB) and
+        // optional; missing files (older exports, entities with no
+        // DataCore paint variants) yield an empty list and the parent
+        // hides the dropdown. We fetch AFTER setStats so the viewer
+        // is fully usable before the dropdown populates; the user can
+        // pan/zoom while the variant list loads.
+        try {
+          const paints = (await loadDecomposedPaints(
+            packageInfo.package_dir,
+          )) as PaintsManifest | null;
+          if (gen !== generationRef.current) return;
+          const variants = paints?.paint_variants ?? [];
+          paintVariantsRef.current = variants;
+          onPaints?.(variants);
+          // Honor a livery selection that was set BEFORE the scene
+          // finished loading. The livery effect only runs on prop
+          // change after the initial mount, so a parent that defaulted
+          // `livery` to a non-null value would otherwise see no swap.
+          // Read through the ref so a selection made between mount
+          // and paints-fetch lands as well.
+          const targetLivery = liveryPropRef.current;
+          if (targetLivery && targetLivery !== activeLiveryRef.current) {
+            await applyLiveryRebuild(targetLivery);
+          }
+        } catch (err) {
+          // Paints are non-essential — log and move on.
+          console.warn("[scene-viewer] paints.json load failed:", err);
+        }
+      } catch (err) {
+        if (gen !== generationRef.current) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[scene-viewer] load failed:", err);
+        setError(msg);
+        setLoading(false);
+        setProgress(null);
+        onStatus?.(`Error: ${msg}`);
+      }
+    })();
+    // `livery`, `onPaints`, and `applyLiveryRebuild` are intentionally
+    // NOT in the dep array. The load runs ONCE per package; livery is
+    // applied via the dedicated effect below (which honors prop changes
+    // mid-load via `liveryPropRef`). Including `livery` here would
+    // tear down and re-load the entire scene on every dropdown click.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [packageInfo.package_dir, packageInfo.export_root, packageInfo.package_name, onStatus]);
+
+  // -- Ground plane visibility toggle. The mesh lives on `scene` (not
+  //    `sceneRoot`), so it survives package switches; flipping
+  //    `mesh.visible` is a near-zero-cost render-loop bypass — no
+  //    material, geometry, or scene-graph mutation. --
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    state.groundMesh.visible = showGroundPlane;
+  }, [showGroundPlane]);
+
+  // -- Grid helper visibility toggle. --
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    state.gridHelper.visible = showGrid;
+  }, [showGrid]);
+
+  // -- Ground plane color. Applied live when the RGB sliders change. --
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    const mat = state.groundMesh.material as THREE.MeshStandardMaterial;
+    const [r, g, b] = groundPlaneColor;
+    mat.color.setRGB(r / 255, g / 255, b / 255);
+    mat.needsUpdate = true;
+  }, [groundPlaneColor]);
+
+  // -- Diagnostic overrides: traverse scene and apply live slider values. --
+  // Runs whenever any diagnostic field changes. Does NOT rebuild materials;
+  // it mutates the already-built Three.js material objects in place so the
+  // next render frame picks up the new values without any allocation.
+  //
+  // Material family detection uses the same criteria as the loader:
+  //  - HardSurface = MeshStandardMaterial or MeshPhysicalMaterial whose
+  //    name doesn't match the hologram/glass/decal sentinel patterns.
+  //    We rely on the ground-plane name guard (skipping the ground mesh)
+  //    rather than trying to enumerate exact shader families here.
+  //  - Glass / hologram / decal materials are skipped for metalness and
+  //    clearcoat overrides because their visually-correct values differ
+  //    from hull paint defaults.
+  //
+  // Color saturation is applied after any color already set by the
+  // loader (including the positive-control red from the triage-instrument
+  // agent), so the two compose correctly.
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    const { renderer, scene } = state;
+
+    // 1. Renderer-level: tone-mapping exposure.
+    renderer.toneMappingExposure = diagnostics.toneMappingExposure;
+
+    // 2. Scene lights.
+    scene.traverse((obj) => {
+      if (obj instanceof THREE.AmbientLight || obj instanceof THREE.HemisphereLight) {
+        // Skip the ground-plane's own pseudo-ambient if any; they are
+        // identified by name. The fallback_hemi we created at init is the
+        // target.
+        obj.intensity = diagnostics.ambientIntensity;
+      } else if (obj instanceof THREE.DirectionalLight) {
+        obj.intensity = diagnostics.directionalIntensity;
+      }
+    });
+
+    // Camera-attached "headlight" — look for a PointLight or SpotLight
+    // that is a direct child of the camera.
+    state.camera.children.forEach((child) => {
+      if (child instanceof THREE.PointLight || child instanceof THREE.SpotLight) {
+        child.intensity = diagnostics.headlightIntensity;
+      }
+    });
+
+    // 3. Material traversal.
+    // Pre-build a scratch Color so we don't allocate one per material.
+    const hsl = { h: 0, s: 0, l: 0 };
+    scene.traverse((obj) => {
+      if (!(obj instanceof THREE.Mesh)) return;
+      // Skip the ground plane.
+      if (obj.name === "ground_plane") return;
+
+      const mats: THREE.Material[] = Array.isArray(obj.material)
+        ? obj.material
+        : [obj.material];
+
+      for (const mat of mats) {
+        // Determine if this is a glass/hologram/decal material. We use the
+        // same name-sentinel the loader uses: glass materials have
+        // transmission=1, holograms are ShaderMaterial, decals have name
+        // containing "decal". Skip those for metalness/clearcoat/envmap.
+        const isGlass =
+          mat instanceof THREE.MeshPhysicalMaterial && mat.transmission > 0.5;
+        const isHologram = mat instanceof THREE.ShaderMaterial;
+        const isDecal =
+          typeof mat.name === "string" && mat.name.toLowerCase().includes("decal");
+        const isHardSurface = !isGlass && !isHologram && !isDecal;
+
+        if (isHardSurface) {
+          if ("envMapIntensity" in mat) {
+            (mat as THREE.MeshStandardMaterial).envMapIntensity =
+              diagnostics.envMapIntensity;
+          }
+          if ("metalness" in mat) {
+            (mat as THREE.MeshStandardMaterial).metalness = diagnostics.metalness;
+          }
+          if (diagnostics.roughnessOverrideEnabled && "roughness" in mat) {
+            (mat as THREE.MeshStandardMaterial).roughness = diagnostics.roughness;
+          }
+          if ("clearcoat" in mat && mat instanceof THREE.MeshPhysicalMaterial) {
+            (mat as THREE.MeshPhysicalMaterial).clearcoat = diagnostics.clearcoat;
+          }
+        }
+
+        // Color saturation: applies to every material that has a .color,
+        // regardless of family. Composes with whatever color is already set
+        // (including positive-control red from the triage-instrument agent).
+        if ("color" in mat && (mat as THREE.MeshStandardMaterial).color instanceof THREE.Color) {
+          const col = (mat as THREE.MeshStandardMaterial).color;
+          // Read the color we last stored in userData.origColor if available;
+          // if not, use current color as the baseline.
+          let base: THREE.Color;
+          if (mat.userData._diagOrigColor instanceof THREE.Color) {
+            base = mat.userData._diagOrigColor;
+          } else {
+            base = col.clone();
+            mat.userData._diagOrigColor = base;
+          }
+          base.getHSL(hsl);
+          col.setHSL(hsl.h, Math.min(1, hsl.s * diagnostics.colorSaturation), hsl.l);
+        }
+
+        mat.needsUpdate = true;
+      }
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    diagnostics.envMapIntensity,
+    diagnostics.toneMappingExposure,
+    diagnostics.metalness,
+    diagnostics.roughness,
+    diagnostics.roughnessOverrideEnabled,
+    diagnostics.clearcoat,
+    diagnostics.ambientIntensity,
+    diagnostics.directionalIntensity,
+    diagnostics.headlightIntensity,
+    diagnostics.colorSaturation,
+    // Re-apply after scene loads so newly-built materials pick up
+    // current slider values without the user having to wiggle a slider.
+    loading,
+  ]);
+
+  // -- First-frame marker. When the load transitions from true -> false,
+  //    schedule one rAF tick and log the wall time from load-start to the
+  //    first rendered frame. This tells us how much overhead React state
+  //    propagation + the render-loop tick adds on top of the load phase. --
+  useEffect(() => {
+    if (loading) return; // still loading or initial mount
+    const t0 = loadStartRef.current;
+    if (t0 === 0) return; // no load has started yet
+    const rafId = requestAnimationFrame(() => {
+      const dt = (performance.now() - t0).toFixed(0);
+      console.info(`[perf] first-frame ${dt}ms (from load-start to rAF)`);
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [loading]);
+
+  // -- Render-style switch: rebuild materials for every recorded
+  // binding without re-loading meshes or textures. Cached materials are
+  // shared across instances of the same submaterial so the rebuild
+  // cost is one buildMaterial call per *unique* (submaterial, style)
+  // pair rather than per mesh. --
+  useEffect(() => {
+    if (renderStyle === activeStyleRef.current) return;
+    if (bindingsRef.current.length === 0) {
+      activeStyleRef.current = renderStyle;
+      return;
+    }
+    // Use the same texture cache the load did, so the textured rebuild
+    // hits the cache instead of re-decoding every PNG.
+    const loadCachedTexture = (path: string): Promise<THREE.Texture | null> => {
+      const cached = textureCacheRef.current.get(path);
+      // Re-read failures yield null without trying to fetch — the
+      // viewer is offline of new IPC during a style switch.
+      return cached ?? Promise.resolve(null);
+    };
+    const newCache = new Map<string, THREE.Material>();
+    for (const binding of bindingsRef.current) {
+      const cacheKey = materialCacheKey(binding.submaterial, renderStyle);
+      let material = newCache.get(cacheKey);
+      if (!material) {
+        const built = buildMaterial(
+          binding.submaterial,
+          loadCachedTexture,
+          renderStyle,
+        );
+        material = built.material;
+        newCache.set(cacheKey, material);
+      }
+      binding.mesh.material = material;
+    }
+    // Dispose old materials that are no longer referenced. Safe because
+    // the bindings list above just rewrote every reference.
+    for (const old of materialCacheRef.current.values()) {
+      old.dispose();
+    }
+    materialCacheRef.current = newCache;
+    activeStyleRef.current = renderStyle;
+  }, [renderStyle]);
+
+  // -- Debug-fallback toggle: walk every cached material and swap its
+  //    `.color` (or `uniforms.baseColor.value` for the Hologram
+  //    ShaderMaterial) to the kind's neon — or restore the stashed
+  //    `userData.originalColor`. Mutating in place avoids the
+  //    rebuild + 1000× shader-recompile storm that froze the main
+  //    thread on big ships. --
+  useEffect(() => {
+    if (debugFallbacks === activeDebugRef.current) return;
+    setDebugFallbackMode(debugFallbacks);
+    let touched = 0;
+    for (const m of materialCacheRef.current.values()) {
+      applyDebugFallbackToMaterial(m);
+      touched += 1;
+    }
+    activeDebugRef.current = debugFallbacks;
+    console.info(
+      `[debug-fallbacks] mode=${debugFallbacks} swapped colours on ${touched} materials`,
+    );
+  }, [debugFallbacks]);
+
+  // -- Livery switch: swap exterior bindings to the variant's
+  //    substitute sidecar (or restore the default). Skips when the
+  //    selection hasn't changed; the load effect handles the
+  //    initial-livery apply once paints.json has been fetched. --
+  useEffect(() => {
+    if (livery === activeLiveryRef.current) return;
+    void applyLiveryRebuild(livery);
+  }, [livery, applyLiveryRebuild]);
+
+  return (
+    <div ref={containerRef} className="relative w-full h-full">
+      {loading && (
+        <div className="absolute top-2 left-2 px-3 py-1.5 rounded-md bg-bg-alt/90 border border-border z-10">
+          <div className="flex items-center gap-2 text-sm text-text-sub">
+            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            <span>
+              Loading {packageInfo.package_name}
+              {progress && progress.total > 0
+                ? ` - ${progress.loaded}/${progress.total} (${Math.floor(
+                    (progress.loaded / progress.total) * 100,
+                  )}%)`
+                : "..."}
+            </span>
+          </div>
+          {progress && progress.current && (
+            <p className="text-[11px] text-text-dim font-mono mt-1 max-w-md truncate">
+              {progress.current}
+            </p>
+          )}
+        </div>
+      )}
+      {error && (
+        <div className="absolute top-2 left-2 right-2 px-3 py-2 rounded-md bg-danger/10 border border-danger z-10">
+          <p className="text-sm font-medium text-danger">Failed to load package</p>
+          <p className="text-xs text-text-dim mt-1 font-mono break-all">{error}</p>
+        </div>
+      )}
+      {stats && !error && (
+        <div className="absolute bottom-2 left-2 px-3 py-1.5 rounded-md bg-bg-alt/90 border border-border z-10 max-w-md">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-text-sub font-mono">
+              {stats.instances} parts &middot; {stats.interiors} interiors &middot; {stats.lights} lights
+            </p>
+            <button
+              type="button"
+              className={`text-[10px] px-2 py-0.5 rounded border font-mono ${
+                debugFallbacks
+                  ? "bg-accent/20 border-accent text-text"
+                  : "bg-bg/50 border-border text-text-sub hover:bg-bg/80"
+              }`}
+              onClick={() => setDebugFallbacks((v) => !v)}
+              title="Recolour fallback / stand-in materials with diagnostic neons (cyan = heuristic primary, green = no palette, red = unknown family, yellow = hologram, magenta-violet = screen, pink = skin)"
+            >
+              {debugFallbacks ? "DBG ON" : "DBG"}
+            </button>
+          </div>
+          <p className="text-[11px] text-text-dim font-mono mt-1">
+            mats {stats.metrics.totalBuilt}
+            {(() => {
+              const fams = Object.entries(stats.metrics.byFamily)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 4)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(" ");
+              return fams ? ` (${fams})` : "";
+            })()}
+          </p>
+          <p className="text-[11px] text-text-dim font-mono">
+            tex {stats.metrics.diffuseTextureSuccess}/
+            {stats.metrics.diffuseTextureSuccess + stats.metrics.diffuseTextureMiss}
+            {" "}&middot; tint {stats.metrics.paletteTintApplied}
+            {stats.metrics.paletteHeuristicPrimaryFallback > 0
+              ? ` (+${stats.metrics.paletteHeuristicPrimaryFallback} heur)`
+              : ""}
+            {stats.metrics.paletteTintMissing > 0
+              ? ` -${stats.metrics.paletteTintMissing} miss`
+              : ""}
+          </p>
+          <p className="text-[11px] text-text-dim font-mono">
+            cc {stats.metrics.clearCoatFired}
+            {" "}&middot; sysB {stats.metrics.systemBFired}
+            {" "}&middot; sysA {stats.metrics.systemAFired}
+            {" "}&middot; ddna {stats.metrics.ddnaRoughnessHooked}
+            {" "}&middot; pom {stats.metrics.pomHooked}
+            {stats.metrics.dirtOverlayHooked > 0
+              ? ` · dirt ${stats.metrics.dirtOverlayHooked}`
+              : ""}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function instanceTransform(instance: SceneInstance): THREE.Matrix4 {
+  return instance.local_transform_sc
+    ? matrixFromRows(instance.local_transform_sc)
+    : matrixFromOffsetEuler(instance.offset_position, instance.offset_rotation);
+}
+
+/**
+ * Run `worker` over `items` with at most `limit` in flight at a time.
+ * After each completed worker the optional `onBatch` callback runs, which
+ * we use to yield to the event loop so input events can drain. Resolves
+ * once every item has been attempted (worker errors are the worker's
+ * problem; this helper does not propagate them).
+ */
+async function runWithLimit<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+  onBatch?: () => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  let cursor = 0;
+  let sinceYield = 0;
+  const inflight = new Set<Promise<void>>();
+  const launch = (): void => {
+    if (cursor >= items.length) return;
+    const item = items[cursor++];
+    const p = worker(item).finally(() => {
+      inflight.delete(p);
+    });
+    inflight.add(p);
+  };
+
+  // Prime up to `limit` workers.
+  for (let i = 0; i < Math.min(limit, items.length); i++) launch();
+
+  while (inflight.size > 0) {
+    await Promise.race(inflight);
+    sinceYield += 1;
+    if (sinceYield >= limit && onBatch) {
+      sinceYield = 0;
+      await onBatch();
+    }
+    while (inflight.size < limit && cursor < items.length) launch();
+  }
+}
+
+/**
+ * Walk an Object3D subtree looking for a node whose name matches
+ * `target` (case-insensitive). Returns the first match in pre-order
+ * traversal; this matches the exporter's `node_name_to_idx` policy of
+ * keeping the first occurrence on collision.
+ *
+ * Three.js's built-in `getObjectByName` is case-sensitive, but the
+ * exporter writes `parent_node_name` from CryEngine NMC node names
+ * which can mix case. Lower-casing both sides is the safe match.
+ */
+function findNodeByName(
+  root: THREE.Object3D,
+  target: string,
+): THREE.Object3D | null {
+  const lower = target.toLowerCase();
+  let found: THREE.Object3D | null = null;
+  let descendantCount = 0;
+  const namedDescendants: string[] = [];
+  root.traverse((node) => {
+    descendantCount += 1;
+    if (node.name) namedDescendants.push(node.name);
+    if (found) return;
+    if (node.name && node.name.toLowerCase() === lower) {
+      found = node;
+    }
+  });
+  if (!found) {
+    // Diagnostic: pinpoint why the lookup failed. If the descendant
+    // list is empty, the parentGroup never received the GLB hierarchy
+    // (clone or strip ate it). If the list is populated but lacks
+    // `target`, the scene.json reference and the GLB node names have
+    // drifted. Close-match shows partial overlaps for naming-convention
+    // bugs (e.g. case, prefix, trailing characters).
+    const closeMatches = namedDescendants.filter(
+      (n) => n.toLowerCase().includes(lower) || lower.includes(n.toLowerCase()),
+    );
+    console.warn(
+      "[findNodeByName] MISS target='%s' rootName='%s' rootDirectChildren=%d descendantsVisited=%d named=%d closeMatches=%o",
+      target,
+      root.name || "<unnamed>",
+      root.children.length,
+      descendantCount,
+      namedDescendants.length,
+      closeMatches.slice(0, 8),
+    );
+  }
+  return found;
+}
+
+/**
+ * Disable any mesh-vertex-colour multiplication that GLTFLoader auto-enables
+ * when a primitive carries a COLOR_0 attribute. CryEngine writes wear / damage
+ * / dirt masks into that channel - they are NOT real colours, and rendering
+ * them as such yields magenta and red blotches all over the model.
+ *
+ * Operates on every Mesh in the subtree:
+ *   - `material.vertexColors = false` and `material.needsUpdate = true` so
+ *     the cached shader recompiles without the mask multiplication.
+ *   - delete `geometry.attributes.color` so the mask data isn't even uploaded
+ *     to the GPU.
+ *
+ * Idempotent. Safe to call on every loaded GLB regardless of whether COLOR_0
+ * is actually present.
+ */
+function stripMaskVertexColors(root: THREE.Object3D): void {
+  root.traverse((node) => {
+    if (!(node instanceof THREE.Mesh)) return;
+    const geom = node.geometry as THREE.BufferGeometry | undefined;
+    if (geom?.attributes.color) {
+      geom.deleteAttribute("color");
+    }
+    const mats = Array.isArray(node.material) ? node.material : [node.material];
+    for (const m of mats) {
+      if (!m) continue;
+      // `vertexColors` only exists on the materials we care about. Use a
+      // type guard so we don't try to assign on (e.g.) a stray ShaderMaterial.
+      if ("vertexColors" in m && (m as THREE.Material & { vertexColors: boolean }).vertexColors) {
+        (m as THREE.Material & { vertexColors: boolean }).vertexColors = false;
+        m.needsUpdate = true;
+      }
+    }
+  });
+}
+
+function clearObject(obj: THREE.Object3D): void {
+  // Dispose children's resources before removing them.
+  while (obj.children.length > 0) {
+    const child = obj.children[0];
+    child.traverse((node) => {
+      if (node instanceof THREE.Mesh) {
+        node.geometry.dispose();
+        if (Array.isArray(node.material)) {
+          for (const m of node.material) m.dispose();
+        } else if (node.material) {
+          node.material.dispose();
+        }
+      }
+    });
+    obj.remove(child);
+  }
+}
+
+function fitCamera(
+  camera: THREE.PerspectiveCamera,
+  controls: OrbitControls,
+  object: THREE.Object3D,
+): void {
+  const box = new THREE.Box3().setFromObject(object);
+  if (box.isEmpty()) return;
+  const center = box.getCenter(new THREE.Vector3());
+  const size = box.getSize(new THREE.Vector3()).length();
+  if (size <= 0 || !Number.isFinite(size)) return;
+  controls.target.copy(center);
+  const fov = camera.fov * (Math.PI / 180);
+  const distance = (size / (2 * Math.tan(fov / 2))) * 1.4;
+  const direction = new THREE.Vector3(1, 0.6, 1).normalize();
+  camera.position.copy(center.clone().add(direction.multiplyScalar(distance)));
+  camera.near = Math.max(size / 1000, 0.05);
+  camera.far = size * 100;
+  camera.updateProjectionMatrix();
+  controls.update();
+}
+
+function guessMime(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".webp")) return "image/webp";
+  // DDS / KTX would need a special loader. Returning a generic mime keeps the
+  // TextureLoader from rejecting it; in practice .dds entries only appear as
+  // projector textures and the viewer skips them.
+  return "application/octet-stream";
+}

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -30,7 +30,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as THREE from "three";
-import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
 import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 import {
@@ -46,6 +45,7 @@ import {
   applySCBasisToObject,
   buildLight,
   buildMaterial,
+  clearMobiGlasMaterials,
   findSubmaterialIndexForGlbName,
   getMaterialMetrics,
   hologramMaterials,
@@ -56,6 +56,7 @@ import {
   resolveContractPath,
   setDebugFallbackMode,
   stripCryEngineZUp,
+  updateMobiGlasTime,
   type LightRecord,
   type MaterialBuildMetrics,
   type MaterialSidecar,
@@ -67,6 +68,12 @@ import {
   type SubmaterialRecord,
 } from "../lib/decomposed-loader";
 import { MaterialInspector, type PickHit } from "./material-inspector";
+import { FlightCamHud } from "./flight-cam-hud";
+import { useFlightCamera, type FlightCamHandle } from "../lib/flight-camera";
+import {
+  captureScreenshot,
+  formatScreenshotFilename,
+} from "../lib/screenshot";
 
 /**
  * Live diagnostic overrides applied to the scene after construction.
@@ -140,6 +147,11 @@ interface Props {
   onPaints?: (variants: PaintVariant[]) => void;
   /** Display under the toolbar, optional. */
   onStatus?: (text: string) => void;
+  /** Fired when the flight camera handle is ready (and again with
+   *  null on unmount). The parent uses this to render the projection-
+   *  mode picker inside its top-right toolbar instead of letting it
+   *  collide with the toolbar's own controls. */
+  onFlightCamReady?: (handle: FlightCamHandle | null) => void;
 }
 
 /** Per-mesh binding so we can rebuild materials in place when the
@@ -195,18 +207,28 @@ export function SceneViewer({
   diagnostics = DEFAULT_DIAGNOSTIC_SETTINGS,
   onPaints,
   onStatus,
+  onFlightCamReady,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef<{
     renderer: THREE.WebGLRenderer;
     scene: THREE.Scene;
     camera: THREE.PerspectiveCamera;
-    controls: OrbitControls;
     sceneRoot: THREE.Group;
     groundMesh: THREE.Mesh;
     gridHelper: THREE.GridHelper;
     animId: number;
   } | null>(null);
+
+  // Flight-camera wiring. The hook reads these refs once its effect runs
+  // (which is after the bootstrap effect below populates them, since
+  // effects fire top-down inside one component). Until then the handle
+  // is null; the HUD and the reset-on-load effect short-circuit cleanly
+  // on null.
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const flightCamRef = useRef<FlightCamHandle | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -323,13 +345,14 @@ export function SceneViewer({
       100000,
     );
     camera.position.set(60, 30, 60);
-
-    const controls = new OrbitControls(camera, renderer.domElement);
-    // Damping is off: it caused post-release momentum (rotate/pan kept moving
-    // after mouseup) and forced the render loop to keep producing frames while
-    // the velocity decayed. Render-on-demand for the always-on animate loop is
-    // a separate follow-up (the loop at `animate()` still ticks every frame).
-    controls.enableDamping = false;
+    // Publish the bootstrapped objects so `useFlightCamera` (which runs its
+    // effect after this one) can attach. The hook owns the per-frame input
+    // loop that previously belonged to OrbitControls; the render loop below
+    // just calls `renderer.render(scene, camera)` and trusts the hook to
+    // keep the camera transform current.
+    rendererRef.current = renderer;
+    cameraRef.current = camera;
+    sceneRef.current = scene;
 
     // Fallback lighting so the model is visible even before scene lights
     // load. The IBL below provides most of the ambient/diffuse fill via
@@ -423,7 +446,7 @@ export function SceneViewer({
     // Perf instrumentation. Logged every 2s; grep `[perf]` in the console.
     // Strip when render-on-demand lands.
     const PERF_LOG_INTERVAL_MS = 2000;
-    const perfWindow: { frameMs: number; renderMs: number; controlsMs: number }[] = [];
+    const perfWindow: { frameMs: number; renderMs: number }[] = [];
     let lastFrameTs = performance.now();
     let lastLogTs = lastFrameTs;
     // Renderer GPU info: use UNMASKED_VENDOR/RENDERER via WEBGL_debug_renderer_info
@@ -441,10 +464,6 @@ export function SceneViewer({
       const frameMs = frameStart - lastFrameTs;
       lastFrameTs = frameStart;
 
-      const ctrlStart = performance.now();
-      controls.update();
-      const ctrlEnd = performance.now();
-
       // Tick hologram materials' `time` uniform so the scanline /
       // shimmer animation runs. The `hologramMaterials` array is
       // populated by `buildHologramMaterial` per package load; we
@@ -454,24 +473,32 @@ export function SceneViewer({
         const u = hologramMaterials[i].uniforms.time;
         if (u) u.value = elapsedSec;
       }
+      // Same lifecycle for MobiGlas-style materials, which use a
+      // separate Set registry rather than the array used by holograms.
+      updateMobiGlasTime(elapsedSec);
 
-      renderer.render(scene, camera);
+      const renderStart = performance.now();
+      // Render with whichever camera the flight cam currently exposes
+      // (perspective, orthographic, or oblique). Until the flight-cam
+      // hook attaches on the next effect pass, `flightCamRef.current`
+      // is null and we fall back to the perspective camera so the very
+      // first frame still renders.
+      const activeCam = flightCamRef.current?.getActiveCamera() ?? camera;
+      renderer.render(scene, activeCam);
       const renderEnd = performance.now();
 
       perfWindow.push({
         frameMs,
-        renderMs: renderEnd - ctrlEnd,
-        controlsMs: ctrlEnd - ctrlStart,
+        renderMs: renderEnd - renderStart,
       });
 
       if (renderEnd - lastLogTs >= PERF_LOG_INTERVAL_MS) {
         const n = perfWindow.length;
         if (n > 0) {
-          let sumFrame = 0, sumRender = 0, sumControls = 0, maxRender = 0;
+          let sumFrame = 0, sumRender = 0, maxRender = 0;
           for (const s of perfWindow) {
             sumFrame += s.frameMs;
             sumRender += s.renderMs;
-            sumControls += s.controlsMs;
             if (s.renderMs > maxRender) maxRender = s.renderMs;
           }
           const avgFrame = sumFrame / n;
@@ -482,7 +509,6 @@ export function SceneViewer({
           console.log(
             `[perf] fps=${fps.toFixed(1)} frame_avg=${avgFrame.toFixed(2)}ms ` +
               `render_avg=${(sumRender / n).toFixed(2)}ms render_max=${maxRender.toFixed(2)}ms ` +
-              `controls_avg=${(sumControls / n).toFixed(3)}ms ` +
               `draw_calls=${info.render.calls} tris=${info.render.triangles} ` +
               `textures=${info.memory.textures} geometries=${info.memory.geometries} ` +
               `programs=${info.programs?.length ?? 0}${heap} samples=${n}`,
@@ -498,7 +524,6 @@ export function SceneViewer({
       renderer,
       scene,
       camera,
-      controls,
       sceneRoot,
       groundMesh: ground,
       gridHelper: grid,
@@ -543,7 +568,17 @@ export function SceneViewer({
       const rect = renderer.domElement.getBoundingClientRect();
       ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
       ndc.y = -(((e.clientY - rect.top) / rect.height) * 2 - 1);
-      raycaster.setFromCamera(ndc, camera);
+      // Read the active camera per-pick so raycasting tracks projection
+      // mode without coupling the flight cam to the picker. THREE's
+      // Raycaster.setFromCamera handles PerspectiveCamera and the
+      // built-in OrthographicCamera natively. The oblique mode
+      // post-multiplies a custom shear onto the ortho's
+      // projectionMatrix; setFromCamera builds rays from
+      // projectionMatrixInverse, which the hook keeps in sync, so the
+      // ray direction reflects the sheared view. Picker accuracy in
+      // oblique mode has not been visually validated yet.
+      const pickCam = flightCamRef.current?.getActiveCamera() ?? camera;
+      raycaster.setFromCamera(ndc, pickCam);
       // Intersect against the scene root (the model). Skip the ground
       // mesh — its hits are noise for material inspection. recursive
       // = true walks the whole subtree.
@@ -580,10 +615,10 @@ export function SceneViewer({
       renderer.domElement.removeEventListener("pointerdown", onPointerDown);
       renderer.domElement.removeEventListener("pointerup", onPointerUp);
       cancelAnimationFrame(animId);
-      controls.dispose();
       // Release the IBL render target and the ground mesh's geometry /
       // material; created once at init so they live as long as the
-      // renderer does.
+      // renderer does. The flight-cam hook owns its own dispose path
+      // (its effect cleanup runs alongside this one).
       pmremGenerator.dispose();
       envTexture.dispose();
       groundGeometry.dispose();
@@ -592,9 +627,73 @@ export function SceneViewer({
       if (renderer.domElement.parentElement === container) {
         container.removeChild(renderer.domElement);
       }
+      rendererRef.current = null;
+      cameraRef.current = null;
+      sceneRef.current = null;
       stateRef.current = null;
     };
   }, []);
+
+  // Attach the flight camera. Runs after the bootstrap effect populated
+  // the renderer/camera/scene refs above, on the same mount pass. Stays
+  // null on the first render (refs are still null), then resolves to a
+  // stable handle once the hook's effect has installed listeners.
+  const flightCam = useFlightCamera({ rendererRef, cameraRef, sceneRef });
+  useEffect(() => {
+    flightCamRef.current = flightCam;
+  }, [flightCam]);
+
+  // Hand the flight-cam handle up to the parent so it can host the
+  // projection-mode picker in its top-right toolbar (the in-canvas
+  // standalone slot collided with the Livery + Style + Settings strip).
+  useEffect(() => {
+    onFlightCamReady?.(flightCam);
+    return () => {
+      onFlightCamReady?.(null);
+    };
+  }, [flightCam, onFlightCamReady]);
+
+  // F9 captures a high-resolution screenshot through the active camera.
+  // Listener lives on `window` so capture works regardless of which
+  // child element holds focus, except for typing targets where F9 is
+  // suppressed to avoid surprise captures while a text field is active.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.code !== "F9") return;
+      const ae = document.activeElement;
+      const tag = ae?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      e.preventDefault();
+      const scene = sceneRef.current;
+      const baseRenderer = rendererRef.current;
+      const camera =
+        flightCamRef.current?.getActiveCamera() ?? cameraRef.current;
+      if (!scene || !baseRenderer || !camera) return;
+      const projectionMode = flightCamRef.current?.getState().projectionMode;
+      const filename = formatScreenshotFilename(
+        packageInfo.package_name ?? null,
+        new Date(),
+      );
+      captureScreenshot({
+        scene,
+        camera,
+        baseRenderer,
+        filename,
+        projectionMode,
+        onProgress: (phase, info) => {
+          console.info(
+            `[screenshot] phase=${phase}${info ? ` ${info}` : ""}`,
+          );
+        },
+      }).catch((err) => {
+        console.error("[screenshot] handler caught:", err);
+      });
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [packageInfo.package_name]);
 
   // Rebuild exterior bindings against either the variant's substitute
   // sidecar (`palette_id !== null && variant.exterior_material_sidecar`)
@@ -821,6 +920,7 @@ export function SceneViewer({
         // resources. The new package will repopulate as its hologram
         // materials are built.
         hologramMaterials.length = 0;
+        clearMobiGlasMaterials();
         const textureCache = textureCacheRef.current;
         activeStyleRef.current = renderStyle;
 
@@ -1370,7 +1470,7 @@ export function SceneViewer({
             if (!framedOnce) {
               framedOnce = true;
               state.sceneRoot.updateMatrixWorld(true);
-              fitCamera(state.camera, state.controls, state.sceneRoot);
+              flightCamRef.current?.resetToScene(state.sceneRoot);
             }
 
             // Sidecar + textures run in parallel with the next mesh.
@@ -1437,7 +1537,7 @@ export function SceneViewer({
         // the initial bounds.
         state.sceneRoot.updateMatrixWorld(true);
         if (!framedOnce) {
-          fitCamera(state.camera, state.controls, state.sceneRoot);
+          flightCamRef.current?.resetToScene(state.sceneRoot);
         }
 
         // Emit a single summary line with all phase deltas so the bottleneck
@@ -1850,6 +1950,7 @@ export function SceneViewer({
           </p>
         </div>
       )}
+      <FlightCamHud handle={flightCam} />
       <MaterialInspector
         hits={pickHits}
         selectedHitIndex={selectedHitIndex}
@@ -2011,27 +2112,6 @@ function clearObject(obj: THREE.Object3D): void {
     });
     obj.remove(child);
   }
-}
-
-function fitCamera(
-  camera: THREE.PerspectiveCamera,
-  controls: OrbitControls,
-  object: THREE.Object3D,
-): void {
-  const box = new THREE.Box3().setFromObject(object);
-  if (box.isEmpty()) return;
-  const center = box.getCenter(new THREE.Vector3());
-  const size = box.getSize(new THREE.Vector3()).length();
-  if (size <= 0 || !Number.isFinite(size)) return;
-  controls.target.copy(center);
-  const fov = camera.fov * (Math.PI / 180);
-  const distance = (size / (2 * Math.tan(fov / 2))) * 1.4;
-  const direction = new THREE.Vector3(1, 0.6, 1).normalize();
-  camera.position.copy(center.clone().add(direction.multiplyScalar(distance)));
-  camera.near = Math.max(size / 1000, 0.05);
-  camera.far = size * 100;
-  camera.updateProjectionMatrix();
-  controls.update();
 }
 
 function guessMime(path: string): string {

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -69,7 +69,11 @@ import {
 } from "../lib/decomposed-loader";
 import { MaterialInspector, type PickHit } from "./material-inspector";
 import { FlightCamHud } from "./flight-cam-hud";
-import { useFlightCamera, type FlightCamHandle } from "../lib/flight-camera";
+import {
+  dispatchViewerHotkey,
+  useFlightCamera,
+  type FlightCamHandle,
+} from "../lib/flight-camera";
 import {
   captureScreenshot,
   formatScreenshotFilename,
@@ -257,6 +261,12 @@ export function SceneViewer({
   // that resolved correctly stay normal-coloured either way.
   const [debugFallbacks, setDebugFallbacks] = useState(false);
   const activeDebugRef = useRef(false);
+
+  // Combined bottom-right panel (flight-cam HUD + scene-load metrics)
+  // visibility. Hidden state collapses both sections to a tiny
+  // re-expand affordance so the canvas reclaims that screen real
+  // estate. Toggled by the H key and the in-panel button below.
+  const [hudVisible, setHudVisible] = useState(true);
 
   // Persistent caches scoped to the current scene load. The bindings
   // list lets us rebuild materials in place when the render style
@@ -694,6 +704,33 @@ export function SceneViewer({
       window.removeEventListener("keydown", onKeyDown);
     };
   }, [packageInfo.package_name]);
+
+  // R reframes the camera to the current sceneRoot. Numpad 0-5 snap to
+  // named view presets (overhead / perspective2 / side / fore / aft /
+  // perspective). H toggles the combined HUD + stats panel. The
+  // dispatch table lives in `dispatchViewerHotkey` so it stays unit-
+  // testable without a DOM. Listener lives on `window` so it fires
+  // regardless of which child element holds focus, except for typing
+  // targets where the binding is suppressed.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const ae = document.activeElement;
+      const tag = ae?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      const sceneRoot = stateRef.current?.sceneRoot ?? null;
+      const handled = dispatchViewerHotkey(
+        { code: e.code, repeat: e.repeat },
+        flightCamRef.current,
+        sceneRoot,
+        () => setHudVisible((v) => !v),
+      );
+      if (handled) e.preventDefault();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
 
   // Rebuild exterior bindings against either the variant's substitute
   // sidecar (`palette_id !== null && variant.exterior_material_sidecar`)
@@ -1897,60 +1934,93 @@ export function SceneViewer({
           <p className="text-xs text-text-dim mt-1 font-mono break-all">{error}</p>
         </div>
       )}
-      {stats && !error && (
-        <div className="absolute bottom-2 left-2 px-3 py-1.5 rounded-md bg-bg-alt/90 border border-border z-10 max-w-md">
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-xs text-text-sub font-mono">
-              {stats.instances} parts &middot; {stats.interiors} interiors &middot; {stats.lights} lights
-            </p>
+      {/* Combined bottom-right panel: flight-cam HUD readout (top
+          section) + scene-load metrics (below the divider). A single
+          show/hide toggle (button + H key) collapses the whole panel
+          to a tiny re-expand affordance so the canvas reclaims the
+          screen real estate. The metrics block is only rendered while
+          stats is non-null and there is no load error. */}
+      {!error && (hudVisible ? (
+        <div
+          className="absolute bottom-2 right-2 z-10 max-w-md rounded-md bg-bg-alt/95 border border-border shadow"
+        >
+          <div className="flex items-start justify-between gap-2 px-3 py-1.5">
+            <FlightCamHud handle={flightCam} embedded />
             <button
               type="button"
-              className={`text-[10px] px-2 py-0.5 rounded border font-mono ${
-                debugFallbacks
-                  ? "bg-accent/20 border-accent text-text"
-                  : "bg-bg/50 border-border text-text-sub hover:bg-bg/80"
-              }`}
-              onClick={() => setDebugFallbacks((v) => !v)}
-              title="Recolour fallback / stand-in materials with diagnostic neons (cyan = heuristic primary, green = no palette, red = unknown family, yellow = hologram, magenta-violet = screen, pink = skin)"
+              onClick={() => setHudVisible(false)}
+              title="Hide stats panel (H)"
+              aria-label="Hide stats panel"
+              className="text-[10px] px-1.5 py-0.5 rounded border border-border bg-bg/50 text-text-sub hover:bg-bg/80 hover:text-text font-mono shrink-0"
             >
-              {debugFallbacks ? "DBG ON" : "DBG"}
+              hide
             </button>
           </div>
-          <p className="text-[11px] text-text-dim font-mono mt-1">
-            mats {stats.metrics.totalBuilt}
-            {(() => {
-              const fams = Object.entries(stats.metrics.byFamily)
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 4)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(" ");
-              return fams ? ` (${fams})` : "";
-            })()}
-          </p>
-          <p className="text-[11px] text-text-dim font-mono">
-            tex {stats.metrics.diffuseTextureSuccess}/
-            {stats.metrics.diffuseTextureSuccess + stats.metrics.diffuseTextureMiss}
-            {" "}&middot; tint {stats.metrics.paletteTintApplied}
-            {stats.metrics.paletteHeuristicPrimaryFallback > 0
-              ? ` (+${stats.metrics.paletteHeuristicPrimaryFallback} heur)`
-              : ""}
-            {stats.metrics.paletteTintMissing > 0
-              ? ` -${stats.metrics.paletteTintMissing} miss`
-              : ""}
-          </p>
-          <p className="text-[11px] text-text-dim font-mono">
-            cc {stats.metrics.clearCoatFired}
-            {" "}&middot; sysB {stats.metrics.systemBFired}
-            {" "}&middot; sysA {stats.metrics.systemAFired}
-            {" "}&middot; ddna {stats.metrics.ddnaRoughnessHooked}
-            {" "}&middot; pom {stats.metrics.pomHooked}
-            {stats.metrics.dirtOverlayHooked > 0
-              ? ` · dirt ${stats.metrics.dirtOverlayHooked}`
-              : ""}
-          </p>
+          {stats && (
+            <div className="border-t border-border px-3 py-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-text-sub font-mono">
+                  {stats.instances} parts &middot; {stats.interiors} interiors &middot; {stats.lights} lights
+                </p>
+                <button
+                  type="button"
+                  className={`text-[10px] px-2 py-0.5 rounded border font-mono ${
+                    debugFallbacks
+                      ? "bg-accent/20 border-accent text-text"
+                      : "bg-bg/50 border-border text-text-sub hover:bg-bg/80"
+                  }`}
+                  onClick={() => setDebugFallbacks((v) => !v)}
+                  title="Recolour fallback / stand-in materials with diagnostic neons (cyan = heuristic primary, green = no palette, red = unknown family, yellow = hologram, magenta-violet = screen, pink = skin)"
+                >
+                  {debugFallbacks ? "DBG ON" : "DBG"}
+                </button>
+              </div>
+              <p className="text-[11px] text-text-dim font-mono mt-1">
+                mats {stats.metrics.totalBuilt}
+                {(() => {
+                  const fams = Object.entries(stats.metrics.byFamily)
+                    .sort((a, b) => b[1] - a[1])
+                    .slice(0, 4)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join(" ");
+                  return fams ? ` (${fams})` : "";
+                })()}
+              </p>
+              <p className="text-[11px] text-text-dim font-mono">
+                tex {stats.metrics.diffuseTextureSuccess}/
+                {stats.metrics.diffuseTextureSuccess + stats.metrics.diffuseTextureMiss}
+                {" "}&middot; tint {stats.metrics.paletteTintApplied}
+                {stats.metrics.paletteHeuristicPrimaryFallback > 0
+                  ? ` (+${stats.metrics.paletteHeuristicPrimaryFallback} heur)`
+                  : ""}
+                {stats.metrics.paletteTintMissing > 0
+                  ? ` -${stats.metrics.paletteTintMissing} miss`
+                  : ""}
+              </p>
+              <p className="text-[11px] text-text-dim font-mono">
+                cc {stats.metrics.clearCoatFired}
+                {" "}&middot; sysB {stats.metrics.systemBFired}
+                {" "}&middot; sysA {stats.metrics.systemAFired}
+                {" "}&middot; ddna {stats.metrics.ddnaRoughnessHooked}
+                {" "}&middot; pom {stats.metrics.pomHooked}
+                {stats.metrics.dirtOverlayHooked > 0
+                  ? ` &middot; dirt ${stats.metrics.dirtOverlayHooked}`
+                  : ""}
+              </p>
+            </div>
+          )}
         </div>
-      )}
-      <FlightCamHud handle={flightCam} />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setHudVisible(true)}
+          title="Show stats panel (H)"
+          aria-label="Show stats panel"
+          className="absolute bottom-2 right-2 z-10 text-[10px] px-2 py-1 rounded border border-border bg-bg-alt/90 text-text-sub hover:bg-bg-alt hover:text-text font-mono shadow"
+        >
+          show stats
+        </button>
+      ))}
       <MaterialInspector
         hits={pickHits}
         selectedHitIndex={selectedHitIndex}

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -66,6 +66,7 @@ import {
   type SceneManifest,
   type SubmaterialRecord,
 } from "../lib/decomposed-loader";
+import { MaterialInspector, type PickHit } from "./material-inspector";
 
 /**
  * Live diagnostic overrides applied to the scene after construction.
@@ -220,6 +221,13 @@ export function SceneViewer({
     metrics: MaterialBuildMetrics;
   } | null>(null);
   const generationRef = useRef(0);
+  // Picker state. `pickHits` is the ordered list of meshes intersected
+  // by the camera ray on the most recent left-click; `selectedHitIndex`
+  // is the row currently expanded into the details panel. Both are
+  // reset to empty/null when the panel's close button is pressed or a
+  // new scene is loaded.
+  const [pickHits, setPickHits] = useState<PickHit[]>([]);
+  const [selectedHitIndex, setSelectedHitIndex] = useState<number | null>(null);
   // Debug-fallback mode: when on, the loader recolours fallback /
   // stand-in material paths into distinct neons so the user can
   // visually identify which case is firing on each surface. Toggling
@@ -506,8 +514,71 @@ export function SceneViewer({
     });
     ro.observe(container);
 
+    // Picker: detect a no-drag left click on the canvas, raycast
+    // through the cursor, and surface the ordered hit list to the
+    // inspector panel. Listening at pointerdown/up rather than "click"
+    // lets us keep the down-position and disambiguate pick from
+    // orbit-drag without fighting OrbitControls.
+    const raycaster = new THREE.Raycaster();
+    const ndc = new THREE.Vector2();
+    let downX = 0;
+    let downY = 0;
+    let downT = 0;
+    const onPointerDown = (e: PointerEvent): void => {
+      if (e.button !== 0) return;
+      downX = e.clientX;
+      downY = e.clientY;
+      downT = performance.now();
+    };
+    const onPointerUp = (e: PointerEvent): void => {
+      if (e.button !== 0) return;
+      const dx = e.clientX - downX;
+      const dy = e.clientY - downY;
+      const dt = performance.now() - downT;
+      // 5px / 350ms thresholds: large enough that a relaxed click
+      // registers, small enough that an orbit drag never triggers
+      // a pick. Tuned to feel like a "tap" rather than a click.
+      if (dx * dx + dy * dy > 25) return;
+      if (dt > 350) return;
+      const rect = renderer.domElement.getBoundingClientRect();
+      ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      ndc.y = -(((e.clientY - rect.top) / rect.height) * 2 - 1);
+      raycaster.setFromCamera(ndc, camera);
+      // Intersect against the scene root (the model). Skip the ground
+      // mesh — its hits are noise for material inspection. recursive
+      // = true walks the whole subtree.
+      const hits = raycaster.intersectObject(sceneRoot, true);
+      const bindings = bindingsRef.current;
+      const bindingByMesh = new Map<THREE.Mesh, MaterialBinding>();
+      for (const b of bindings) bindingByMesh.set(b.mesh, b);
+      const pickList: PickHit[] = [];
+      let idx = 0;
+      for (const hit of hits) {
+        // Only meshes carry materials; lines/points etc. would never
+        // bind to a SubmaterialRecord, and the user wouldn't be
+        // clicking those for material info.
+        if (!(hit.object instanceof THREE.Mesh)) continue;
+        const binding = bindingByMesh.get(hit.object);
+        pickList.push({
+          hitIndex: idx++,
+          distance: hit.distance,
+          mesh: hit.object,
+          point: hit.point.clone(),
+          submaterial: binding?.submaterial ?? null,
+          sidecarKey: binding?.sidecarKey ?? null,
+          defaultSidecarKey: binding?.defaultSidecarKey ?? null,
+        });
+      }
+      setPickHits(pickList);
+      setSelectedHitIndex(pickList.length > 0 ? 0 : null);
+    };
+    renderer.domElement.addEventListener("pointerdown", onPointerDown);
+    renderer.domElement.addEventListener("pointerup", onPointerUp);
+
     return () => {
       ro.disconnect();
+      renderer.domElement.removeEventListener("pointerdown", onPointerDown);
+      renderer.domElement.removeEventListener("pointerup", onPointerUp);
       cancelAnimationFrame(animId);
       controls.dispose();
       // Release the IBL render target and the ground mesh's geometry /
@@ -669,6 +740,8 @@ export function SceneViewer({
     setError(null);
     setStats(null);
     setProgress(null);
+    setPickHits([]);
+    setSelectedHitIndex(null);
     resetMaterialMetrics();
 
     // Clear previous scene. The basis rotation lives on the sceneRoot
@@ -1777,6 +1850,17 @@ export function SceneViewer({
           </p>
         </div>
       )}
+      <MaterialInspector
+        hits={pickHits}
+        selectedHitIndex={selectedHitIndex}
+        onSelectHit={setSelectedHitIndex}
+        onClose={() => {
+          setPickHits([]);
+          setSelectedHitIndex(null);
+        }}
+        packageSlug={packageInfo.package_name}
+        liveryState={livery ?? "nolivery"}
+      />
     </div>
   );
 }

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -68,7 +68,8 @@ import {
   type SubmaterialRecord,
 } from "../lib/decomposed-loader";
 import { MaterialInspector, type PickHit } from "./material-inspector";
-import { FlightCamHud } from "./flight-cam-hud";
+import { SceneInfoPanel } from "./scene-info-panel";
+import { NavWidget } from "./nav-widget";
 import {
   dispatchViewerHotkey,
   useFlightCamera,
@@ -273,11 +274,6 @@ export function SceneViewer({
   const [debugFallbacks, setDebugFallbacks] = useState(false);
   const activeDebugRef = useRef(false);
 
-  // Combined bottom-right panel (flight-cam HUD + scene-load metrics)
-  // visibility. Hidden state collapses both sections to a tiny
-  // re-expand affordance so the canvas reclaims that screen real
-  // estate. Toggled by the H key and the in-panel button below.
-  const [hudVisible, setHudVisible] = useState(true);
 
   // Persistent caches scoped to the current scene load. The bindings
   // list lets us rebuild materials in place when the render style
@@ -1945,34 +1941,17 @@ export function SceneViewer({
           <p className="text-xs text-text-dim mt-1 font-mono break-all">{error}</p>
         </div>
       )}
-      {/* Combined bottom-right panel: flight-cam HUD readout (top
-          section) + scene-load metrics (below the divider). A single
-          show/hide toggle (button + H key) collapses the whole panel
-          to a tiny re-expand affordance so the canvas reclaims the
-          screen real estate. The metrics block is only rendered while
-          stats is non-null and there is no load error. */}
-      {!error && (hudVisible ? (
-        <div
-          className="absolute bottom-2 right-2 z-10 max-w-md rounded-md bg-bg-alt/95 border border-border shadow"
-        >
-          <div className="flex items-start justify-between gap-2 px-3 py-1.5">
-            <FlightCamHud handle={flightCam} embedded />
-            <button
-              type="button"
-              onClick={() => setHudVisible(false)}
-              title="Hide stats panel (H)"
-              aria-label="Hide stats panel"
-              className="text-[10px] px-1.5 py-0.5 rounded border border-border bg-bg/50 text-text-sub hover:bg-bg/80 hover:text-text font-mono shrink-0"
-            >
-              hide
-            </button>
-          </div>
-          {stats && (
-            <div className="border-t border-border px-3 py-1.5">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs text-text-sub font-mono">
-                  {stats.instances} parts &middot; {stats.interiors} interiors &middot; {stats.lights} lights
-                </p>
+      {/* Bottom-right column: on-screen nav widget on top, scene-info
+          panel below. Both panels render embedded so the wrapper can
+          stack them with a small gap. */}
+      {!error && (
+        <div className="absolute bottom-2 right-2 z-10 flex flex-col items-end gap-2">
+          <NavWidget flightCamHandle={flightCam} />
+          <SceneInfoPanel
+            flightCamHandle={flightCam}
+            embedded
+            actions={
+              stats ? (
                 <button
                   type="button"
                   className={`text-[10px] px-2 py-0.5 rounded border font-mono ${
@@ -1981,57 +1960,55 @@ export function SceneViewer({
                       : "bg-bg/50 border-border text-text-sub hover:bg-bg/80"
                   }`}
                   onClick={() => setDebugFallbacks((v) => !v)}
-                  title="Recolour fallback / stand-in materials with diagnostic neons (cyan = heuristic primary, green = no palette, red = unknown family, yellow = hologram, magenta-violet = screen, pink = skin)"
                 >
                   {debugFallbacks ? "DBG ON" : "DBG"}
                 </button>
-              </div>
-              <p className="text-[11px] text-text-dim font-mono mt-1">
-                mats {stats.metrics.totalBuilt}
-                {(() => {
-                  const fams = Object.entries(stats.metrics.byFamily)
-                    .sort((a, b) => b[1] - a[1])
-                    .slice(0, 4)
-                    .map(([k, v]) => `${k}=${v}`)
-                    .join(" ");
-                  return fams ? ` (${fams})` : "";
-                })()}
-              </p>
-              <p className="text-[11px] text-text-dim font-mono">
-                tex {stats.metrics.diffuseTextureSuccess}/
-                {stats.metrics.diffuseTextureSuccess + stats.metrics.diffuseTextureMiss}
-                {" "}&middot; tint {stats.metrics.paletteTintApplied}
-                {stats.metrics.paletteHeuristicPrimaryFallback > 0
-                  ? ` (+${stats.metrics.paletteHeuristicPrimaryFallback} heur)`
-                  : ""}
-                {stats.metrics.paletteTintMissing > 0
-                  ? ` -${stats.metrics.paletteTintMissing} miss`
-                  : ""}
-              </p>
-              <p className="text-[11px] text-text-dim font-mono">
-                cc {stats.metrics.clearCoatFired}
-                {" "}&middot; sysB {stats.metrics.systemBFired}
-                {" "}&middot; sysA {stats.metrics.systemAFired}
-                {" "}&middot; ddna {stats.metrics.ddnaRoughnessHooked}
-                {" "}&middot; pom {stats.metrics.pomHooked}
-                {stats.metrics.dirtOverlayHooked > 0
-                  ? ` &middot; dirt ${stats.metrics.dirtOverlayHooked}`
-                  : ""}
-              </p>
-            </div>
-          )}
+              ) : undefined
+            }
+            actionsTitle="Recolour fallback / stand-in materials with diagnostic neons (cyan = heuristic primary, green = no palette, red = unknown family, yellow = hologram, magenta-violet = screen, pink = skin)"
+          >
+            {stats && (
+              <>
+                <p className="text-xs text-text-sub font-mono">
+                  {stats.instances} parts &middot; {stats.interiors} interiors &middot; {stats.lights} lights
+                </p>
+                <p className="text-[11px] text-text-dim font-mono mt-1">
+                  mats {stats.metrics.totalBuilt}
+                  {(() => {
+                    const fams = Object.entries(stats.metrics.byFamily)
+                      .sort((a, b) => b[1] - a[1])
+                      .slice(0, 4)
+                      .map(([k, v]) => `${k}=${v}`)
+                      .join(" ");
+                    return fams ? ` (${fams})` : "";
+                  })()}
+                </p>
+                <p className="text-[11px] text-text-dim font-mono">
+                  tex {stats.metrics.diffuseTextureSuccess}/
+                  {stats.metrics.diffuseTextureSuccess + stats.metrics.diffuseTextureMiss}
+                  {" "}&middot; tint {stats.metrics.paletteTintApplied}
+                  {stats.metrics.paletteHeuristicPrimaryFallback > 0
+                    ? ` (+${stats.metrics.paletteHeuristicPrimaryFallback} heur)`
+                    : ""}
+                  {stats.metrics.paletteTintMissing > 0
+                    ? ` -${stats.metrics.paletteTintMissing} miss`
+                    : ""}
+                </p>
+                <p className="text-[11px] text-text-dim font-mono">
+                  cc {stats.metrics.clearCoatFired}
+                  {" "}&middot; sysB {stats.metrics.systemBFired}
+                  {" "}&middot; sysA {stats.metrics.systemAFired}
+                  {" "}&middot; ddna {stats.metrics.ddnaRoughnessHooked}
+                  {" "}&middot; pom {stats.metrics.pomHooked}
+                  {stats.metrics.dirtOverlayHooked > 0
+                    ? ` &middot; dirt ${stats.metrics.dirtOverlayHooked}`
+                    : ""}
+                </p>
+              </>
+            )}
+          </SceneInfoPanel>
         </div>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setHudVisible(true)}
-          title="Show stats panel (H)"
-          aria-label="Show stats panel"
-          className="absolute bottom-2 right-2 z-10 text-[10px] px-2 py-1 rounded border border-border bg-bg-alt/90 text-text-sub hover:bg-bg-alt hover:text-text font-mono shadow"
-        >
-          show stats
-        </button>
-      ))}
+      )}
       <MaterialInspector
         hits={pickHits}
         selectedHitIndex={selectedHitIndex}

--- a/app/src/components/scene-viewer.tsx
+++ b/app/src/components/scene-viewer.tsx
@@ -156,6 +156,10 @@ interface Props {
    *  mode picker inside its top-right toolbar instead of letting it
    *  collide with the toolbar's own controls. */
   onFlightCamReady?: (handle: FlightCamHandle | null) => void;
+  /** H key handler. The parent owns the pivot-orb visibility setting,
+   *  so the binding flips a parent-side state rather than mutating
+   *  anything on this component. Optional; if omitted, H is a no-op. */
+  onTogglePivotOrb?: () => void;
 }
 
 /** Per-mesh binding so we can rebuild materials in place when the
@@ -212,7 +216,14 @@ export function SceneViewer({
   onPaints,
   onStatus,
   onFlightCamReady,
+  onTogglePivotOrb,
 }: Props) {
+  // Mirror the latest togglePivotOrb prop into a ref so the keydown
+  // listener (registered once on mount with empty deps) always calls
+  // the current callback. Without the ref, the listener captures the
+  // first value and ignores later prop changes.
+  const togglePivotOrbRef = useRef<(() => void) | undefined>(onTogglePivotOrb);
+  togglePivotOrbRef.current = onTogglePivotOrb;
   const containerRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef<{
     renderer: THREE.WebGLRenderer;
@@ -722,7 +733,7 @@ export function SceneViewer({
         { code: e.code, repeat: e.repeat },
         flightCamRef.current,
         sceneRoot,
-        () => setHudVisible((v) => !v),
+        () => togglePivotOrbRef.current?.(),
       );
       if (handled) e.preventDefault();
     };

--- a/app/src/components/settings-panel.tsx
+++ b/app/src/components/settings-panel.tsx
@@ -1,0 +1,412 @@
+// Floating, collapsible Settings panel anchored to the top-right of the
+// viewer pane. Used by both the Ships viewer and the Maps (SOC) viewer.
+//
+// The same `ViewerSettings` shape feeds both surfaces so user-tuned
+// values persist as the user switches tabs. A few rows are Ships-only
+// because they map to data the SOC GLB does not carry (per-shader-
+// family metalness override, MeshPhysicalMaterial clearcoat, the
+// camera-attached headlight); those rows are gated by the `kind` prop.
+
+import {
+  useCallback,
+  useState,
+  type ReactNode,
+} from "react";
+import { ChevronDown, ChevronUp, Settings } from "lucide-react";
+import {
+  DEFAULT_DIAGNOSTIC_SETTINGS,
+  type DiagnosticSettings,
+} from "./scene-viewer";
+
+/** Surface this panel is rendering against -- gates Ships-only rows
+ *  whose underlying material/light targets do not exist on SOC scenes. */
+export type ViewerSurfaceKind = "ships" | "soc";
+
+/** User-tunable viewer settings. Flat object so adding a new field is
+ *  one line per setting; the panel renders rows declaratively from
+ *  this shape so growing the surface is a localised edit. */
+export interface ViewerSettings {
+  showGroundPlane: boolean;
+  showGrid: boolean;
+  /** Show the orange sphere marking the orbit pivot. Off by default
+   *  -- the orb is a debug-style affordance most users do not want
+   *  visible all the time. Toggling this calls
+   *  `flightCamHandle.setPivotOrbVisible(...)` from the parent. */
+  showPivotOrb: boolean;
+  groundPlaneColor: [number, number, number];
+  diagnostics: DiagnosticSettings;
+}
+
+export const DEFAULT_VIEWER_SETTINGS: ViewerSettings = {
+  showGroundPlane: false,
+  showGrid: false,
+  showPivotOrb: false,
+  groundPlaneColor: [128, 128, 128],
+  diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS },
+};
+
+interface SettingsPanelProps {
+  settings: ViewerSettings;
+  onChange: (patch: Partial<ViewerSettings>) => void;
+  kind: ViewerSurfaceKind;
+}
+
+/**
+ * Floating, collapsible settings overlay anchored to the top-right of
+ * the viewer pane. Starts collapsed (button only). Clicking the button
+ * toggles the body open/closed.
+ */
+export function SettingsPanel({ settings, onChange, kind }: SettingsPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  // Guard: merge defaults so that missing fields (e.g. after a store
+  // hydration against an older settings shape) never produce undefined
+  // values reaching .toFixed() in the slider rows.
+  const diag: DiagnosticSettings = {
+    ...DEFAULT_DIAGNOSTIC_SETTINGS,
+    ...settings.diagnostics,
+  };
+  const groundColor: [number, number, number] =
+    settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
+
+  const patchDiag = useCallback(
+    (patch: Partial<DiagnosticSettings>) => {
+      onChange({
+        diagnostics: {
+          ...DEFAULT_DIAGNOSTIC_SETTINGS,
+          ...settings.diagnostics,
+          ...patch,
+        },
+      });
+    },
+    [onChange, settings.diagnostics],
+  );
+
+  const patchGroundColor = useCallback(
+    (channel: 0 | 1 | 2, val: number) => {
+      const base =
+        settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
+      const next: [number, number, number] = [...base] as [
+        number,
+        number,
+        number,
+      ];
+      next[channel] = val;
+      onChange({ groundPlaneColor: next });
+    },
+    [onChange, settings.groundPlaneColor],
+  );
+
+  const resetAll = useCallback(() => {
+    onChange({ diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS } });
+  }, [onChange]);
+
+  const showShipsOnlyRows = kind === "ships";
+
+  return (
+    <div className="relative z-10">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub hover:text-text hover:bg-bg-alt shadow transition-colors cursor-pointer select-none"
+        title={open ? "Collapse settings" : "Expand settings"}
+        aria-label={open ? "Collapse settings panel" : "Expand settings panel"}
+      >
+        <Settings size={14} strokeWidth={1.75} />
+        <span>Settings</span>
+        {open ? (
+          <ChevronDown size={12} strokeWidth={1.75} />
+        ) : (
+          <ChevronUp size={12} strokeWidth={1.75} />
+        )}
+      </button>
+      {open && (
+        <div
+          className="absolute top-full right-0 mt-1.5 w-[280px] max-h-[70vh] overflow-y-auto bg-bg-alt/95 border border-border rounded-md shadow-lg p-3 flex flex-col gap-3 backdrop-blur-sm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <SettingsSection title="Display">
+            <SettingsToggleRow
+              label="Show ground plane"
+              checked={
+                settings.showGroundPlane ??
+                DEFAULT_VIEWER_SETTINGS.showGroundPlane
+              }
+              onChange={(v) => onChange({ showGroundPlane: v })}
+            />
+            <SettingsToggleRow
+              label="Show grid"
+              checked={settings.showGrid ?? DEFAULT_VIEWER_SETTINGS.showGrid}
+              onChange={(v) => onChange({ showGrid: v })}
+            />
+            <SettingsToggleRow
+              label="Show pivot orb"
+              checked={
+                settings.showPivotOrb ?? DEFAULT_VIEWER_SETTINGS.showPivotOrb
+              }
+              onChange={(v) => onChange({ showPivotOrb: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Ground Plane Color">
+            <SettingsSliderRow
+              label="R"
+              value={groundColor[0]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(0, v)}
+            />
+            <SettingsSliderRow
+              label="G"
+              value={groundColor[1]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(1, v)}
+            />
+            <SettingsSliderRow
+              label="B"
+              value={groundColor[2]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(2, v)}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Render Tuning">
+            <SettingsSliderRow
+              label="envMapIntensity"
+              value={diag.envMapIntensity}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ envMapIntensity: v })}
+            />
+            <SettingsSliderRow
+              label="Tone map exposure"
+              value={diag.toneMappingExposure}
+              min={0}
+              max={3}
+              step={0.05}
+              onChange={(v) => patchDiag({ toneMappingExposure: v })}
+            />
+            {showShipsOnlyRows && (
+              <SettingsSliderRow
+                label="Metalness"
+                value={diag.metalness}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={(v) => patchDiag({ metalness: v })}
+              />
+            )}
+            {showShipsOnlyRows && (
+              <SettingsCheckboxSliderRow
+                label="Roughness"
+                value={diag.roughness}
+                min={0}
+                max={1}
+                step={0.01}
+                enabled={diag.roughnessOverrideEnabled}
+                onEnabledChange={(v) =>
+                  patchDiag({ roughnessOverrideEnabled: v })
+                }
+                onChange={(v) => patchDiag({ roughness: v })}
+              />
+            )}
+            {showShipsOnlyRows && (
+              <SettingsSliderRow
+                label="Clearcoat"
+                value={diag.clearcoat}
+                min={0}
+                max={1}
+                step={0.05}
+                onChange={(v) => patchDiag({ clearcoat: v })}
+              />
+            )}
+          </SettingsSection>
+
+          <SettingsSection title="Scene Lights">
+            <SettingsSliderRow
+              label="Ambient intensity"
+              value={diag.ambientIntensity}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ ambientIntensity: v })}
+            />
+            <SettingsSliderRow
+              label="Directional intensity"
+              value={diag.directionalIntensity}
+              min={0}
+              max={5}
+              step={0.1}
+              onChange={(v) => patchDiag({ directionalIntensity: v })}
+            />
+            {showShipsOnlyRows && (
+              <SettingsSliderRow
+                label="Headlight intensity"
+                value={diag.headlightIntensity}
+                min={0}
+                max={5}
+                step={0.1}
+                onChange={(v) => patchDiag({ headlightIntensity: v })}
+              />
+            )}
+          </SettingsSection>
+
+          <SettingsSection title="Color Path">
+            <SettingsSliderRow
+              label="Color saturation"
+              value={diag.colorSaturation}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ colorSaturation: v })}
+            />
+          </SettingsSection>
+
+          <button
+            onClick={resetAll}
+            className="mt-1 w-full py-1.5 rounded-md text-xs font-medium bg-surface hover:bg-surface-hi text-text-sub hover:text-text transition-colors cursor-pointer"
+            title="Reset all sliders to defaults"
+          >
+            Reset all
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SettingsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="text-[10px] uppercase tracking-wider text-text-faint font-medium">
+        {title}
+      </div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  );
+}
+
+function SettingsToggleRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 px-1.5 py-1 rounded text-xs text-text-sub hover:bg-surface/40 cursor-pointer select-none">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-accent cursor-pointer"
+      />
+    </label>
+  );
+}
+
+function SettingsSliderRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  displayDecimals = 2,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  displayDecimals?: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 px-1.5 py-1">
+      <div className="flex items-center justify-between text-xs text-text-sub select-none">
+        <span>{label}</span>
+        <span className="tabular-nums text-text-faint">
+          {value.toFixed(displayDecimals)}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-accent cursor-pointer"
+      />
+    </div>
+  );
+}
+
+function SettingsCheckboxSliderRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  enabled,
+  onEnabledChange,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  enabled: boolean;
+  onEnabledChange: (v: boolean) => void;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div
+      className={`flex flex-col gap-0.5 px-1.5 py-1 ${enabled ? "" : "opacity-60"}`}
+    >
+      <div className="flex items-center justify-between text-xs text-text-sub select-none">
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => onEnabledChange(e.target.checked)}
+            className="accent-accent cursor-pointer"
+          />
+          <span>{label}</span>
+        </label>
+        <span className="tabular-nums text-text-faint">
+          {value.toFixed(2)}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={!enabled}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-accent cursor-pointer disabled:cursor-not-allowed"
+      />
+    </div>
+  );
+}

--- a/app/src/components/sidebar.tsx
+++ b/app/src/components/sidebar.tsx
@@ -1,4 +1,11 @@
-import { Archive, Database, Box, Volume2, type LucideIcon } from "lucide-react";
+import {
+  Archive,
+  Database,
+  Box,
+  Volume2,
+  Orbit,
+  type LucideIcon,
+} from "lucide-react";
 import { useAppStore, type AppMode } from "../stores/app-store";
 
 interface ModeButton {
@@ -19,6 +26,7 @@ const modes: ModeButton[] = [
   { id: "p4k", label: "P4k Browser", icon: Archive },
   { id: "datacore", label: "DataCore", icon: Database },
   { id: "export", label: "3D Export", icon: Box },
+  { id: "scene", label: "3D Viewer", icon: Orbit },
   { id: "audio", label: "Audio", icon: Volume2 },
 ];
 

--- a/app/src/components/soc-scene-viewer.tsx
+++ b/app/src/components/soc-scene-viewer.tsx
@@ -1,0 +1,685 @@
+// Renders a SOC scene-package GLB (the output of `load_scene_to_gltf`)
+// in Three.js. Different from `scene-viewer.tsx`, which consumes a
+// decomposed-export package directory; this loads a single
+// self-contained `.glb` from the scene cache.
+//
+// What this component does in load order:
+//   1. Set up Three.js (renderer, perspective camera, environment,
+//      fallback lights). Same canonical setup that `scene-viewer.tsx`
+//      uses, simplified -- no paint-variant / livery state, no per-mesh
+//      submaterial-index binding, no scene.json walk. The SOC GLB is
+//      self-contained.
+//   2. Attach the shared flight camera via `useFlightCamera` so WASDQE /
+//      orbit / oblique projection / F9 capture all work the same way as
+//      in the ship viewer. The handle is republished to the parent via
+//      `onFlightCamReady` so the parent can host the projection-mode
+//      picker in its toolbar.
+//   3. Build an `asset://` URL for the cached GLB on disk (via
+//      `sceneGlbAssetUrl`, which wraps Tauri's `convertFileSrc`) and
+//      hand it to `GLTFLoader.load` so the webview fetches the file
+//      through its own HTTP path. This avoids shipping the GLB across
+//      the IPC channel as a `number[]` -- the prior `loader.parse(bytes)`
+//      pathway crashed the renderer with `STATUS_BREAKPOINT` on the
+//      ~272 MB Exec Hangar GLB once the IPC custom protocol fell back
+//      to `postMessage`. Lights live in the `KHR_lights_punctual`
+//      extension and are auto-instantiated as `THREE.PointLight` /
+//      `THREE.SpotLight` by the loader.
+//   4. Walk every loaded material. If `userData.diffuse_texture_path`
+//      is set, queue a Tauri-side DDS decode (`previewDds`) and assign
+//      the resulting `THREE.Texture` to the material's `map` slot. The
+//      GLB does not embed any placeholder textures (earlier iterations
+//      did, which produced "Couldn't load texture blob:" errors when
+//      thousands of materials shared one blob-backed image whose blob
+//      URL the GLTFLoader had already revoked); until the DDS resolves,
+//      the material renders with its `baseColorFactor` only. Texture
+//      lookups are cached by source path so repeated submaterials
+//      share one `THREE.Texture`. Failures fall back to a flat color
+//      (debug magenta in dev, neutral grey in production).
+//   5. Apply a -90deg rotation around X to the SCENE ROOT to flip
+//      CryEngine Z-up into Three.js / glTF Y-up. The emitter
+//      deliberately does not bake this rotation into the GLB; the
+//      flight cam is basis-agnostic, so the rotation lives here.
+//   6. After the GLB is added to the scene root, frame the camera with
+//      `flightCam.resetToScene(sceneRoot)`. The flight cam computes the
+//      AABB itself; the response's `aabb_min/max` are kept on hand for
+//      the bottom-left stats overlay only.
+//
+// Console.log lines the user should look for in DevTools when running
+// the Tauri app:
+//   [soc-scene] init three=<rev>
+//   [soc-scene] glb-loaded bytes=<N> meshes=<N> nodes=<N> lights=<N> ms=<N>
+//   [soc-scene] textures resolved=<R>/<T> failed=<F>
+
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
+import {
+  previewDds,
+  sceneGlbAssetUrl,
+  type LoadSceneResponse,
+} from "../lib/commands";
+import { FlightCamHud } from "./flight-cam-hud";
+import { useFlightCamera, type FlightCamHandle } from "../lib/flight-camera";
+
+/**
+ * Diffuse map intensity scalar. Engine intensity values for SOC lights
+ * are in physical units (candela for point / lux for directional);
+ * Three.js MeshStandardMaterial / lights use arbitrary scene units.
+ * The emitter writes a default intensity of 1.0 per light, so the
+ * scaling here is mostly cosmetic until a future iteration threads
+ * real DataCore intensities through. Documented here so the choice
+ * is obvious to the next person tweaking it.
+ */
+const LIGHT_INTENSITY_SCALE = 1.0;
+
+/**
+ * Z-up to Y-up basis flip. SOC coordinates are CryEngine Z-up; glTF /
+ * Three.js are Y-up. Rotating the scene root by -90deg around X moves
+ * world +Z (CryEngine "up") onto world +Y (Three.js "up"). Verified
+ * by inspecting where lights land -- a "ceiling" point light lands
+ * above the geometry after rotation, not below.
+ */
+function applyZUpToYUp(root: THREE.Object3D) {
+  root.rotation.x = -Math.PI / 2;
+}
+
+/** Debug fallback color in dev mode, neutral grey in production. */
+function fallbackColor(): number {
+  // import.meta.env.DEV is true under `vite dev`. Hot path: we only
+  // see this when texture resolution fails, so the cost of the env
+  // check is fine.
+  if (typeof import.meta !== "undefined" && import.meta.env?.DEV) {
+    return 0xff00ff;
+  }
+  return 0x808080;
+}
+
+export interface SocSceneViewerProps {
+  /** Response from `loadSceneToGltf` -- carries the cached GLB path
+   *  and the AABB used for the stats overlay. */
+  response: LoadSceneResponse;
+  /** Optional status callback (e.g. for the toolbar). */
+  onStatus?: (text: string) => void;
+  /** Optional progress callback for the asset-protocol GLB fetch.
+   *  Receives a fraction in [0, 1] derived from the underlying
+   *  `XMLHttpRequest.onprogress` event; when the response is not
+   *  `Content-Length`-tagged the fraction stays at the previous
+   *  value rather than oscillating. */
+  onLoadProgress?: (fraction: number, message: string) => void;
+  /** Optional callback invoked once the flight-camera handle resolves.
+   *  The parent uses this to host the projection-mode picker in its
+   *  toolbar (mirrors the ship viewer). Called with `null` on
+   *  unmount. */
+  onFlightCamReady?: (handle: FlightCamHandle | null) => void;
+}
+
+interface TextureResolutionStats {
+  resolved: number;
+  total: number;
+  failed: number;
+}
+
+export function SocSceneViewer({
+  response,
+  onStatus,
+  onLoadProgress,
+  onFlightCamReady,
+}: SocSceneViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Refs published by the bootstrap effect so `useFlightCamera` (which
+  // runs its own effect after this one) can attach. The render loop
+  // reads `flightCamRef.current?.getActiveCamera()` so projection-mode
+  // swaps and oblique screenshots both work.
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const sceneRootRef = useRef<THREE.Group | null>(null);
+  const flightCamRef = useRef<FlightCamHandle | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<{
+    meshes: number;
+    nodes: number;
+    lights: number;
+    textures: TextureResolutionStats;
+  } | null>(null);
+  const generationRef = useRef(0);
+
+  // ── Three.js bootstrap (runs once) ────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: "high-performance",
+    });
+    renderer.setClearColor(0x101418);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 0.85;
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      100000,
+    );
+    camera.position.set(60, 30, 60);
+
+    // Publish refs so `useFlightCamera` (next effect on this mount)
+    // can read them. Must happen before the render loop starts so the
+    // flight cam attaches on the first useful frame.
+    rendererRef.current = renderer;
+    cameraRef.current = camera;
+    sceneRef.current = scene;
+
+    // Fallback fill so a level with disabled lights still shows up.
+    // SOC scenes carry hundreds-to-thousands of point lights through
+    // `KHR_lights_punctual` so this is mostly a safety net.
+    const hemi = new THREE.HemisphereLight(0xb1bfd8, 0x202428, 0.3);
+    hemi.name = "fallback_hemi";
+    scene.add(hemi);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.6);
+    dir.position.set(50, 100, 25);
+    dir.name = "fallback_dir";
+    scene.add(dir);
+
+    // PMREM environment so PBR materials get reasonable IBL.
+    const pmremGenerator = new THREE.PMREMGenerator(renderer);
+    const roomEnv = new RoomEnvironment();
+    const envTexture = pmremGenerator.fromScene(roomEnv, 0.04).texture;
+    scene.environment = envTexture;
+    scene.environmentIntensity = 0.5;
+
+    const sceneRoot = new THREE.Group();
+    sceneRoot.name = "soc_scene_root";
+    applyZUpToYUp(sceneRoot);
+    scene.add(sceneRoot);
+    sceneRootRef.current = sceneRoot;
+
+    let animId = 0;
+    const animate = () => {
+      animId = requestAnimationFrame(animate);
+      // Render with whichever camera the flight cam currently exposes
+      // (perspective, orthographic, or oblique). Until the flight-cam
+      // hook attaches on the next effect pass, `flightCamRef.current`
+      // is null and we fall back to the perspective camera so the very
+      // first frame still renders.
+      const activeCam = flightCamRef.current?.getActiveCamera() ?? camera;
+      renderer.render(scene, activeCam);
+    };
+    animate();
+
+    console.log(`[soc-scene] init three=${THREE.REVISION}`);
+
+    const ro = new ResizeObserver(() => {
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    });
+    ro.observe(container);
+
+    return () => {
+      cancelAnimationFrame(animId);
+      ro.disconnect();
+      renderer.dispose();
+      pmremGenerator.dispose();
+      envTexture.dispose();
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+      rendererRef.current = null;
+      cameraRef.current = null;
+      sceneRef.current = null;
+      sceneRootRef.current = null;
+    };
+  }, []);
+
+  // Attach the flight camera. Runs after the bootstrap effect populated
+  // the renderer/camera/scene refs above, on the same mount pass. Stays
+  // null on the first render (refs are still null), then resolves to a
+  // stable handle once the hook's effect has installed listeners.
+  const flightCam = useFlightCamera({ rendererRef, cameraRef, sceneRef });
+  useEffect(() => {
+    flightCamRef.current = flightCam;
+  }, [flightCam]);
+
+  // Hand the flight-cam handle up to the parent so it can host the
+  // projection-mode picker in its top-right toolbar.
+  useEffect(() => {
+    onFlightCamReady?.(flightCam);
+    return () => {
+      onFlightCamReady?.(null);
+    };
+  }, [flightCam, onFlightCamReady]);
+
+  // F9 captures a high-resolution screenshot through the active camera.
+  // Listener lives on `window` so capture works regardless of which
+  // child element holds focus, except for typing targets where F9 is
+  // suppressed to avoid surprise captures while a text field is active.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.code !== "F9") return;
+      const ae = document.activeElement;
+      const tag = ae?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      // The decomposed scene viewer owns the screenshot helper; the
+      // SOC viewer does not bring its own copy. F9 here is a no-op
+      // hook for symmetry; if the user wants captures of SOC scenes,
+      // the existing screenshot capture path can be wired in a future
+      // iteration. For now, do nothing rather than throw.
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+
+  // ── Scene load on response change ────────────────────────────────
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    const sceneRoot = sceneRootRef.current;
+    if (!renderer || !sceneRoot) return;
+    const gen = ++generationRef.current;
+    setError(null);
+    setStats(null);
+
+    // Clear previous scene children. Do not strip the basis rotation
+    // from sceneRoot itself -- that lives on the root and persists
+    // across loads.
+    clearChildren(sceneRoot);
+
+    void (async () => {
+      const t0 = performance.now();
+      onStatus?.("Fetching scene...");
+      try {
+        // Build the asset:// URL up front. This is a pure path
+        // mangling operation (no IPC), and it is what lets the GLB
+        // bypass the JSON-encoded `Vec<u8>` IPC channel that crashed
+        // the renderer with `STATUS_BREAKPOINT` on prior iterations.
+        // The asset-protocol scope in `tauri.conf.json` restricts
+        // resolvable paths to `$APPLOCALDATA/scene_cache/**`.
+        const glbUrl = sceneGlbAssetUrl(response.glb_path);
+        console.log(`[soc-scene] glb-fetch url=${glbUrl}`);
+
+        const tFetch0 = performance.now();
+        const loader = new GLTFLoader();
+        const gltf = await new Promise<{
+          scene: THREE.Group;
+          parser: { json: { meshes?: unknown[]; nodes?: unknown[] } };
+        }>((resolve, reject) => {
+          loader.load(
+            glbUrl,
+            (g) =>
+              resolve({
+                scene: g.scene as unknown as THREE.Group,
+                parser: g.parser as unknown as {
+                  json: { meshes?: unknown[]; nodes?: unknown[] };
+                },
+              }),
+            (event) => {
+              // Three.js forwards XHR progress events. `lengthComputable`
+              // is false when the response has no `Content-Length`
+              // header -- for the local asset protocol it is reliably
+              // populated, but we guard either way to avoid a
+              // divide-by-zero.
+              if (gen !== generationRef.current) return;
+              if (event.lengthComputable && event.total > 0) {
+                const fraction = Math.min(1, event.loaded / event.total);
+                onLoadProgress?.(
+                  fraction,
+                  `Fetching GLB ${(event.loaded / 1024 / 1024).toFixed(0)} ` +
+                    `/ ${(event.total / 1024 / 1024).toFixed(0)} MiB`,
+                );
+              }
+            },
+            (err) => reject(err),
+          );
+        });
+        if (gen !== generationRef.current) return;
+        const tFetch1 = performance.now();
+
+        // Count what came in. The fetch + parse pair is reported as
+        // a single `parse_ms` for continuity with prior iterations'
+        // diagnostic output; the underlying split is fetch + parse
+        // running back-to-back inside the loader.
+        const counts = countSceneContent(gltf.scene);
+        const meshCount = (gltf.parser.json.meshes ?? []).length;
+        const nodeCount = (gltf.parser.json.nodes ?? []).length;
+        console.log(
+          `[soc-scene] glb-loaded bytes=${response.glb_bytes} ` +
+            `meshes=${meshCount} nodes=${nodeCount} ` +
+            `lights=${counts.lights} lights_dropped=${response.lights_dropped} ` +
+            `parse_ms=${(tFetch1 - tFetch0).toFixed(0)}`,
+        );
+
+        // Scale every light's intensity. KHR_lights_punctual values
+        // come from the SOC emitter's defaults (1.0) until a future
+        // iteration threads real DataCore-side intensities through;
+        // we apply the scaling scalar so future intensity tuning is
+        // centralised here.
+        applyLightIntensityScale(gltf.scene);
+
+        // Attach the loaded tree to the basis-rotated scene root.
+        sceneRoot.add(gltf.scene);
+
+        // Resolve textures in the background. Materials render with
+        // the placeholder white until each resolves, then swap in.
+        onStatus?.("Resolving textures...");
+        const texStats = await resolveAllTextures(
+          gltf.scene,
+          response.placement_count,
+        );
+        if (gen !== generationRef.current) return;
+
+        // Hand framing to the flight cam. It walks the scene root's
+        // AABB itself and positions the camera + orbit pivot. Until
+        // the hook has attached on this mount, the call falls through
+        // and the user can re-frame manually with the keys.
+        flightCamRef.current?.resetToScene(sceneRoot);
+
+        setStats({
+          meshes: meshCount,
+          nodes: nodeCount,
+          lights: counts.lights,
+          textures: texStats,
+        });
+        const t1 = performance.now();
+        onStatus?.(
+          `Loaded ${meshCount} meshes / ${counts.lights} lights ` +
+            `/ ${texStats.resolved}/${texStats.total} textures (${((t1 - t0) / 1000).toFixed(1)}s)`,
+        );
+        console.log(
+          `[soc-scene] textures resolved=${texStats.resolved}/${texStats.total} ` +
+            `failed=${texStats.failed}`,
+        );
+      } catch (err) {
+        if (gen !== generationRef.current) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("[soc-scene] load failed:", msg);
+        setError(msg);
+        onStatus?.(`Load failed: ${msg}`);
+      }
+    })();
+  }, [response, onStatus, onLoadProgress]);
+
+  return (
+    <div className="relative w-full h-full">
+      <div ref={containerRef} className="w-full h-full" />
+      {error && (
+        <div className="absolute top-3 left-3 right-3 z-10 max-w-[80vw] mx-auto bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
+          {error}
+        </div>
+      )}
+      {stats && (
+        <div className="absolute bottom-3 left-3 z-10 bg-bg-alt/90 border border-border text-xs text-text-sub px-3 py-1.5 rounded-md shadow font-mono tabular-nums">
+          {stats.meshes} meshes / {stats.nodes} nodes
+          {" / lights "}
+          {stats.lights}
+          {response.lights_dropped > 0
+            ? `/${stats.lights + response.lights_dropped}`
+            : ""}
+          {" / "}
+          {stats.textures.resolved}/{stats.textures.total} textures
+          {response.materials_resolved > 0 || response.materials_default > 0 ? (
+            <>
+              {" / "}
+              materials {response.materials_resolved}/
+              {response.materials_resolved + response.materials_default}
+            </>
+          ) : null}
+        </div>
+      )}
+      <FlightCamHud handle={flightCam} />
+    </div>
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function clearChildren(group: THREE.Object3D) {
+  for (let i = group.children.length - 1; i >= 0; i--) {
+    const child = group.children[i];
+    group.remove(child);
+    disposeRecursive(child);
+  }
+}
+
+function disposeRecursive(obj: THREE.Object3D) {
+  obj.traverse((child) => {
+    if (child instanceof THREE.Mesh) {
+      child.geometry?.dispose();
+      const m = child.material;
+      if (Array.isArray(m)) {
+        for (const mat of m) mat.dispose();
+      } else if (m) {
+        m.dispose();
+      }
+    }
+  });
+}
+
+function countSceneContent(root: THREE.Object3D): {
+  meshes: number;
+  lights: number;
+} {
+  let meshes = 0;
+  let lights = 0;
+  root.traverse((c) => {
+    if (c instanceof THREE.Mesh) meshes += 1;
+    if (c instanceof THREE.Light) lights += 1;
+  });
+  return { meshes, lights };
+}
+
+function applyLightIntensityScale(root: THREE.Object3D) {
+  root.traverse((c) => {
+    if (c instanceof THREE.Light) {
+      c.intensity *= LIGHT_INTENSITY_SCALE;
+    }
+  });
+}
+
+/**
+ * Walk every material in the scene; for each one that has a
+ * `userData.diffuse_texture_path` extra, kick off a Tauri-side DDS
+ * decode and assign the result to the material's `.map` slot. The GLB
+ * does not embed any placeholder texture, so `.map` is `null` on every
+ * material when the loader returns; until the DDS resolves a material
+ * renders with its `baseColorFactor` only. Texture lookups are cached
+ * so duplicate paths share one `THREE.Texture`. Failures keep `.map =
+ * null` and tint the base color (debug magenta in dev, neutral grey
+ * in prod).
+ */
+async function resolveAllTextures(
+  root: THREE.Object3D,
+  _placementCount: number,
+): Promise<TextureResolutionStats> {
+  const cache = new Map<string, Promise<THREE.Texture | null>>();
+  const stats: TextureResolutionStats = { resolved: 0, total: 0, failed: 0 };
+
+  // Materials are shared across many meshes (one material per
+  // submaterial). We collect a unique set first so we only walk
+  // each one once.
+  const materials = new Set<THREE.Material>();
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    const m = child.material;
+    if (Array.isArray(m)) {
+      for (const mat of m) materials.add(mat);
+    } else if (m) {
+      materials.add(m);
+    }
+  });
+
+  const tasks: Promise<void>[] = [];
+
+  for (const material of materials) {
+    const userData = (material as unknown as { userData?: Record<string, unknown> })
+      .userData;
+    const diffusePath = userData?.diffuse_texture_path;
+    const normalPath = userData?.normal_texture_path;
+
+    if (typeof diffusePath === "string" && diffusePath.length > 0) {
+      stats.total += 1;
+      tasks.push(
+        loadTextureCached(cache, diffusePath, "diffuse").then((tex) => {
+          const standard = material as THREE.MeshStandardMaterial;
+          if (tex) {
+            // Diffuse maps render in sRGB; createImageBitmap-backed
+            // THREE.Texture defaults to NoColorSpace, so set explicitly.
+            tex.colorSpace = THREE.SRGBColorSpace;
+            standard.map = tex;
+            standard.needsUpdate = true;
+            stats.resolved += 1;
+          } else {
+            // Resolution failed. Material renders with its
+            // baseColorFactor only, tinted for debug visibility in dev.
+            standard.map = null;
+            standard.color = new THREE.Color(fallbackColor());
+            standard.needsUpdate = true;
+            stats.failed += 1;
+          }
+        }),
+      );
+    }
+
+    if (typeof normalPath === "string" && normalPath.length > 0) {
+      stats.total += 1;
+      tasks.push(
+        loadTextureCached(cache, normalPath, "normal").then((tex) => {
+          const standard = material as THREE.MeshStandardMaterial;
+          if (tex) {
+            // Normal maps stay Linear (no gamma).
+            tex.colorSpace = THREE.NoColorSpace;
+            standard.normalMap = tex;
+            standard.needsUpdate = true;
+            stats.resolved += 1;
+          } else {
+            stats.failed += 1;
+          }
+        }),
+      );
+    }
+  }
+
+  // Bound concurrency: too many simultaneous Tauri previewDds calls
+  // saturate the IPC channel. 6 keeps the renderer responsive.
+  await runWithLimit(tasks, 6);
+  return stats;
+}
+
+async function runWithLimit<T>(tasks: Promise<T>[], limit: number): Promise<T[]> {
+  if (limit <= 0 || tasks.length <= limit) return Promise.all(tasks);
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  const workers = Array.from({ length: limit }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i];
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Resolve one CryEngine texture path against the loaded p4k via the
+ * `previewDds` Tauri command. The MTL stores texture paths with `.tif`
+ * extensions; the engine swaps that for `.dds` at load time. We try
+ * the same fallback ladder: `.dds`, then the original extension. Mip
+ * 2 (1/4 size) is the chosen detail level -- full-size textures are
+ * 4x larger and the SOC scene viewer needs to budget VRAM.
+ */
+function loadTextureCached(
+  cache: Map<string, Promise<THREE.Texture | null>>,
+  contractPath: string,
+  _kind: "diffuse" | "normal",
+): Promise<THREE.Texture | null> {
+  const cached = cache.get(contractPath);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<THREE.Texture | null> => {
+    const candidates = buildTextureCandidates(contractPath);
+    for (const candidate of candidates) {
+      try {
+        const result = await previewDds(candidate, 2);
+        if (!result?.png || result.png.length === 0) continue;
+        const blob = new Blob([new Uint8Array(result.png)], {
+          type: "image/png",
+        });
+        if (typeof createImageBitmap === "function") {
+          const bitmap = await createImageBitmap(blob);
+          const texture = new THREE.Texture(
+            bitmap as unknown as HTMLImageElement,
+          );
+          texture.needsUpdate = true;
+          texture.wrapS = THREE.RepeatWrapping;
+          texture.wrapT = THREE.RepeatWrapping;
+          return texture;
+        }
+        // Fallback for environments without createImageBitmap.
+        const url = URL.createObjectURL(blob);
+        try {
+          return await new Promise<THREE.Texture>((resolve, reject) => {
+            new THREE.TextureLoader().load(
+              url,
+              (tex) => {
+                tex.wrapS = THREE.RepeatWrapping;
+                tex.wrapT = THREE.RepeatWrapping;
+                resolve(tex);
+              },
+              undefined,
+              (err) => reject(err),
+            );
+          });
+        } finally {
+          URL.revokeObjectURL(url);
+        }
+      } catch {
+        // Try the next candidate.
+        continue;
+      }
+    }
+    console.warn("[soc-scene] texture resolve failed:", contractPath);
+    return null;
+  })();
+
+  cache.set(contractPath, promise);
+  return promise;
+}
+
+/**
+ * Build the ordered list of p4k paths to try when resolving a texture
+ * path from an MTL. MTL paths arrive in mixed forms:
+ *   - "objects/foo/diffuse.tif"        (no Data prefix, .tif extension)
+ *   - "objects/foo/diffuse.dds"        (already .dds)
+ *   - "Data\\objects\\foo\\diffuse"    (no extension)
+ * We normalise separators and try .dds first (the engine's runtime
+ * extension), then the original.
+ */
+function buildTextureCandidates(rawPath: string): string[] {
+  const normalised = rawPath.replace(/\//g, "\\");
+  const withDataPrefix = normalised.toLowerCase().startsWith("data\\")
+    ? normalised
+    : `Data\\${normalised}`;
+  const dot = withDataPrefix.lastIndexOf(".");
+  const stem = dot >= 0 ? withDataPrefix.slice(0, dot) : withDataPrefix;
+  const candidates = [
+    `${stem}.dds`,
+    withDataPrefix,
+    `${stem}.tif`,
+  ];
+  // De-dupe while preserving order.
+  return Array.from(new Set(candidates));
+}

--- a/app/src/components/soc-scene-viewer.tsx
+++ b/app/src/components/soc-scene-viewer.tsx
@@ -59,12 +59,17 @@ import {
   sceneGlbAssetUrl,
   type LoadSceneResponse,
 } from "../lib/commands";
-import { FlightCamHud } from "./flight-cam-hud";
+import { SceneInfoPanel } from "./scene-info-panel";
+import { NavWidget } from "./nav-widget";
 import {
   dispatchViewerHotkey,
   useFlightCamera,
   type FlightCamHandle,
 } from "../lib/flight-camera";
+import {
+  captureScreenshot,
+  formatScreenshotFilename,
+} from "../lib/screenshot";
 import {
   applyRenderStyleToScene,
   clearMobiGlasMaterials,
@@ -139,6 +144,11 @@ export interface SocSceneViewerProps {
    *  so the binding flips a parent-side state rather than mutating
    *  anything on this component. Optional; if omitted, H is a no-op. */
   onTogglePivotOrb?: () => void;
+  /** Slug used as the screenshot filename prefix when F9 fires. The
+   *  Ships viewer derives this from the package name; for SOC scenes
+   *  the parent passes the socpak path tail (without `.socpak`).
+   *  Falls back to "soc_scene" when not provided. */
+  screenshotSlug?: string;
 }
 
 interface TextureResolutionStats {
@@ -155,6 +165,7 @@ export function SocSceneViewer({
   onLoadComplete,
   onFlightCamReady,
   onTogglePivotOrb,
+  screenshotSlug,
 }: SocSceneViewerProps) {
   // Mirror the latest togglePivotOrb prop into a ref so the keydown
   // listener (registered once on mount with empty deps) always calls
@@ -187,6 +198,11 @@ export function SocSceneViewer({
   // texture decode all over again) instead of just swapping materials.
   const renderStyleRef = useRef<RenderStyle>(renderStyle);
   renderStyleRef.current = renderStyle;
+  // Mirror screenshotSlug into a ref so the F9 keydown handler always
+  // reads the latest socpak slug without forcing the listener to
+  // re-register on every parent render.
+  const screenshotSlugRef = useRef<string | undefined>(screenshotSlug);
+  screenshotSlugRef.current = screenshotSlug;
 
   // ── Three.js bootstrap (runs once) ────────────────────────────────
   useEffect(() => {
@@ -310,19 +326,45 @@ export function SocSceneViewer({
   }, [flightCam, onFlightCamReady]);
 
   // Top-level viewer shortcuts: R reframes, H toggles the pivot orb,
-  // Numpad 0-5 snap to view presets. Same dispatch table the Ships
-  // viewer uses (`dispatchViewerHotkey` in flight-camera.ts), so the
-  // two surfaces stay in lockstep. Listener on `window` so it fires
-  // regardless of focus, except for typing targets.
-  //
-  // F9 (high-res screenshot) is intentionally NOT bound here -- the
-  // capture helper is package-aware and only the Ships viewer wires
-  // it today. A SOC-flavoured screenshot path is on the C7+ backlog.
+  // Numpad 0-5 snap to view presets, F9 captures a high-res
+  // screenshot. Same dispatch + capture path the Ships viewer uses,
+  // so the two surfaces stay in lockstep. Listener on `window` so it
+  // fires regardless of focus, except for typing targets.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent): void => {
       const ae = document.activeElement;
       const tag = ae?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
+      // F9 first -- not part of dispatchViewerHotkey because it
+      // needs the THREE refs that only this component owns.
+      if (e.code === "F9") {
+        e.preventDefault();
+        const scene = sceneRef.current;
+        const baseRenderer = rendererRef.current;
+        const camera =
+          flightCamRef.current?.getActiveCamera() ?? cameraRef.current;
+        if (!scene || !baseRenderer || !camera) return;
+        const projectionMode = flightCamRef.current?.getState().projectionMode;
+        const filename = formatScreenshotFilename(
+          screenshotSlugRef.current ?? "soc_scene",
+          new Date(),
+        );
+        captureScreenshot({
+          scene,
+          camera,
+          baseRenderer,
+          filename,
+          projectionMode,
+          onProgress: (phase, info) => {
+            console.info(
+              `[screenshot] phase=${phase}${info ? ` ${info}` : ""}`,
+            );
+          },
+        }).catch((err) => {
+          console.error("[screenshot] handler caught:", err);
+        });
+        return;
+      }
       const handled = dispatchViewerHotkey(
         { code: e.code, repeat: e.repeat },
         flightCamRef.current,
@@ -522,26 +564,30 @@ export function SocSceneViewer({
           {error}
         </div>
       )}
-      {stats && (
-        <div className="absolute bottom-3 left-3 z-10 bg-bg-alt/90 border border-border text-xs text-text-sub px-3 py-1.5 rounded-md shadow font-mono tabular-nums">
-          {stats.meshes} meshes / {stats.nodes} nodes
-          {" / lights "}
-          {stats.lights}
-          {response.lights_dropped > 0
-            ? `/${stats.lights + response.lights_dropped}`
-            : ""}
-          {" / "}
-          {stats.textures.resolved}/{stats.textures.total} textures
-          {response.materials_resolved > 0 || response.materials_default > 0 ? (
-            <>
-              {" / "}
-              materials {response.materials_resolved}/
-              {response.materials_resolved + response.materials_default}
-            </>
-          ) : null}
-        </div>
-      )}
-      <FlightCamHud handle={flightCam} />
+      <div className="absolute bottom-2 right-2 z-10 flex flex-col items-end gap-2">
+        <NavWidget flightCamHandle={flightCam} />
+        <SceneInfoPanel flightCamHandle={flightCam} embedded>
+          {stats && (
+            <p className="text-xs text-text-sub font-mono tabular-nums">
+              {stats.meshes} meshes &middot; {stats.nodes} nodes &middot;{" "}
+              {stats.lights}
+              {response.lights_dropped > 0
+                ? `/${stats.lights + response.lights_dropped}`
+                : ""}{" "}
+              lights &middot; {stats.textures.resolved}/{stats.textures.total}{" "}
+              textures
+              {(response.materials_resolved > 0 ||
+                response.materials_default > 0) && (
+                <>
+                  {" "}
+                  &middot; materials {response.materials_resolved}/
+                  {response.materials_resolved + response.materials_default}
+                </>
+              )}
+            </p>
+          )}
+        </SceneInfoPanel>
+      </div>
     </div>
   );
 }

--- a/app/src/components/soc-scene-viewer.tsx
+++ b/app/src/components/soc-scene-viewer.tsx
@@ -60,7 +60,17 @@ import {
   type LoadSceneResponse,
 } from "../lib/commands";
 import { FlightCamHud } from "./flight-cam-hud";
-import { useFlightCamera, type FlightCamHandle } from "../lib/flight-camera";
+import {
+  dispatchViewerHotkey,
+  useFlightCamera,
+  type FlightCamHandle,
+} from "../lib/flight-camera";
+import {
+  applyRenderStyleToScene,
+  clearMobiGlasMaterials,
+  updateMobiGlasTime,
+  type RenderStyle,
+} from "../lib/render-styles";
 
 /**
  * Diffuse map intensity scalar. Engine intensity values for SOC lights
@@ -101,17 +111,34 @@ export interface SocSceneViewerProps {
   response: LoadSceneResponse;
   /** Optional status callback (e.g. for the toolbar). */
   onStatus?: (text: string) => void;
-  /** Optional progress callback for the asset-protocol GLB fetch.
-   *  Receives a fraction in [0, 1] derived from the underlying
-   *  `XMLHttpRequest.onprogress` event; when the response is not
-   *  `Content-Length`-tagged the fraction stays at the previous
-   *  value rather than oscillating. */
-  onLoadProgress?: (fraction: number, message: string) => void;
+  /** Render style to apply to all materials in the scene. Driven by
+   *  the shared `<ViewerToolbar>` Style dropdown. Switching is
+   *  in-place: a per-mesh material swap walks the loaded GLB and
+   *  builds the stylised variant; the original material is preserved
+   *  on `mesh.userData` so flipping back to "textured" restores
+   *  fidelity without a reload. */
+  renderStyle?: RenderStyle;
+  /** Optional callback for the unified progress reporter. Called from
+   *  the GLB fetch (`fetch` phase) and the texture decode loop
+   *  (`decode` phase) so the parent's <ProgressOverlay> stays up
+   *  through the whole load -- not just the backend portion. */
+  onPhaseProgress?: (
+    id: "fetch" | "decode",
+    patch: Partial<{ fraction: number | null; detail: string }>,
+  ) => void;
+  /** Called once textures are resolved and the camera has framed the
+   *  scene -- the user can now interact. Lets the parent close the
+   *  unified progress overlay. */
+  onLoadComplete?: () => void;
   /** Optional callback invoked once the flight-camera handle resolves.
    *  The parent uses this to host the projection-mode picker in its
    *  toolbar (mirrors the ship viewer). Called with `null` on
    *  unmount. */
   onFlightCamReady?: (handle: FlightCamHandle | null) => void;
+  /** H key handler. The parent owns the pivot-orb visibility setting,
+   *  so the binding flips a parent-side state rather than mutating
+   *  anything on this component. Optional; if omitted, H is a no-op. */
+  onTogglePivotOrb?: () => void;
 }
 
 interface TextureResolutionStats {
@@ -123,9 +150,17 @@ interface TextureResolutionStats {
 export function SocSceneViewer({
   response,
   onStatus,
-  onLoadProgress,
+  renderStyle = "textured",
+  onPhaseProgress,
+  onLoadComplete,
   onFlightCamReady,
+  onTogglePivotOrb,
 }: SocSceneViewerProps) {
+  // Mirror the latest togglePivotOrb prop into a ref so the keydown
+  // listener (registered once on mount with empty deps) always calls
+  // the current callback. Same pattern as the Ships viewer.
+  const togglePivotOrbRef = useRef<(() => void) | undefined>(onTogglePivotOrb);
+  togglePivotOrbRef.current = onTogglePivotOrb;
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Refs published by the bootstrap effect so `useFlightCamera` (which
@@ -146,6 +181,12 @@ export function SocSceneViewer({
     textures: TextureResolutionStats;
   } | null>(null);
   const generationRef = useRef(0);
+  // Mirror `renderStyle` into a ref so the scene-load effect can read
+  // the current value without listing it in its dep array. Otherwise
+  // toggling the Style dropdown would re-run the entire load (fetch +
+  // texture decode all over again) instead of just swapping materials.
+  const renderStyleRef = useRef<RenderStyle>(renderStyle);
+  renderStyleRef.current = renderStyle;
 
   // ── Three.js bootstrap (runs once) ────────────────────────────────
   useEffect(() => {
@@ -204,9 +245,15 @@ export function SocSceneViewer({
     scene.add(sceneRoot);
     sceneRootRef.current = sceneRoot;
 
+    // Clock for the MobiGlas shader's `time` uniform. The
+    // `updateMobiGlasTime` registry walk is a no-op when no MobiGlas
+    // material is registered, so we tick it unconditionally rather
+    // than gating on the current render style.
+    const clock = new THREE.Clock();
     let animId = 0;
     const animate = () => {
       animId = requestAnimationFrame(animate);
+      updateMobiGlasTime(clock.getElapsedTime());
       // Render with whichever camera the flight cam currently exposes
       // (perspective, orthographic, or oblique). Until the flight-cam
       // hook attaches on the next effect pass, `flightCamRef.current`
@@ -262,21 +309,27 @@ export function SocSceneViewer({
     };
   }, [flightCam, onFlightCamReady]);
 
-  // F9 captures a high-resolution screenshot through the active camera.
-  // Listener lives on `window` so capture works regardless of which
-  // child element holds focus, except for typing targets where F9 is
-  // suppressed to avoid surprise captures while a text field is active.
+  // Top-level viewer shortcuts: R reframes, H toggles the pivot orb,
+  // Numpad 0-5 snap to view presets. Same dispatch table the Ships
+  // viewer uses (`dispatchViewerHotkey` in flight-camera.ts), so the
+  // two surfaces stay in lockstep. Listener on `window` so it fires
+  // regardless of focus, except for typing targets.
+  //
+  // F9 (high-res screenshot) is intentionally NOT bound here -- the
+  // capture helper is package-aware and only the Ships viewer wires
+  // it today. A SOC-flavoured screenshot path is on the C7+ backlog.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.code !== "F9") return;
       const ae = document.activeElement;
       const tag = ae?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
-      // The decomposed scene viewer owns the screenshot helper; the
-      // SOC viewer does not bring its own copy. F9 here is a no-op
-      // hook for symmetry; if the user wants captures of SOC scenes,
-      // the existing screenshot capture path can be wired in a future
-      // iteration. For now, do nothing rather than throw.
+      const handled = dispatchViewerHotkey(
+        { code: e.code, repeat: e.repeat },
+        flightCamRef.current,
+        sceneRootRef.current,
+        () => togglePivotOrbRef.current?.(),
+      );
+      if (handled) e.preventDefault();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => {
@@ -295,8 +348,11 @@ export function SocSceneViewer({
 
     // Clear previous scene children. Do not strip the basis rotation
     // from sceneRoot itself -- that lives on the root and persists
-    // across loads.
+    // across loads. Also drop any MobiGlas materials registered by a
+    // prior load so the per-frame `time` tick does not touch
+    // disposed GPU resources.
     clearChildren(sceneRoot);
+    clearMobiGlasMaterials();
 
     void (async () => {
       const t0 = performance.now();
@@ -335,11 +391,12 @@ export function SocSceneViewer({
               if (gen !== generationRef.current) return;
               if (event.lengthComputable && event.total > 0) {
                 const fraction = Math.min(1, event.loaded / event.total);
-                onLoadProgress?.(
+                onPhaseProgress?.("fetch", {
                   fraction,
-                  `Fetching GLB ${(event.loaded / 1024 / 1024).toFixed(0)} ` +
+                  detail:
+                    `Fetching GLB ${(event.loaded / 1024 / 1024).toFixed(0)} ` +
                     `/ ${(event.total / 1024 / 1024).toFixed(0)} MiB`,
-                );
+                });
               }
             },
             (err) => reject(err),
@@ -347,6 +404,10 @@ export function SocSceneViewer({
         });
         if (gen !== generationRef.current) return;
         const tFetch1 = performance.now();
+        // Mark fetch complete so the unified overlay advances to the
+        // decode phase. Setting `fraction: 1` lets the bar fill to the
+        // fetch phase's full weight share.
+        onPhaseProgress?.("fetch", { fraction: 1 });
 
         // Count what came in. The fetch + parse pair is reported as
         // a single `parse_ms` for continuity with prior iterations'
@@ -374,12 +435,38 @@ export function SocSceneViewer({
 
         // Resolve textures in the background. Materials render with
         // the placeholder white until each resolves, then swap in.
+        // Per-texture progress is forwarded to the unified overlay's
+        // `decode` phase so the bar continues to move during what is
+        // typically the dominant wall-clock phase on big maps.
         onStatus?.("Resolving textures...");
         const texStats = await resolveAllTextures(
           gltf.scene,
           response.placement_count,
+          (resolved, failed, total) => {
+            if (gen !== generationRef.current) return;
+            const done = resolved + failed;
+            const fraction = total > 0 ? Math.min(1, done / total) : 1;
+            onPhaseProgress?.("decode", {
+              fraction,
+              detail: `Resolving textures ${done} / ${total}`,
+            });
+          },
         );
         if (gen !== generationRef.current) return;
+        // Make sure the final state is reported even when total === 0
+        // (no userData-tagged textures), where the per-tick callback
+        // never fires.
+        onPhaseProgress?.("decode", { fraction: 1 });
+
+        // Apply the active render style (textured / mobiglas / metallic
+        // / opaque / glass / holographic). For the textured default
+        // this is a no-op; for the others it walks every mesh and
+        // swaps materials. The MobiGlas variant registers itself with
+        // the per-frame time tick we set up in the bootstrap effect.
+        // Read from the ref so a style change while the load was in
+        // flight still picks up the latest value -- and so the load
+        // effect does not depend on `renderStyle` in its deps.
+        applyRenderStyleToScene(sceneRoot, renderStyleRef.current);
 
         // Hand framing to the flight cam. It walks the scene root's
         // AABB itself and positions the camera + orbit pivot. Until
@@ -393,6 +480,9 @@ export function SocSceneViewer({
           lights: counts.lights,
           textures: texStats,
         });
+        // Tell the parent the load is fully done so it can dismiss
+        // the unified progress overlay.
+        onLoadComplete?.();
         const t1 = performance.now();
         onStatus?.(
           `Loaded ${meshCount} meshes / ${counts.lights} lights ` +
@@ -410,7 +500,19 @@ export function SocSceneViewer({
         onStatus?.(`Load failed: ${msg}`);
       }
     })();
-  }, [response, onStatus, onLoadProgress]);
+  }, [response, onStatus, onPhaseProgress, onLoadComplete]);
+
+  // Apply render-style changes WITHOUT rebuilding the scene. Skips the
+  // first run after a fresh load (the load effect itself applies the
+  // current style); subsequent runs handle live toggles from the Style
+  // dropdown. Also fires on initial mount when there's no scene yet --
+  // the early-out keeps that as a no-op.
+  useEffect(() => {
+    const sceneRoot = sceneRootRef.current;
+    if (!sceneRoot) return;
+    if (sceneRoot.children.length === 0) return;
+    applyRenderStyleToScene(sceneRoot, renderStyle);
+  }, [renderStyle]);
 
   return (
     <div className="relative w-full h-full">
@@ -503,6 +605,7 @@ function applyLightIntensityScale(root: THREE.Object3D) {
 async function resolveAllTextures(
   root: THREE.Object3D,
   _placementCount: number,
+  onTick?: (resolved: number, failed: number, total: number) => void,
 ): Promise<TextureResolutionStats> {
   const cache = new Map<string, Promise<THREE.Texture | null>>();
   const stats: TextureResolutionStats = { resolved: 0, total: 0, failed: 0 };
@@ -521,6 +624,20 @@ async function resolveAllTextures(
     }
   });
 
+  // Pre-compute totals so the tick callback can report a stable
+  // denominator from the very first tick. Without this the bar would
+  // jump as new tasks are discovered mid-resolve.
+  for (const material of materials) {
+    const userData = (
+      material as unknown as { userData?: Record<string, unknown> }
+    ).userData;
+    if (typeof userData?.diffuse_texture_path === "string") stats.total += 1;
+    if (typeof userData?.normal_texture_path === "string") stats.total += 1;
+  }
+  // Initial tick so the overlay shows 0 / N immediately rather than
+  // waiting for the first resolve to land.
+  onTick?.(0, 0, stats.total);
+
   const tasks: Promise<void>[] = [];
 
   for (const material of materials) {
@@ -530,7 +647,6 @@ async function resolveAllTextures(
     const normalPath = userData?.normal_texture_path;
 
     if (typeof diffusePath === "string" && diffusePath.length > 0) {
-      stats.total += 1;
       tasks.push(
         loadTextureCached(cache, diffusePath, "diffuse").then((tex) => {
           const standard = material as THREE.MeshStandardMaterial;
@@ -549,12 +665,12 @@ async function resolveAllTextures(
             standard.needsUpdate = true;
             stats.failed += 1;
           }
+          onTick?.(stats.resolved, stats.failed, stats.total);
         }),
       );
     }
 
     if (typeof normalPath === "string" && normalPath.length > 0) {
-      stats.total += 1;
       tasks.push(
         loadTextureCached(cache, normalPath, "normal").then((tex) => {
           const standard = material as THREE.MeshStandardMaterial;
@@ -567,6 +683,7 @@ async function resolveAllTextures(
           } else {
             stats.failed += 1;
           }
+          onTick?.(stats.resolved, stats.failed, stats.total);
         }),
       );
     }

--- a/app/src/components/socpak-tree.tsx
+++ b/app/src/components/socpak-tree.tsx
@@ -1,0 +1,573 @@
+// Lazy directory-tree view of the p4k's socpak filesystem.
+//
+// Replaces the eager catalog list in the Maps tab. The user starts
+// with one prefix (e.g. `Data\ObjectContainers\`); we render the
+// immediate children, and each directory expands on click via a
+// fresh `listSocpakDir` call. Loaded children are cached per branch
+// so collapsing and re-expanding is free.
+//
+// Why this exists: the eager `enumerateScenes` call walked every
+// `.socpak` under `Data\ObjectContainers\`, parsed each one's child
+// XML, and built a graph -- 1700+ socpaks worth of zip-within-zip
+// reads on every cold call. That locked up the Tauri webview before
+// returning. The lazy tree pays only for what the user expands.
+
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { ChevronRight, Folder, Box, Loader2, AlertCircle } from "lucide-react";
+import { listSocpakDir, type SocpakDirEntry } from "../lib/commands";
+
+interface SocpakTreeProps {
+  /** Initial top-level prefix; e.g. `Data\ObjectContainers\`. */
+  rootPrefix: string;
+  /** Called when the user clicks a `.socpak` leaf. */
+  onLeafClick: (entry: SocpakDirEntry) => void;
+  /** When set, the leaf at this path renders with an active-branch highlight. */
+  activePath?: string | null;
+  /**
+   * Flat list of every `.socpak` path in the p4k. Drives the
+   * "search everywhere" mode: when `search` is non-empty AND this is
+   * non-null, the tree hides its lazy-branch view and shows a flat
+   * filtered list of matches against the index. When this is null
+   * (still loading or unavailable), search input falls back to the
+   * legacy "filter visible branches" behaviour and a "Indexing..."
+   * hint replaces the empty-results message.
+   */
+  globalIndex?: string[] | null;
+}
+
+interface BranchState {
+  status: "loading" | "loaded" | "error";
+  /** Cached children once loaded; preserved across collapse/expand. */
+  children?: SocpakDirEntry[];
+  /** True when the branch is currently expanded in the tree. */
+  expanded: boolean;
+  /** Free-text error message when `status === "error"`. */
+  error?: string;
+}
+
+type TreeState = Map<string, BranchState>;
+
+/**
+ * Format a byte count as a short human string. Mirrors the helper in
+ * scene-view.tsx; redeclared here because the file is small enough
+ * that pulling it into a shared module would be more code than it
+ * saves.
+ */
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let idx = 0;
+  while (value >= 1000 && idx < units.length - 1) {
+    value /= 1000;
+    idx += 1;
+  }
+  const digits = idx === 0 || value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(digits)} ${units[idx]}`;
+}
+
+/**
+ * Apply a search filter to a list of children. The filter is
+ * substring-on-display-name, case-insensitive. Returns the input
+ * unchanged when the query is empty so the caller does not have to
+ * re-allocate.
+ *
+ * Exported (named) for unit tests.
+ */
+export function filterTreeChildren(
+  children: SocpakDirEntry[],
+  query: string,
+): SocpakDirEntry[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return children;
+  return children.filter((c) => c.display_name.toLowerCase().includes(q));
+}
+
+/**
+ * Cap on results returned by a global-index search. The full archive
+ * carries ~1700 socpaks and a 1- or 2-letter query can match most of
+ * them; rendering them all is wasteful and would defeat the purpose of
+ * a browser. 200 is enough that any plausible query has its real hits
+ * inside the cap; the user can refine if they hit the cap.
+ */
+export const GLOBAL_INDEX_RESULT_CAP = 200;
+
+/** One row in the flat search-results list. */
+export interface GlobalIndexHit {
+  /** Full p4k path (matches the path the lazy tree leaf would carry). */
+  path: string;
+  /** Trailing path segment, suitable for the row's main label. */
+  display_name: string;
+  /**
+   * Parent directory in display form, e.g.
+   * `PU/loc/mod/pyro/station/...`. Backslashes normalised to forward
+   * slashes; the leading `Data\` prefix is preserved so the user can
+   * tell at a glance where the file lives.
+   */
+  parent_display: string;
+}
+
+/**
+ * Apply a substring search to a flat list of socpak paths. Returns at
+ * most {@link GLOBAL_INDEX_RESULT_CAP} hits. Empty query returns an
+ * empty list (the caller renders the tree in that case).
+ *
+ * Search target is the full path: a query like `pyro` matches any
+ * socpak under a `pyro` directory, even if the filename does not
+ * mention pyro. This is the behaviour the user actually wants -- the
+ * lazy tree's display_name filter only ever matched leaf filenames.
+ *
+ * Exported (named) for unit tests.
+ */
+export function filterGlobalIndex(
+  paths: string[],
+  query: string,
+  cap: number = GLOBAL_INDEX_RESULT_CAP,
+): GlobalIndexHit[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return [];
+  const out: GlobalIndexHit[] = [];
+  for (const path of paths) {
+    if (!path.toLowerCase().includes(q)) continue;
+    out.push(toGlobalIndexHit(path));
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/**
+ * Split a full p4k path into a `display_name` (last segment) and a
+ * `parent_display` (everything before that, with backslashes turned
+ * into forward slashes for legibility). Exported (named) for unit
+ * tests.
+ */
+export function toGlobalIndexHit(path: string): GlobalIndexHit {
+  // Find the last separator (either flavour) so we are correct on
+  // either path style.
+  let cut = -1;
+  for (let i = path.length - 1; i >= 0; i -= 1) {
+    const ch = path[i];
+    if (ch === "\\" || ch === "/") {
+      cut = i;
+      break;
+    }
+  }
+  if (cut < 0) {
+    return { path, display_name: path, parent_display: "" };
+  }
+  const display = path.slice(cut + 1);
+  const parent = path.slice(0, cut).replace(/\\/g, "/");
+  return { path, display_name: display, parent_display: parent };
+}
+
+/**
+ * Pure helper: return a new TreeState with the branch at `path`
+ * patched to `next`. Map mutation in React state is a footgun
+ * (reference equality fails to trigger re-render); this builds a
+ * fresh map each call.
+ *
+ * Exported (named) for unit tests.
+ */
+export function setBranchState(
+  state: TreeState,
+  path: string,
+  next: BranchState,
+): TreeState {
+  const out = new Map(state);
+  out.set(path, next);
+  return out;
+}
+
+interface BranchProps {
+  entry: SocpakDirEntry;
+  depth: number;
+  state: TreeState;
+  setState: (updater: (prev: TreeState) => TreeState) => void;
+  onLeafClick: (entry: SocpakDirEntry) => void;
+  activePath?: string | null;
+}
+
+/**
+ * One row in the tree -- either a directory (with chevron + child
+ * subtree) or a socpak leaf. Recursive: a directory branch renders
+ * one `Branch` per child once expanded.
+ */
+function Branch({
+  entry,
+  depth,
+  state,
+  setState,
+  onLeafClick,
+  activePath,
+}: BranchProps): JSX.Element {
+  const branch = state.get(entry.path);
+
+  const indentStyle = { paddingLeft: `${depth * 12 + 8}px` };
+
+  // Socpak leaf: clickable, optionally highlighted as the active load.
+  if (entry.kind === "socpak_file") {
+    const isActive = activePath === entry.path;
+    return (
+      <div
+        onClick={() => onLeafClick(entry)}
+        style={indentStyle}
+        className={`
+          group flex items-center gap-1.5 pr-3 py-1 text-xs cursor-pointer
+          transition-colors border-l-2
+          ${
+            isActive
+              ? "bg-primary/10 text-text border-l-accent"
+              : "text-text-sub hover:bg-surface/40 border-l-transparent"
+          }
+        `}
+        title={entry.path}
+      >
+        <Box size={12} strokeWidth={1.75} className="text-text-faint shrink-0" />
+        <span className="flex-1 min-w-0 truncate">{entry.display_name}</span>
+        <span className="shrink-0 text-[10px] text-text-faint tabular-nums">
+          {formatBytes(entry.size_or_count)}
+        </span>
+      </div>
+    );
+  }
+
+  // Directory branch.
+  const expanded = branch?.expanded ?? false;
+  const status = branch?.status;
+
+  const toggle = useCallback(async () => {
+    const current = state.get(entry.path);
+    if (current?.expanded) {
+      // Collapse -- preserve children for instant re-expand.
+      setState((prev) => setBranchState(prev, entry.path, {
+        ...(prev.get(entry.path) ?? { status: "loaded", expanded: true }),
+        expanded: false,
+      }));
+      return;
+    }
+    if (current?.status === "loaded" && current.children !== undefined) {
+      // Already loaded -- just flip the expanded flag.
+      setState((prev) => setBranchState(prev, entry.path, {
+        ...current,
+        expanded: true,
+      }));
+      return;
+    }
+    // Cold expand: fetch children.
+    setState((prev) => setBranchState(prev, entry.path, {
+      status: "loading",
+      expanded: true,
+    }));
+    try {
+      const children = await listSocpakDir(entry.path);
+      setState((prev) => setBranchState(prev, entry.path, {
+        status: "loaded",
+        expanded: true,
+        children,
+      }));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setState((prev) => setBranchState(prev, entry.path, {
+        status: "error",
+        expanded: true,
+        error: msg,
+      }));
+    }
+  }, [entry.path, state, setState]);
+
+  const retry = useCallback(async () => {
+    setState((prev) => setBranchState(prev, entry.path, {
+      status: "loading",
+      expanded: true,
+    }));
+    try {
+      const children = await listSocpakDir(entry.path);
+      setState((prev) => setBranchState(prev, entry.path, {
+        status: "loaded",
+        expanded: true,
+        children,
+      }));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setState((prev) => setBranchState(prev, entry.path, {
+        status: "error",
+        expanded: true,
+        error: msg,
+      }));
+    }
+  }, [entry.path, setState]);
+
+  return (
+    <>
+      <div
+        onClick={toggle}
+        style={indentStyle}
+        className="group flex items-center gap-1.5 pr-3 py-1 text-xs cursor-pointer transition-colors text-text-sub hover:bg-surface/40 border-l-2 border-l-transparent select-none"
+        title={entry.path}
+      >
+        <ChevronRight
+          size={12}
+          strokeWidth={1.75}
+          className={`shrink-0 text-text-faint transition-transform ${expanded ? "rotate-90" : ""}`}
+        />
+        <Folder size={12} strokeWidth={1.75} className="text-text-faint shrink-0" />
+        <span className="flex-1 min-w-0 truncate">{entry.display_name}</span>
+        {status === "loading" && (
+          <Loader2
+            size={12}
+            strokeWidth={1.75}
+            className="shrink-0 text-text-faint animate-spin"
+          />
+        )}
+        {status === "error" && (
+          <AlertCircle
+            size={12}
+            strokeWidth={1.75}
+            className="shrink-0 text-warning"
+          />
+        )}
+        {entry.size_or_count > 0 && (
+          <span className="shrink-0 text-[10px] text-text-faint tabular-nums">
+            {entry.size_or_count}
+          </span>
+        )}
+      </div>
+      {expanded && status === "error" && (
+        <div
+          style={{ paddingLeft: `${(depth + 1) * 12 + 8}px` }}
+          className="py-1 pr-3 text-[11px] text-warning flex items-center gap-2"
+        >
+          <span className="flex-1 min-w-0 break-words font-mono text-[10px]">
+            {branch?.error ?? "unknown error"}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              void retry();
+            }}
+            className="shrink-0 px-2 py-0.5 rounded bg-surface hover:bg-surface-hi text-text-sub hover:text-text text-[10px]"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {expanded && status === "loaded" && branch?.children !== undefined && (
+        <>
+          {branch.children.length === 0 && (
+            <div
+              style={{ paddingLeft: `${(depth + 1) * 12 + 8}px` }}
+              className="py-1 pr-3 text-[10px] text-text-faint italic"
+            >
+              empty
+            </div>
+          )}
+          {branch.children.map((child) => (
+            <Branch
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              state={state}
+              setState={setState}
+              onLeafClick={onLeafClick}
+              activePath={activePath}
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+}
+
+/**
+ * Lazy socpak directory tree. Loads the root prefix on mount; each
+ * directory branch fetches its own children on click. Children are
+ * cached per branch path so collapse/re-expand is instant.
+ *
+ * Search semantics depend on whether `globalIndex` is populated:
+ *
+ * - **Global-index mode** (search non-empty AND `globalIndex != null`):
+ *   the tree is hidden and a flat list of matches against the global
+ *   path index is rendered instead. Matches anywhere in the path
+ *   (`pyro`, `hangar`, etc.), capped at 200 entries. Clicking a hit
+ *   loads that scene exactly the same way a tree-leaf click would.
+ *   The tree's expanded state is preserved underneath, so clearing
+ *   the search restores the user's prior navigation.
+ * - **Tree mode** (search empty, OR `globalIndex == null`): the lazy
+ *   tree drives the view. Search input filters the immediate
+ *   top-level children by display name as before -- handy for
+ *   narrowing the root list while the global index is still
+ *   loading.
+ *
+ * When the index is still loading and the user types, the empty-state
+ * message reads "Indexing... results will appear when ready." rather
+ * than the misleading "no visible branches match" string.
+ */
+export function SocpakTree({
+  rootPrefix,
+  onLeafClick,
+  activePath,
+  globalIndex,
+}: SocpakTreeProps): JSX.Element {
+  const [state, setState] = useState<TreeState>(() => new Map());
+  const [rootChildren, setRootChildren] = useState<SocpakDirEntry[] | null>(null);
+  const [rootStatus, setRootStatus] = useState<"loading" | "loaded" | "error">(
+    "loading",
+  );
+  const [rootError, setRootError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  const loadRoot = useCallback(async () => {
+    setRootStatus("loading");
+    setRootError(null);
+    try {
+      const children = await listSocpakDir(rootPrefix);
+      setRootChildren(children);
+      setRootStatus("loaded");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setRootError(msg);
+      setRootStatus("error");
+    }
+  }, [rootPrefix]);
+
+  useEffect(() => {
+    void loadRoot();
+  }, [loadRoot]);
+
+  const trimmedSearch = search.trim();
+  const inSearchMode = trimmedSearch.length > 0;
+  // When search is non-empty AND the index has landed, switch to the
+  // flat global-index view. Otherwise we fall back to the legacy
+  // "filter visible branches" behaviour against the loaded root.
+  const useGlobalIndex = inSearchMode && globalIndex != null;
+  const globalHits = useGlobalIndex
+    ? filterGlobalIndex(globalIndex!, trimmedSearch)
+    : [];
+  const visibleChildren =
+    rootChildren && !useGlobalIndex
+      ? filterTreeChildren(rootChildren, search)
+      : [];
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="px-3 py-2 border-b border-border/60 flex items-center gap-2 shrink-0">
+        <input
+          type="text"
+          placeholder={
+            globalIndex != null ? "Search all socpaks..." : "Filter visible branches..."
+          }
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 bg-transparent outline-none text-sm text-text placeholder:text-text-faint"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {/* Global-index search mode. */}
+        {useGlobalIndex && globalHits.length === 0 && (
+          <div className="px-4 py-6 text-xs text-text-dim leading-relaxed">
+            No socpaks match.
+          </div>
+        )}
+        {useGlobalIndex && globalHits.length > 0 && (
+          <>
+            {globalHits.length >= GLOBAL_INDEX_RESULT_CAP && (
+              <div className="px-3 py-1.5 text-[10px] text-text-faint border-b border-border/60">
+                Showing first {GLOBAL_INDEX_RESULT_CAP} hits. Refine the
+                query to narrow.
+              </div>
+            )}
+            {globalHits.map((hit) => {
+              const isActive = activePath === hit.path;
+              return (
+                <div
+                  key={hit.path}
+                  onClick={() =>
+                    onLeafClick({
+                      path: hit.path,
+                      display_name: hit.display_name,
+                      kind: "socpak_file",
+                      size_or_count: 0,
+                    })
+                  }
+                  className={`
+                    flex items-start gap-1.5 px-3 py-1.5 text-xs cursor-pointer
+                    transition-colors border-l-2
+                    ${
+                      isActive
+                        ? "bg-primary/10 text-text border-l-accent"
+                        : "text-text-sub hover:bg-surface/40 border-l-transparent"
+                    }
+                  `}
+                  title={hit.path}
+                >
+                  <Box
+                    size={12}
+                    strokeWidth={1.75}
+                    className="text-text-faint shrink-0 mt-0.5"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="truncate">{hit.display_name}</div>
+                    {hit.parent_display.length > 0 && (
+                      <div className="truncate text-[10px] text-text-faint">
+                        in {hit.parent_display}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </>
+        )}
+
+        {/* Tree mode. */}
+        {!useGlobalIndex && rootStatus === "loading" && (
+          <div className="px-4 py-6 text-xs text-text-dim flex items-center gap-2">
+            <Loader2 size={14} strokeWidth={1.75} className="animate-spin" />
+            <span>Listing {rootPrefix}...</span>
+          </div>
+        )}
+        {!useGlobalIndex && rootStatus === "error" && (
+          <div className="px-4 py-3 text-[11px] text-warning leading-snug border-b border-border/60">
+            <div className="flex items-center gap-1.5 mb-1">
+              <AlertCircle size={12} strokeWidth={1.75} />
+              <span>Failed to list {rootPrefix}</span>
+            </div>
+            <div className="text-text-faint break-words font-mono text-[10px] mb-2">
+              {rootError}
+            </div>
+            <button
+              onClick={() => void loadRoot()}
+              className="px-2 py-0.5 rounded bg-surface hover:bg-surface-hi text-text-sub hover:text-text text-[10px]"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {!useGlobalIndex &&
+          rootStatus === "loaded" &&
+          visibleChildren.length === 0 && (
+            <div className="px-4 py-6 text-xs text-text-dim leading-relaxed">
+              {inSearchMode && globalIndex == null
+                ? "Indexing... results will appear when ready."
+                : inSearchMode
+                  ? "No visible branches match the filter."
+                  : "Empty directory."}
+            </div>
+          )}
+        {!useGlobalIndex &&
+          rootStatus === "loaded" &&
+          visibleChildren.map((entry) => (
+            <Branch
+              key={entry.path}
+              entry={entry}
+              depth={0}
+              state={state}
+              setState={setState}
+              onLeafClick={onLeafClick}
+              activePath={activePath}
+            />
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/viewer-toolbar.tsx
+++ b/app/src/components/viewer-toolbar.tsx
@@ -1,0 +1,77 @@
+// Top-right strip of controls overlaid on the 3D viewer pane. Both the
+// Ships and the Maps surfaces render this same strip so future controls
+// land in one place. The Ships surface plugs its livery dropdown into
+// `leadingSlot`; everything else is shared.
+
+import { type ReactNode } from "react";
+import { ProjectionModePicker } from "./projection-mode-picker";
+import {
+  SettingsPanel,
+  type ViewerSettings,
+  type ViewerSurfaceKind,
+} from "./settings-panel";
+import { HelpPanel } from "./help-panel";
+import {
+  RENDER_STYLES,
+  type RenderStyle,
+} from "../lib/render-styles";
+import type { FlightCamHandle } from "../lib/flight-camera";
+
+export interface ViewerToolbarProps {
+  flightCamHandle: FlightCamHandle | null;
+  renderStyle: RenderStyle;
+  onRenderStyleChange: (style: RenderStyle) => void;
+  settings: ViewerSettings;
+  onSettingsChange: (patch: Partial<ViewerSettings>) => void;
+  kind: ViewerSurfaceKind;
+  /** Optional element rendered between the projection picker and the
+   *  style dropdown. The Ships surface uses this slot for the per-ship
+   *  livery picker (which only renders when paint variants exist). */
+  leadingSlot?: ReactNode;
+}
+
+export function ViewerToolbar({
+  flightCamHandle,
+  renderStyle,
+  onRenderStyleChange,
+  settings,
+  onSettingsChange,
+  kind,
+  leadingSlot,
+}: ViewerToolbarProps) {
+  return (
+    <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+      <ProjectionModePicker handle={flightCamHandle} embedded />
+      {leadingSlot}
+      <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
+        <span className="text-text-faint">Style</span>
+        <select
+          value={renderStyle}
+          // Blur after selection so arrow keys go back to orbiting
+          // the camera instead of cycling the dropdown options.
+          onChange={(e) => {
+            onRenderStyleChange(e.target.value as RenderStyle);
+            e.currentTarget.blur();
+          }}
+          className="bg-transparent outline-none text-text cursor-pointer"
+        >
+          {RENDER_STYLES.map((opt) => (
+            <option
+              key={opt.value}
+              value={opt.value}
+              className="bg-bg-alt text-text"
+            >
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <SettingsPanel
+        settings={settings}
+        onChange={onSettingsChange}
+        kind={kind}
+      />
+      <HelpPanel kind={kind} />
+    </div>
+  );
+}

--- a/app/src/lib/__tests__/flight-camera.test.ts
+++ b/app/src/lib/__tests__/flight-camera.test.ts
@@ -1,0 +1,550 @@
+// Pure-math coverage for the flight-camera helpers. The hook itself is
+// excluded - it talks to a live renderer and DOM, neither of which are
+// healthy to spin up in a Vitest unit run. The math below is the load-
+// bearing logic the hook depends on; if these are right, the hook only
+// has DOM wiring to get wrong.
+
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  adjustMoveSpeed,
+  advanceState,
+  applyOrbitAroundTarget,
+  applyOrbitFromTarget,
+  clampFov,
+  FOV_MAX,
+  FOV_MIN,
+  getCameraDirections,
+  rotateCameraLocal,
+  SPEED_MAX,
+  SPEED_MIN,
+  SPEED_STEP,
+  syncOrbitTargetToView,
+  type FlightCamState,
+} from "../flight-camera";
+
+const EPS = 1e-6;
+
+function vecCloseTo(a: THREE.Vector3, b: THREE.Vector3, eps = EPS): void {
+  expect(a.x).toBeCloseTo(b.x, 5);
+  expect(a.y).toBeCloseTo(b.y, 5);
+  expect(a.z).toBeCloseTo(b.z, 5);
+  void eps;
+}
+
+function makeState(overrides: Partial<FlightCamState> = {}): FlightCamState {
+  return {
+    pos: new THREE.Vector3(0, 0, 0),
+    quat: new THREE.Quaternion(),
+    orbitDist: 10,
+    moveSpeed: 1.0,
+    fov: 60,
+    projectionMode: "perspective",
+    ...overrides,
+  };
+}
+
+describe("getCameraDirections", () => {
+  it("returns orthonormal fwd/right/up for identity quat", () => {
+    const dirs = getCameraDirections(new THREE.Quaternion());
+    vecCloseTo(dirs.fwd, new THREE.Vector3(0, 0, -1));
+    vecCloseTo(dirs.right, new THREE.Vector3(1, 0, 0));
+    vecCloseTo(dirs.up, new THREE.Vector3(0, 1, 0));
+
+    // Pairwise orthogonal
+    expect(dirs.fwd.dot(dirs.right)).toBeCloseTo(0, 5);
+    expect(dirs.fwd.dot(dirs.up)).toBeCloseTo(0, 5);
+    expect(dirs.right.dot(dirs.up)).toBeCloseTo(0, 5);
+
+    // Unit length
+    expect(dirs.fwd.length()).toBeCloseTo(1, 5);
+    expect(dirs.right.length()).toBeCloseTo(1, 5);
+    expect(dirs.up.length()).toBeCloseTo(1, 5);
+  });
+
+  it("rotates fwd/right consistently for a +90deg yaw quat", () => {
+    // Three.js is right-handed: rotating about +Y by +90deg maps
+    //   (1,0,0) -> (0,0,-1)
+    //   (0,0,-1) -> (-1,0,0)
+    // So the fwd vector swings to old -right (i.e. -X), and right swings
+    // to old fwd (-Z). Up is unchanged.
+    const yaw = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 2,
+    );
+    const dirs = getCameraDirections(yaw);
+    vecCloseTo(dirs.fwd, new THREE.Vector3(-1, 0, 0));
+    vecCloseTo(dirs.right, new THREE.Vector3(0, 0, -1));
+    vecCloseTo(dirs.up, new THREE.Vector3(0, 1, 0));
+  });
+
+  it("yaws fwd to +X for a -90deg yaw quat", () => {
+    // Symmetric of the above with negated angle: fwd (-Z) goes to +X.
+    const yaw = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      -Math.PI / 2,
+    );
+    const dirs = getCameraDirections(yaw);
+    vecCloseTo(dirs.fwd, new THREE.Vector3(1, 0, 0));
+  });
+});
+
+describe("rotateCameraLocal", () => {
+  it("returns an identity-equivalent quat when all deltas are zero", () => {
+    const q0 = new THREE.Quaternion(0.1, 0.2, 0.3, 0.9).normalize();
+    const q1 = rotateCameraLocal(q0, 0, 0, 0);
+    expect(q1.x).toBeCloseTo(q0.x, 5);
+    expect(q1.y).toBeCloseTo(q0.y, 5);
+    expect(q1.z).toBeCloseTo(q0.z, 5);
+    expect(q1.w).toBeCloseTo(q0.w, 5);
+  });
+
+  it("does not mutate the input quaternion", () => {
+    const q0 = new THREE.Quaternion();
+    const before = q0.clone();
+    rotateCameraLocal(q0, 0.5, 0.5, 0.5);
+    expect(q0.equals(before)).toBe(true);
+  });
+
+  it("is order-dependent: yaw-then-pitch != pitch-then-yaw", () => {
+    const id = new THREE.Quaternion();
+
+    const yawFirst = rotateCameraLocal(id, 0, Math.PI / 2, 0);
+    const yawThenPitch = rotateCameraLocal(yawFirst, Math.PI / 2, 0, 0);
+    const fwdA = new THREE.Vector3(0, 0, -1).applyQuaternion(yawThenPitch);
+
+    const pitchFirst = rotateCameraLocal(id, Math.PI / 2, 0, 0);
+    const pitchThenYaw = rotateCameraLocal(pitchFirst, 0, Math.PI / 2, 0);
+    const fwdB = new THREE.Vector3(0, 0, -1).applyQuaternion(pitchThenYaw);
+
+    // The two orderings should produce visibly different final forwards.
+    const diff = fwdA.distanceTo(fwdB);
+    expect(diff).toBeGreaterThan(0.5);
+  });
+
+  it("rotates fwd correctly for a single-axis yaw applied to identity", () => {
+    // +Y rotation by +90deg in a right-handed system takes fwd (-Z) to -X.
+    const q = rotateCameraLocal(new THREE.Quaternion(), 0, Math.PI / 2, 0);
+    const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(q);
+    vecCloseTo(fwd, new THREE.Vector3(-1, 0, 0));
+  });
+
+  it("rotates fwd correctly for a single-axis pitch applied to identity", () => {
+    // Positive pitch rotates about local +X, which tilts -Z (fwd) toward +Y (up).
+    // Wait: rotating (0,0,-1) about (+1,0,0) by +90deg: right-hand rule, thumb
+    // along +X, fingers curl from +Y to +Z. So +Y -> +Z, -Z -> +Y. Therefore
+    // fwd (-Z) goes to +Y.
+    const q = rotateCameraLocal(new THREE.Quaternion(), Math.PI / 2, 0, 0);
+    const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(q);
+    vecCloseTo(fwd, new THREE.Vector3(0, 1, 0));
+  });
+});
+
+describe("applyOrbitFromTarget", () => {
+  it("places camera at target - fwd * orbitDist for identity quat", () => {
+    const state = makeState({ orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = applyOrbitFromTarget(state, target);
+    // fwd = -Z, so pos = target - (-Z)*10 = +Z*10.
+    vecCloseTo(out.pos, new THREE.Vector3(0, 0, 10));
+  });
+
+  it("places camera correctly for a non-zero target and a yawed quat", () => {
+    const yaw = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 2,
+    );
+    const state = makeState({ orbitDist: 5, quat: yaw });
+    const target = new THREE.Vector3(10, 20, 30);
+    const out = applyOrbitFromTarget(state, target);
+    // fwd after +PI/2 yaw = -X (right-handed). pos = target - fwd*orbitDist
+    // = (10,20,30) - (-X)*5 = (10,20,30) + (5,0,0) = (15,20,30).
+    vecCloseTo(out.pos, new THREE.Vector3(15, 20, 30));
+  });
+
+  it("does not mutate the input state.pos or the orbitTarget", () => {
+    const state = makeState();
+    const posBefore = state.pos.clone();
+    const target = new THREE.Vector3(1, 2, 3);
+    const targetBefore = target.clone();
+    applyOrbitFromTarget(state, target);
+    expect(state.pos.equals(posBefore)).toBe(true);
+    expect(target.equals(targetBefore)).toBe(true);
+  });
+});
+
+describe("clampFov", () => {
+  it("clamps below FOV_MIN", () => {
+    expect(clampFov(5)).toBe(FOV_MIN);
+    expect(clampFov(-100)).toBe(FOV_MIN);
+    expect(clampFov(0)).toBe(FOV_MIN);
+  });
+
+  it("clamps above FOV_MAX", () => {
+    expect(clampFov(200)).toBe(FOV_MAX);
+    expect(clampFov(121)).toBe(FOV_MAX);
+  });
+
+  it("passes values in [FOV_MIN, FOV_MAX] unchanged", () => {
+    expect(clampFov(FOV_MIN)).toBe(FOV_MIN);
+    expect(clampFov(FOV_MAX)).toBe(FOV_MAX);
+    expect(clampFov(60)).toBe(60);
+    expect(clampFov(45)).toBe(45);
+  });
+});
+
+describe("adjustMoveSpeed", () => {
+  it("increases on negative deltaY", () => {
+    expect(adjustMoveSpeed(1.0, -100)).toBeCloseTo(1.0 * SPEED_STEP, 5);
+    expect(adjustMoveSpeed(2.0, -1)).toBeCloseTo(2.0 * SPEED_STEP, 5);
+  });
+
+  it("decreases on positive deltaY", () => {
+    expect(adjustMoveSpeed(1.0, 100)).toBeCloseTo(1.0 / SPEED_STEP, 5);
+    expect(adjustMoveSpeed(2.0, 1)).toBeCloseTo(2.0 / SPEED_STEP, 5);
+  });
+
+  it("clamps at SPEED_MIN on the way down", () => {
+    let s = SPEED_MIN;
+    for (let i = 0; i < 20; i++) s = adjustMoveSpeed(s, 1);
+    expect(s).toBe(SPEED_MIN);
+  });
+
+  it("clamps at SPEED_MAX on the way up", () => {
+    let s = SPEED_MAX;
+    for (let i = 0; i < 20; i++) s = adjustMoveSpeed(s, -1);
+    expect(s).toBe(SPEED_MAX);
+  });
+
+  it("is geometric (factor SPEED_STEP), not additive", () => {
+    // Magnitude of deltaY does not matter, only sign.
+    expect(adjustMoveSpeed(1.0, -1)).toBeCloseTo(adjustMoveSpeed(1.0, -10000), 5);
+    expect(adjustMoveSpeed(1.0, 1)).toBeCloseTo(adjustMoveSpeed(1.0, 10000), 5);
+    // A "factor 1.15" check: ratio is exactly SPEED_STEP irrespective of input.
+    const s1 = adjustMoveSpeed(0.5, -100);
+    expect(s1 / 0.5).toBeCloseTo(SPEED_STEP, 5);
+    const s2 = adjustMoveSpeed(8.0, -100);
+    expect(s2 / 8.0).toBeCloseTo(SPEED_STEP, 5);
+  });
+
+  it("returns current unchanged for deltaY === 0", () => {
+    expect(adjustMoveSpeed(1.5, 0)).toBe(1.5);
+  });
+});
+
+describe("advanceState", () => {
+  it("does nothing when no keys are held", () => {
+    const state = makeState();
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set());
+    vecCloseTo(out.state.pos, state.pos);
+    vecCloseTo(out.orbitTarget, target);
+    expect(out.state.quat.equals(state.quat)).toBe(true);
+    expect(out.state.orbitDist).toBe(state.orbitDist);
+  });
+
+  it("advances pos along fwd for KeyW", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["KeyW"]));
+    // fwd = -Z, pan = 0.5 * 1.0, so pos = (0, 0, -0.5).
+    vecCloseTo(out.state.pos, new THREE.Vector3(0, 0, -0.5));
+    // orbitTarget tracks the camera.
+    vecCloseTo(out.orbitTarget, new THREE.Vector3(0, 0, -0.5));
+  });
+
+  it("advances pos along -fwd for KeyS", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["KeyS"]));
+    vecCloseTo(out.state.pos, new THREE.Vector3(0, 0, 0.5));
+  });
+
+  it("strafes along right for KeyD and -right for KeyA", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const right = advanceState(state, target, new Set(["KeyD"]));
+    vecCloseTo(right.state.pos, new THREE.Vector3(0.5, 0, 0));
+    const left = advanceState(state, target, new Set(["KeyA"]));
+    vecCloseTo(left.state.pos, new THREE.Vector3(-0.5, 0, 0));
+  });
+
+  it("rises for KeyE and falls for KeyQ", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const e = advanceState(state, target, new Set(["KeyE"]));
+    vecCloseTo(e.state.pos, new THREE.Vector3(0, 0.5, 0));
+    const q = advanceState(state, target, new Set(["KeyQ"]));
+    vecCloseTo(q.state.pos, new THREE.Vector3(0, -0.5, 0));
+  });
+
+  it("composes WASDQE: holding W and D advances along fwd + right", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["KeyW", "KeyD"]));
+    // fwd*0.5 + right*0.5 = (0.5, 0, -0.5).
+    vecCloseTo(out.state.pos, new THREE.Vector3(0.5, 0, -0.5));
+    vecCloseTo(out.orbitTarget, new THREE.Vector3(0.5, 0, -0.5));
+  });
+
+  it("scales translation step with moveSpeed", () => {
+    const state = makeState({ moveSpeed: 2.5 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["KeyW"]));
+    vecCloseTo(out.state.pos, new THREE.Vector3(0, 0, -1.25));
+  });
+
+  it("rotates quat for IJKL and changes fwd accordingly", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const before = new THREE.Vector3(0, 0, -1).applyQuaternion(state.quat);
+    const out = advanceState(state, target, new Set(["KeyJ"])); // yaw left
+    const after = new THREE.Vector3(0, 0, -1).applyQuaternion(out.state.quat);
+    // The forward should have rotated, so the two should differ noticeably.
+    expect(before.distanceTo(after)).toBeGreaterThan(0);
+    // Pos should be unchanged (no translation key held).
+    vecCloseTo(out.state.pos, state.pos);
+  });
+
+  it("BracketRight dollies in, shrinks orbitDist, clamps at 1", () => {
+    const state = makeState({ orbitDist: 1.2, moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["BracketRight"]));
+    // pan = 0.5; orbitDist = max(1, 1.2 - 0.5) = max(1, 0.7) = 1.
+    expect(out.state.orbitDist).toBe(1);
+    // pos moves along fwd by 0.5: (0, 0, -0.5).
+    vecCloseTo(out.state.pos, new THREE.Vector3(0, 0, -0.5));
+  });
+
+  it("BracketLeft dollies out, grows orbitDist", () => {
+    const state = makeState({ orbitDist: 10, moveSpeed: 1.0 });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = advanceState(state, target, new Set(["BracketLeft"]));
+    expect(out.state.orbitDist).toBeCloseTo(10.5, 5);
+    // pos moves along -fwd by 0.5: (0, 0, +0.5).
+    vecCloseTo(out.state.pos, new THREE.Vector3(0, 0, 0.5));
+  });
+
+  it("returns a NEW state object, leaving the input untouched", () => {
+    const state = makeState({ moveSpeed: 1.0 });
+    const posBefore = state.pos.clone();
+    const target = new THREE.Vector3(0, 0, 0);
+    const targetBefore = target.clone();
+    advanceState(state, target, new Set(["KeyW", "KeyD"]));
+    expect(state.pos.equals(posBefore)).toBe(true);
+    expect(target.equals(targetBefore)).toBe(true);
+  });
+});
+
+describe("syncOrbitTargetToView", () => {
+  it("returns pos + fwd*orbitDist for identity quat", () => {
+    const pos = new THREE.Vector3(0, 0, 0);
+    const quat = new THREE.Quaternion();
+    const out = syncOrbitTargetToView(pos, quat, 10);
+    // fwd = -Z, so target = (0, 0, 0) + (-Z)*10 = (0, 0, -10).
+    vecCloseTo(out, new THREE.Vector3(0, 0, -10));
+  });
+
+  it("moves target to the new fwd direction after a yaw", () => {
+    const pos = new THREE.Vector3(0, 0, 0);
+    // +90deg yaw: fwd swings from -Z to -X.
+    const quat = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 2,
+    );
+    const out = syncOrbitTargetToView(pos, quat, 5);
+    // target = pos + fwd*orbitDist = (0,0,0) + (-1,0,0)*5 = (-5, 0, 0).
+    vecCloseTo(out, new THREE.Vector3(-5, 0, 0));
+  });
+
+  it("does not mutate the input pos or quat", () => {
+    const pos = new THREE.Vector3(1, 2, 3);
+    const posBefore = pos.clone();
+    const quat = new THREE.Quaternion(0.1, 0.2, 0.3, 0.9).normalize();
+    const quatBefore = quat.clone();
+    syncOrbitTargetToView(pos, quat, 7);
+    expect(pos.equals(posBefore)).toBe(true);
+    expect(quat.equals(quatBefore)).toBe(true);
+  });
+
+  it("places target at distance orbitDist from pos along fwd", () => {
+    // Property: || target - pos || == orbitDist for any quat.
+    const quat = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(1, 1, 0).normalize(),
+      0.7,
+    );
+    const pos = new THREE.Vector3(4, -2, 9);
+    const dist = 12.5;
+    const target = syncOrbitTargetToView(pos, quat, dist);
+    expect(target.distanceTo(pos)).toBeCloseTo(dist, 5);
+  });
+});
+
+describe("applyOrbitAroundTarget", () => {
+  it("places camera at orbitTarget - fwd*orbitDist for identity quat", () => {
+    const state = makeState({
+      pos: new THREE.Vector3(99, 99, 99), // start somewhere arbitrary
+      orbitDist: 10,
+    });
+    const target = new THREE.Vector3(0, 0, 0);
+    const out = applyOrbitAroundTarget(state, target);
+    // fwd = -Z, so pos = target - fwd*10 = (0,0,0) - (0,0,-10) = (0,0,10).
+    vecCloseTo(out.pos, new THREE.Vector3(0, 0, 10));
+  });
+
+  it("places camera at distance orbitDist from target after yaw", () => {
+    // Property: after rotating quat, pos must still sit at orbitDist from
+    // target along the new fwd.
+    const yaw = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 2,
+    );
+    const state = makeState({ orbitDist: 8, quat: yaw });
+    const target = new THREE.Vector3(10, 0, 0);
+    const out = applyOrbitAroundTarget(state, target);
+    expect(out.pos.distanceTo(target)).toBeCloseTo(8, 5);
+    // After +90deg yaw, fwd = -X. pos = target - fwd*8 = (10,0,0) - (-8,0,0) = (18,0,0).
+    vecCloseTo(out.pos, new THREE.Vector3(18, 0, 0));
+  });
+
+  it("does not mutate the input state.pos / state.quat / orbitTarget", () => {
+    const state = makeState({ pos: new THREE.Vector3(1, 2, 3) });
+    const posBefore = state.pos.clone();
+    const quatBefore = state.quat.clone();
+    const target = new THREE.Vector3(5, 6, 7);
+    const targetBefore = target.clone();
+    applyOrbitAroundTarget(state, target);
+    expect(state.pos.equals(posBefore)).toBe(true);
+    expect(state.quat.equals(quatBefore)).toBe(true);
+    expect(target.equals(targetBefore)).toBe(true);
+  });
+});
+
+describe("advanceState - orbit-target tracking after rotation", () => {
+  it("KeyJ (yaw) moves orbitTarget so it stays at pos + fwd*orbitDist", () => {
+    // Regression test for the original pivot-orb-doesn't-track bug. Yawing
+    // the camera with IJKL must reposition the orb in world space so it
+    // remains screen-centred along the new look direction.
+    const state = makeState({ moveSpeed: 1.0, orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, -10); // initial: pos=origin, fwd=-Z
+    const out = advanceState(state, target, new Set(["KeyJ"]));
+    // After yaw, target should NOT equal the original (0,0,-10).
+    expect(out.orbitTarget.equals(target)).toBe(false);
+    // It must satisfy target == pos + fwd*orbitDist for the new quat.
+    const newFwd = new THREE.Vector3(0, 0, -1).applyQuaternion(out.state.quat);
+    const expected = out.state.pos
+      .clone()
+      .addScaledVector(newFwd, out.state.orbitDist);
+    vecCloseTo(out.orbitTarget, expected);
+  });
+
+  it("KeyI (pitch) updates orbitTarget to track the new fwd", () => {
+    const state = makeState({ moveSpeed: 1.0, orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, -10);
+    const out = advanceState(state, target, new Set(["KeyI"]));
+    // Pitch up (KeyI) tilts fwd from -Z toward +Y, so target should shift.
+    expect(out.orbitTarget.equals(target)).toBe(false);
+    const newFwd = new THREE.Vector3(0, 0, -1).applyQuaternion(out.state.quat);
+    const expected = out.state.pos
+      .clone()
+      .addScaledVector(newFwd, out.state.orbitDist);
+    vecCloseTo(out.orbitTarget, expected);
+  });
+
+  it("KeyW (translation) keeps target tracking pos+fwd*orbitDist", () => {
+    // Pure translation: both pos and target advance together; the
+    // invariant should still hold afterward.
+    const state = makeState({ moveSpeed: 1.0, orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, -10);
+    const out = advanceState(state, target, new Set(["KeyW"]));
+    const newFwd = new THREE.Vector3(0, 0, -1).applyQuaternion(out.state.quat);
+    const expected = out.state.pos
+      .clone()
+      .addScaledVector(newFwd, out.state.orbitDist);
+    vecCloseTo(out.orbitTarget, expected);
+  });
+
+  it("BracketRight (cart in) keeps target tracking pos+fwd*orbitDist", () => {
+    const state = makeState({ moveSpeed: 1.0, orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, -10);
+    const out = advanceState(state, target, new Set(["BracketRight"]));
+    const newFwd = new THREE.Vector3(0, 0, -1).applyQuaternion(out.state.quat);
+    const expected = out.state.pos
+      .clone()
+      .addScaledVector(newFwd, out.state.orbitDist);
+    vecCloseTo(out.orbitTarget, expected);
+    // Sanity: orbitDist shrank.
+    expect(out.state.orbitDist).toBeCloseTo(9.5, 5);
+  });
+});
+
+describe("advanceState - arrow-key orbit", () => {
+  it("ArrowLeft rotates quat AND keeps pos at distance orbitDist from target", () => {
+    const orbitDist = 10;
+    const state = makeState({ moveSpeed: 1.0, orbitDist });
+    // Camera starts at origin looking -Z, target at (0,0,-10).
+    const target = new THREE.Vector3(0, 0, -10);
+    const out = advanceState(state, target, new Set(["ArrowLeft"]));
+    // Quat should have changed (yaw).
+    expect(out.state.quat.equals(state.quat)).toBe(false);
+    // Pos must now sit at orbitDist from target.
+    expect(out.state.pos.distanceTo(out.orbitTarget)).toBeCloseTo(orbitDist, 5);
+    // Target must NOT have moved (orbit-mode invariant).
+    vecCloseTo(out.orbitTarget, target);
+  });
+
+  it("ArrowRight orbits the opposite way; pos moves to a different angle", () => {
+    const orbitDist = 10;
+    const state = makeState({ moveSpeed: 1.0, orbitDist });
+    const target = new THREE.Vector3(0, 0, -10);
+    const left = advanceState(state, target, new Set(["ArrowLeft"]));
+    const right = advanceState(state, target, new Set(["ArrowRight"]));
+    // Both should orbit on the sphere - distance to target == orbitDist.
+    expect(left.state.pos.distanceTo(left.orbitTarget)).toBeCloseTo(orbitDist, 5);
+    expect(right.state.pos.distanceTo(right.orbitTarget)).toBeCloseTo(orbitDist, 5);
+    // And they should land in different places.
+    expect(left.state.pos.distanceTo(right.state.pos)).toBeGreaterThan(0);
+    // Both leave the target untouched.
+    vecCloseTo(left.orbitTarget, target);
+    vecCloseTo(right.orbitTarget, target);
+  });
+
+  it("ArrowUp pitches up; pos sits on the orbit sphere", () => {
+    const orbitDist = 10;
+    const state = makeState({ moveSpeed: 1.0, orbitDist });
+    const target = new THREE.Vector3(0, 0, -10);
+    const out = advanceState(state, target, new Set(["ArrowUp"]));
+    expect(out.state.quat.equals(state.quat)).toBe(false);
+    expect(out.state.pos.distanceTo(out.orbitTarget)).toBeCloseTo(orbitDist, 5);
+    vecCloseTo(out.orbitTarget, target);
+    // ArrowUp = pitch up = -ROT pitch sign convention. Camera was at
+    // origin looking -Z; pitching up should swing pos in +Y/-Z direction
+    // (camera goes "down and behind" the target as it pitches up).
+    // We just sanity-check that y went one direction or the other - the
+    // exact sign is locked in by the ArrowUp = -rot pitch convention.
+    expect(Math.abs(out.state.pos.y)).toBeGreaterThan(0);
+  });
+
+  it("ArrowDown is mirror-image of ArrowUp (pitch down)", () => {
+    const state = makeState({ moveSpeed: 1.0, orbitDist: 10 });
+    const target = new THREE.Vector3(0, 0, -10);
+    const up = advanceState(state, target, new Set(["ArrowUp"]));
+    const down = advanceState(state, target, new Set(["ArrowDown"]));
+    // ArrowUp and ArrowDown should produce mirror-image positions about
+    // the y=0 plane (within numerical tolerance) when starting from
+    // identity quat with target at -Z.
+    expect(up.state.pos.y).toBeCloseTo(-down.state.pos.y, 5);
+  });
+});
+
+describe("constants", () => {
+  it("has SPEED_MIN < SPEED_MAX and SPEED_STEP > 1", () => {
+    expect(SPEED_MIN).toBeLessThan(SPEED_MAX);
+    expect(SPEED_STEP).toBeGreaterThan(1);
+  });
+  it("has FOV_MIN < FOV_MAX in valid camera range", () => {
+    expect(FOV_MIN).toBeGreaterThan(0);
+    expect(FOV_MAX).toBeLessThanOrEqual(180);
+    expect(FOV_MIN).toBeLessThan(FOV_MAX);
+  });
+});

--- a/app/src/lib/__tests__/flight-camera.test.ts
+++ b/app/src/lib/__tests__/flight-camera.test.ts
@@ -12,15 +12,23 @@ import {
   applyOrbitAroundTarget,
   applyOrbitFromTarget,
   clampFov,
+  computeFramingDistance,
+  dispatchViewerHotkey,
   FOV_MAX,
   FOV_MIN,
+  FRAMING_FALLBACK_DISTANCE,
   getCameraDirections,
+  PRESET_FILL_FRACTION,
   rotateCameraLocal,
   SPEED_MAX,
   SPEED_MIN,
   SPEED_STEP,
   syncOrbitTargetToView,
+  viewPresetForKeyCode,
+  viewPresetOffset,
+  type FlightCamHandle,
   type FlightCamState,
+  type ViewPreset,
 } from "../flight-camera";
 
 const EPS = 1e-6;
@@ -546,5 +554,305 @@ describe("constants", () => {
     expect(FOV_MIN).toBeGreaterThan(0);
     expect(FOV_MAX).toBeLessThanOrEqual(180);
     expect(FOV_MIN).toBeLessThan(FOV_MAX);
+  });
+  it("has PRESET_FILL_FRACTION in (0, 1]", () => {
+    expect(PRESET_FILL_FRACTION).toBeGreaterThan(0);
+    expect(PRESET_FILL_FRACTION).toBeLessThanOrEqual(1);
+  });
+  it("has FRAMING_FALLBACK_DISTANCE > 0", () => {
+    expect(FRAMING_FALLBACK_DISTANCE).toBeGreaterThan(0);
+  });
+});
+
+describe("computeFramingDistance", () => {
+  it("frames a 100-unit cube at 45deg FoV / 16:9 / 80% fill at the expected distance", () => {
+    // extent_max = 100. vfov = 45deg. dV = 50 / tan(22.5deg).
+    // hfov  = 2 * atan(tan(22.5deg) * 16/9). dH = 50 / tan(hfov/2).
+    // For aspect > 1, hfov > vfov => tan(hfov/2) > tan(vfov/2) => dH < dV.
+    // So dist = dV / 0.8.
+    const aspect = 16 / 9;
+    const fov = 45;
+    const min = new THREE.Vector3(-50, -50, -50);
+    const max = new THREE.Vector3(50, 50, 50);
+    const d = computeFramingDistance(min, max, fov, aspect, 0.8);
+    const vfov = (fov * Math.PI) / 180;
+    const dV = (100 / 2) / Math.tan(vfov / 2);
+    const expected = dV / 0.8;
+    expect(d).toBeCloseTo(expected, 3);
+    // Sanity: ~150-152 for these inputs.
+    expect(d).toBeGreaterThan(140);
+    expect(d).toBeLessThan(160);
+  });
+
+  it("uses the larger of dV and dH so neither axis crops", () => {
+    // For a tall narrow viewport (aspect < 1), hfov < vfov so dH > dV;
+    // the function should pick dH.
+    const aspect = 0.5;
+    const fov = 60;
+    const min = new THREE.Vector3(-1, -1, -1);
+    const max = new THREE.Vector3(1, 1, 1);
+    const d = computeFramingDistance(min, max, fov, aspect, 1.0);
+    const vfov = (fov * Math.PI) / 180;
+    const hfov = 2 * Math.atan(Math.tan(vfov / 2) * aspect);
+    const dV = 1 / Math.tan(vfov / 2);
+    const dH = 1 / Math.tan(hfov / 2);
+    expect(d).toBeCloseTo(Math.max(dV, dH), 5);
+    expect(d).toBeGreaterThanOrEqual(dV);
+  });
+
+  it("handles a flat panel (one extent == 0) without producing NaN", () => {
+    // Panel: 100 wide in X, 0 thick in Y, 50 deep in Z. extent_max = 100.
+    const min = new THREE.Vector3(-50, 0, -25);
+    const max = new THREE.Vector3(50, 0, 25);
+    const d = computeFramingDistance(min, max, 45, 16 / 9, 0.8);
+    expect(Number.isFinite(d)).toBe(true);
+    expect(d).toBeGreaterThan(0);
+  });
+
+  it("returns the fallback distance when the AABB is degenerate (min == max)", () => {
+    const p = new THREE.Vector3(5, 5, 5);
+    const d = computeFramingDistance(p, p, 45, 16 / 9, 0.8);
+    expect(d).toBe(FRAMING_FALLBACK_DISTANCE);
+  });
+
+  it("treats viewportAspect <= 0 as 1 to avoid singular hfov", () => {
+    const min = new THREE.Vector3(-1, -1, -1);
+    const max = new THREE.Vector3(1, 1, 1);
+    const d = computeFramingDistance(min, max, 45, 0, 0.8);
+    expect(Number.isFinite(d)).toBe(true);
+    expect(d).toBeGreaterThan(0);
+  });
+
+  it("treats fillFraction <= 0 as PRESET_FILL_FRACTION", () => {
+    const min = new THREE.Vector3(-1, -1, -1);
+    const max = new THREE.Vector3(1, 1, 1);
+    const dBad = computeFramingDistance(min, max, 45, 1, 0);
+    const dDefault = computeFramingDistance(min, max, 45, 1, PRESET_FILL_FRACTION);
+    expect(dBad).toBeCloseTo(dDefault, 5);
+  });
+
+  it("scales linearly with the largest extent", () => {
+    const small = computeFramingDistance(
+      new THREE.Vector3(-1, -1, -1),
+      new THREE.Vector3(1, 1, 1),
+      60,
+      1,
+      1,
+    );
+    const big = computeFramingDistance(
+      new THREE.Vector3(-10, -10, -10),
+      new THREE.Vector3(10, 10, 10),
+      60,
+      1,
+      1,
+    );
+    // Same FoV / aspect / fill, just 10x extent => 10x distance.
+    expect(big / small).toBeCloseTo(10, 5);
+  });
+});
+
+describe("viewPresetOffset", () => {
+  it("overhead places camera directly above target on +Y", () => {
+    const off = viewPresetOffset("overhead", 50);
+    expect(off.x).toBeCloseTo(0, 5);
+    expect(off.z).toBeCloseTo(0, 5);
+    expect(off.y).toBeCloseTo(50, 5);
+  });
+
+  it("side places camera along +X at y == 0", () => {
+    const off = viewPresetOffset("side", 30);
+    expect(off.x).toBeCloseTo(30, 5);
+    expect(off.y).toBeCloseTo(0, 5);
+    expect(off.z).toBeCloseTo(0, 5);
+  });
+
+  it("fore places camera along +Z; aft along -Z; mirror image", () => {
+    const fore = viewPresetOffset("fore", 20);
+    const aft = viewPresetOffset("aft", 20);
+    expect(fore.z).toBeCloseTo(20, 5);
+    expect(aft.z).toBeCloseTo(-20, 5);
+    expect(fore.x).toBeCloseTo(0, 5);
+    expect(aft.x).toBeCloseTo(0, 5);
+  });
+
+  it("perspective places camera in +X / +Y / +Z octant at half-distance per axis", () => {
+    const off = viewPresetOffset("perspective", 40);
+    // 3/4 view: each component is dist * 0.5.
+    expect(off.x).toBeCloseTo(20, 5);
+    expect(off.y).toBeCloseTo(20, 5);
+    expect(off.z).toBeCloseTo(20, 5);
+  });
+
+  it("perspective2 differs from perspective by a sign flip on X", () => {
+    const p1 = viewPresetOffset("perspective", 40);
+    const p2 = viewPresetOffset("perspective2", 40);
+    expect(p2.x).toBeCloseTo(-p1.x, 5);
+    // Y and Z stay the same so the camera ends up 90deg around the
+    // vertical axis from the perspective preset.
+    expect(p2.y).toBeCloseTo(p1.y, 5);
+    expect(p2.z).toBeCloseTo(p1.z, 5);
+  });
+
+  it("preserves length close to dist for axial presets", () => {
+    // Axial presets (overhead / side / fore / aft) sit at exactly `dist`
+    // from the origin so the camera-to-target distance == dist.
+    expect(viewPresetOffset("overhead", 17).length()).toBeCloseTo(17, 5);
+    expect(viewPresetOffset("side", 17).length()).toBeCloseTo(17, 5);
+    expect(viewPresetOffset("fore", 17).length()).toBeCloseTo(17, 5);
+    expect(viewPresetOffset("aft", 17).length()).toBeCloseTo(17, 5);
+  });
+});
+
+describe("viewPresetForKeyCode", () => {
+  it("maps Numpad0..5 to the expected presets", () => {
+    expect(viewPresetForKeyCode("Numpad0")).toBe("overhead");
+    expect(viewPresetForKeyCode("Numpad1")).toBe("perspective2");
+    expect(viewPresetForKeyCode("Numpad2")).toBe("side");
+    expect(viewPresetForKeyCode("Numpad3")).toBe("fore");
+    expect(viewPresetForKeyCode("Numpad4")).toBe("aft");
+    expect(viewPresetForKeyCode("Numpad5")).toBe("perspective");
+  });
+
+  it("returns null for unbound codes", () => {
+    expect(viewPresetForKeyCode("KeyR")).toBeNull();
+    expect(viewPresetForKeyCode("KeyH")).toBeNull();
+    expect(viewPresetForKeyCode("Numpad6")).toBeNull();
+    expect(viewPresetForKeyCode("Digit0")).toBeNull();
+    expect(viewPresetForKeyCode("")).toBeNull();
+  });
+});
+
+describe("dispatchViewerHotkey", () => {
+  function makeMockHandle(): {
+    handle: Pick<FlightCamHandle, "resetToScene" | "setView">;
+    resetCalls: THREE.Object3D[];
+    setViewCalls: { preset: ViewPreset; root: THREE.Object3D }[];
+  } {
+    const resetCalls: THREE.Object3D[] = [];
+    const setViewCalls: { preset: ViewPreset; root: THREE.Object3D }[] = [];
+    return {
+      handle: {
+        resetToScene(root) {
+          resetCalls.push(root);
+        },
+        setView(preset, root) {
+          setViewCalls.push({ preset, root });
+        },
+      },
+      resetCalls,
+      setViewCalls,
+    };
+  }
+
+  it("KeyR triggers handle.resetToScene with the provided sceneRoot", () => {
+    const m = makeMockHandle();
+    const root = new THREE.Object3D();
+    let toggled = 0;
+    const handled = dispatchViewerHotkey(
+      { code: "KeyR", repeat: false },
+      m.handle,
+      root,
+      () => { toggled += 1; },
+    );
+    expect(handled).toBe(true);
+    expect(m.resetCalls.length).toBe(1);
+    expect(m.resetCalls[0]).toBe(root);
+    expect(m.setViewCalls.length).toBe(0);
+    expect(toggled).toBe(0);
+  });
+
+  it("KeyR with a null handle is a no-op but still claims the event", () => {
+    const root = new THREE.Object3D();
+    let toggled = 0;
+    const handled = dispatchViewerHotkey(
+      { code: "KeyR", repeat: false },
+      null,
+      root,
+      () => { toggled += 1; },
+    );
+    // Still handled (caller will preventDefault); just nothing to call.
+    expect(handled).toBe(true);
+    expect(toggled).toBe(0);
+  });
+
+  it("KeyH toggles HUD on first press but not on repeat", () => {
+    const m = makeMockHandle();
+    const root = new THREE.Object3D();
+    let toggled = 0;
+    const handled = dispatchViewerHotkey(
+      { code: "KeyH", repeat: false },
+      m.handle,
+      root,
+      () => { toggled += 1; },
+    );
+    expect(handled).toBe(true);
+    expect(toggled).toBe(1);
+
+    // Repeat event must not re-fire the toggle (held H should not strobe).
+    const handled2 = dispatchViewerHotkey(
+      { code: "KeyH", repeat: true },
+      m.handle,
+      root,
+      () => { toggled += 1; },
+    );
+    expect(handled2).toBe(true);
+    expect(toggled).toBe(1);
+  });
+
+  it("Numpad0 triggers handle.setView('overhead', sceneRoot)", () => {
+    const m = makeMockHandle();
+    const root = new THREE.Object3D();
+    const handled = dispatchViewerHotkey(
+      { code: "Numpad0", repeat: false },
+      m.handle,
+      root,
+      () => {},
+    );
+    expect(handled).toBe(true);
+    expect(m.setViewCalls.length).toBe(1);
+    expect(m.setViewCalls[0].preset).toBe("overhead");
+    expect(m.setViewCalls[0].root).toBe(root);
+  });
+
+  it("Numpad presets ignore repeat events", () => {
+    const m = makeMockHandle();
+    const root = new THREE.Object3D();
+    const handled = dispatchViewerHotkey(
+      { code: "Numpad2", repeat: true },
+      m.handle,
+      root,
+      () => {},
+    );
+    expect(handled).toBe(true);
+    expect(m.setViewCalls.length).toBe(0);
+  });
+
+  it("returns false for unbound codes (caller preserves default behaviour)", () => {
+    const m = makeMockHandle();
+    const root = new THREE.Object3D();
+    let toggled = 0;
+    const handled = dispatchViewerHotkey(
+      { code: "KeyZ", repeat: false },
+      m.handle,
+      root,
+      () => { toggled += 1; },
+    );
+    expect(handled).toBe(false);
+    expect(m.resetCalls.length).toBe(0);
+    expect(m.setViewCalls.length).toBe(0);
+    expect(toggled).toBe(0);
+  });
+
+  it("KeyR with null sceneRoot is a no-op but still handled", () => {
+    const m = makeMockHandle();
+    const handled = dispatchViewerHotkey(
+      { code: "KeyR", repeat: false },
+      m.handle,
+      null,
+      () => {},
+    );
+    expect(handled).toBe(true);
+    // No call placed because there is no sceneRoot to frame.
+    expect(m.resetCalls.length).toBe(0);
   });
 });

--- a/app/src/lib/__tests__/flight-camera.test.ts
+++ b/app/src/lib/__tests__/flight-camera.test.ts
@@ -775,7 +775,7 @@ describe("dispatchViewerHotkey", () => {
     expect(toggled).toBe(0);
   });
 
-  it("KeyH toggles HUD on first press but not on repeat", () => {
+  it("KeyH toggles pivot orb on first press but not on repeat", () => {
     const m = makeMockHandle();
     const root = new THREE.Object3D();
     let toggled = 0;

--- a/app/src/lib/__tests__/mobiglas.test.ts
+++ b/app/src/lib/__tests__/mobiglas.test.ts
@@ -1,0 +1,122 @@
+// Coverage for the MobiGlas render-style helpers. Math correctness lives
+// in `blendTowardCyan`; lifecycle correctness lives in the registry +
+// `updateMobiGlasTime`. Both are headless-testable without a live
+// WebGLRenderer, since ShaderMaterial accepts uniform writes outside a
+// render loop.
+
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  blendTowardCyan,
+  clearMobiGlasMaterials,
+  isMobiGlasMaterialRegistered,
+  makeMobiGlasMaterial,
+  updateMobiGlasTime,
+} from "../decomposed-loader";
+
+const TARGET_HUE = 0.52;
+const HUE_BLEND = 0.15;
+const TARGET_SATURATION = 0.7;
+const TARGET_LIGHTNESS = 0.55;
+
+/** Convert (h, s, l) to (r, g, b) using THREE.Color so the expected
+ *  values come from the same conversion path the production code uses. */
+function expectedRgb(h: number): { r: number; g: number; b: number } {
+  const c = new THREE.Color().setHSL(h, TARGET_SATURATION, TARGET_LIGHTNESS);
+  return { r: c.r, g: c.g, b: c.b };
+}
+
+describe("blendTowardCyan", () => {
+  it("biases red toward cyan with the documented hue blend", () => {
+    // Red has h=0, so blendedHue = 0.52 + (0 - 0.52) * 0.15 = 0.442.
+    const { r, g, b } = blendTowardCyan(0xff0000);
+    const blendedHue = TARGET_HUE + (0 - TARGET_HUE) * HUE_BLEND;
+    expect(blendedHue).toBeCloseTo(0.442, 4);
+    const exp = expectedRgb(blendedHue);
+    expect(r).toBeCloseTo(exp.r, 2);
+    expect(g).toBeCloseTo(exp.g, 2);
+    expect(b).toBeCloseTo(exp.b, 2);
+  });
+
+  it("leaves cyan nearly at the target hue", () => {
+    // Cyan has h=0.5, so blendedHue = 0.52 + (0.5 - 0.52) * 0.15 = 0.517.
+    const { r, g, b } = blendTowardCyan(0x00ffff);
+    const blendedHue = TARGET_HUE + (0.5 - TARGET_HUE) * HUE_BLEND;
+    expect(blendedHue).toBeCloseTo(0.517, 4);
+    const exp = expectedRgb(blendedHue);
+    expect(r).toBeCloseTo(exp.r, 3);
+    expect(g).toBeCloseTo(exp.g, 3);
+    expect(b).toBeCloseTo(exp.b, 3);
+  });
+
+  it("returns components in the 0..1 range", () => {
+    const { r, g, b } = blendTowardCyan(0x123456);
+    expect(r).toBeGreaterThanOrEqual(0);
+    expect(r).toBeLessThanOrEqual(1);
+    expect(g).toBeGreaterThanOrEqual(0);
+    expect(g).toBeLessThanOrEqual(1);
+    expect(b).toBeGreaterThanOrEqual(0);
+    expect(b).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("makeMobiGlasMaterial + lifecycle", () => {
+  it("registers the material and ticks its time uniform", () => {
+    clearMobiGlasMaterials();
+    const { material } = makeMobiGlasMaterial(0xff0000);
+    expect(isMobiGlasMaterialRegistered(material)).toBe(true);
+    updateMobiGlasTime(1.5);
+    expect(material.uniforms.time.value).toBe(1.5);
+    clearMobiGlasMaterials();
+  });
+
+  it("stops ticking once unregistered", () => {
+    clearMobiGlasMaterials();
+    const { material, unregister } = makeMobiGlasMaterial(0x00ff00);
+    updateMobiGlasTime(2.0);
+    expect(material.uniforms.time.value).toBe(2.0);
+    unregister();
+    expect(isMobiGlasMaterialRegistered(material)).toBe(false);
+    updateMobiGlasTime(99.0);
+    // Last tick before unregister was 2.0; the uniform must not advance.
+    expect(material.uniforms.time.value).toBe(2.0);
+    clearMobiGlasMaterials();
+  });
+
+  it("clearMobiGlasMaterials drops every registered material", () => {
+    clearMobiGlasMaterials();
+    const a = makeMobiGlasMaterial(0xff0000).material;
+    const b = makeMobiGlasMaterial(0x00ff00).material;
+    expect(isMobiGlasMaterialRegistered(a)).toBe(true);
+    expect(isMobiGlasMaterialRegistered(b)).toBe(true);
+    clearMobiGlasMaterials();
+    expect(isMobiGlasMaterialRegistered(a)).toBe(false);
+    expect(isMobiGlasMaterialRegistered(b)).toBe(false);
+  });
+
+  it("dispose after unregister does not throw", () => {
+    clearMobiGlasMaterials();
+    const { material, unregister } = makeMobiGlasMaterial(0x0000ff);
+    unregister();
+    expect(() => material.dispose()).not.toThrow();
+  });
+
+  it("seeds baseColor uniform from blendTowardCyan", () => {
+    clearMobiGlasMaterials();
+    const input = 0xff0000;
+    const blended = blendTowardCyan(input);
+    const { material } = makeMobiGlasMaterial(input);
+    const uVec = material.uniforms.baseColor.value as THREE.Vector3;
+    expect(uVec.x).toBeCloseTo(blended.r, 5);
+    expect(uVec.y).toBeCloseTo(blended.g, 5);
+    expect(uVec.z).toBeCloseTo(blended.b, 5);
+    clearMobiGlasMaterials();
+  });
+
+  it("seeds time uniform at 0.0", () => {
+    clearMobiGlasMaterials();
+    const { material } = makeMobiGlasMaterial(0xffffff);
+    expect(material.uniforms.time.value).toBe(0.0);
+    clearMobiGlasMaterials();
+  });
+});

--- a/app/src/lib/__tests__/projection-modes.test.ts
+++ b/app/src/lib/__tests__/projection-modes.test.ts
@@ -1,0 +1,172 @@
+// Pure-math coverage for the projection-mode helpers added alongside
+// the flight cam. The hook itself wires these into a live ortho camera
+// + the renderer; that path is integration-only. The math below is the
+// load-bearing piece - if the frustum and shear are right, the hook
+// only has DOM/three-side wiring to get wrong.
+
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  applyObliqueShear,
+  computeOrthoFrustum,
+  nextProjectionMode,
+  obliqueCabinetShear,
+  PROJECTION_MODES,
+  type ProjectionMode,
+} from "../flight-camera";
+
+const EPS = 1e-6;
+
+describe("computeOrthoFrustum", () => {
+  it("returns the canonical frustum for orbitDist=10 and 1920x1080", () => {
+    const f = computeOrthoFrustum(10, 1920, 1080);
+    expect(f.top).toBeCloseTo(5, 6);
+    expect(f.bottom).toBeCloseTo(-5, 6);
+    expect(f.right).toBeCloseTo((5 * 1920) / 1080, 6);
+    expect(f.left).toBeCloseTo((-5 * 1920) / 1080, 6);
+  });
+
+  it("scales linearly with orbitDist", () => {
+    const a = computeOrthoFrustum(10, 1600, 900);
+    const b = computeOrthoFrustum(20, 1600, 900);
+    expect(b.top).toBeCloseTo(a.top * 2, 6);
+    expect(b.right).toBeCloseTo(a.right * 2, 6);
+  });
+
+  it("matches aspect for square viewport", () => {
+    const f = computeOrthoFrustum(10, 800, 800);
+    expect(f.right).toBeCloseTo(5, 6);
+    expect(f.top).toBeCloseTo(5, 6);
+  });
+
+  it("returns a degenerate (zero-size) frustum for orbitDist=0", () => {
+    // Zero is a sentinel - we choose to return zeros rather than crash
+    // or NaN. Three.js will produce a singular projection matrix in this
+    // case; callers are expected to clamp orbitDist if they need a
+    // finite image, but the helper itself stays defined.
+    const f = computeOrthoFrustum(0, 1920, 1080);
+    // Use toBeCloseTo to side-step the +0 / -0 distinction that
+    // toBe checks via Object.is. The value semantics are what matter.
+    expect(f.top).toBeCloseTo(0, 6);
+    expect(f.bottom).toBeCloseTo(0, 6);
+    expect(f.left).toBeCloseTo(0, 6);
+    expect(f.right).toBeCloseTo(0, 6);
+  });
+
+  it("does not produce NaN when viewportHeight is 0", () => {
+    // Falls back to aspect=1 rather than divide-by-zero. A hidden tab or
+    // minimised window can briefly report height 0, and we'd rather keep
+    // a finite (square) frustum on the books than poison the projection
+    // matrix until the next resize.
+    const f = computeOrthoFrustum(10, 1920, 0);
+    expect(Number.isFinite(f.left)).toBe(true);
+    expect(Number.isFinite(f.right)).toBe(true);
+    expect(f.top).toBeCloseTo(5, 6);
+    // aspect = 1, so right == top.
+    expect(f.right).toBeCloseTo(5, 6);
+    expect(f.left).toBeCloseTo(-5, 6);
+  });
+
+  it("does not produce NaN when viewportHeight is negative", () => {
+    // Defensive: negative is nonsense input, but we still don't want a
+    // NaN frustum to leak into Three.js.
+    const f = computeOrthoFrustum(10, 1920, -100);
+    expect(Number.isFinite(f.left)).toBe(true);
+    expect(Number.isFinite(f.right)).toBe(true);
+  });
+});
+
+describe("obliqueCabinetShear", () => {
+  it("encodes 45deg cabinet shear with scale 0.5", () => {
+    const m = obliqueCabinetShear();
+    // Three.js Matrix4 storage is column-major: elements[i + j*4] is
+    // the entry at row i, column j. Shear values land at row 0/1
+    // column 2, which is index 8 (j=2, i=0) and 9 (j=2, i=1).
+    const expectedX = 0.5 * Math.cos(Math.PI / 4);
+    const expectedY = 0.5 * Math.sin(Math.PI / 4);
+    expect(m.elements[8]).toBeCloseTo(expectedX, 6);
+    expect(m.elements[9]).toBeCloseTo(expectedY, 6);
+    // The diagonal stays identity.
+    expect(m.elements[0]).toBeCloseTo(1, 6);
+    expect(m.elements[5]).toBeCloseTo(1, 6);
+    expect(m.elements[10]).toBeCloseTo(1, 6);
+    expect(m.elements[15]).toBeCloseTo(1, 6);
+    // The remaining off-diagonal entries are zero.
+    const zeroIdx = [1, 2, 3, 4, 6, 7, 11, 12, 13, 14];
+    for (const i of zeroIdx) {
+      expect(Math.abs(m.elements[i])).toBeLessThan(EPS);
+    }
+  });
+
+  it("returns a fresh matrix every call", () => {
+    const a = obliqueCabinetShear();
+    const b = obliqueCabinetShear();
+    expect(a).not.toBe(b);
+    a.identity();
+    // Mutating `a` must not affect `b`.
+    expect(b.elements[8]).toBeCloseTo(0.5 * Math.cos(Math.PI / 4), 6);
+  });
+});
+
+describe("applyObliqueShear", () => {
+  it("post-multiplies the shear into the input (this = this * shear)", () => {
+    // Three.js convention: m.multiply(other) is `this = this * other`.
+    // We verify that by starting with identity and confirming the
+    // resulting matrix equals the shear itself.
+    const proj = new THREE.Matrix4().identity();
+    const shear = obliqueCabinetShear();
+    const out = applyObliqueShear(proj, shear);
+    expect(out).toBe(proj);
+    for (let i = 0; i < 16; i += 1) {
+      expect(out.elements[i]).toBeCloseTo(shear.elements[i], 6);
+    }
+  });
+
+  it("does not mutate the shear matrix", () => {
+    const proj = new THREE.Matrix4().makeScale(2, 3, 4);
+    const shear = obliqueCabinetShear();
+    const shearBefore = shear.clone();
+    applyObliqueShear(proj, shear);
+    for (let i = 0; i < 16; i += 1) {
+      expect(shear.elements[i]).toBeCloseTo(shearBefore.elements[i], 6);
+    }
+  });
+
+  it("composes with a non-identity projection (post-multiply order)", () => {
+    // Build a known projection (a scale), apply the shear, and confirm
+    // the result equals scale * shear computed manually. If the helper
+    // accidentally pre-multiplied (this = other * this) the entries
+    // outside row 0/1 col 2 would change.
+    const scale = new THREE.Matrix4().makeScale(2, 3, 4);
+    const shear = obliqueCabinetShear();
+    const expected = scale.clone().multiply(shear);
+    const out = applyObliqueShear(scale, shear);
+    for (let i = 0; i < 16; i += 1) {
+      expect(out.elements[i]).toBeCloseTo(expected.elements[i], 6);
+    }
+  });
+});
+
+describe("nextProjectionMode / cycle", () => {
+  it("advances perspective -> orthographic -> oblique -> perspective", () => {
+    expect(nextProjectionMode("perspective")).toBe("orthographic");
+    expect(nextProjectionMode("orthographic")).toBe("oblique");
+    expect(nextProjectionMode("oblique")).toBe("perspective");
+  });
+
+  it("returns to perspective after three cycles", () => {
+    let m: ProjectionMode = "perspective";
+    m = nextProjectionMode(m);
+    m = nextProjectionMode(m);
+    m = nextProjectionMode(m);
+    expect(m).toBe("perspective");
+  });
+
+  it("PROJECTION_MODES carries all three values exactly once", () => {
+    expect(PROJECTION_MODES).toHaveLength(3);
+    expect(new Set(PROJECTION_MODES).size).toBe(3);
+    expect(PROJECTION_MODES).toContain("perspective");
+    expect(PROJECTION_MODES).toContain("orthographic");
+    expect(PROJECTION_MODES).toContain("oblique");
+  });
+});

--- a/app/src/lib/__tests__/screenshot.test.ts
+++ b/app/src/lib/__tests__/screenshot.test.ts
@@ -1,0 +1,77 @@
+// Pure-helper coverage for the screenshot module. Skips captureScreenshot
+// itself - that path needs a live WebGL context, a DOM, and Tauri APIs,
+// none of which are healthy under Vitest. The math + filename helpers are
+// the load-bearing pieces that govern output framing and naming; if these
+// are right, the live capture path only has Three.js wiring to get wrong.
+
+import { describe, expect, it } from "vitest";
+import {
+  computeScreenshotDimensions,
+  formatScreenshotFilename,
+} from "../screenshot";
+
+describe("computeScreenshotDimensions", () => {
+  it("returns ~10000x5000 for aspect=2.0 and 50 megapixels", () => {
+    const { width, height } = computeScreenshotDimensions(2.0, 50);
+    // Within 1% of 10000x5000.
+    expect(Math.abs(width - 10000)).toBeLessThan(100);
+    expect(Math.abs(height - 5000)).toBeLessThan(50);
+  });
+
+  it("returns ~7071x7071 for aspect=1.0 and 50 megapixels", () => {
+    const { width, height } = computeScreenshotDimensions(1.0, 50);
+    expect(Math.abs(width - 7071)).toBeLessThan(71);
+    expect(Math.abs(height - 7071)).toBeLessThan(71);
+  });
+
+  it("produces ~50M pixels for aspect=16/9 and 50 megapixels", () => {
+    const { width, height } = computeScreenshotDimensions(16 / 9, 50);
+    const total = width * height;
+    // Within 1% of 50,000,000.
+    expect(Math.abs(total - 50_000_000) / 50_000_000).toBeLessThan(0.01);
+  });
+
+  it("preserves the requested aspect ratio within rounding distance", () => {
+    const { width, height } = computeScreenshotDimensions(2.0, 50);
+    expect(Math.abs(width / height - 2.0)).toBeLessThan(0.001);
+  });
+});
+
+describe("formatScreenshotFilename", () => {
+  it("formats a known slug + date deterministically", () => {
+    // April is month index 3 in JS Date; the formatter must zero-pad
+    // both the date and the time fields.
+    const d = new Date(2026, 3, 28, 14, 23, 45);
+    expect(formatScreenshotFilename("mustang_alpha", d)).toBe(
+      "screenshot_mustang_alpha_20260428_142345.png",
+    );
+  });
+
+  it("falls back to 'viewer' when the slug is null", () => {
+    const d = new Date(2026, 0, 1, 0, 0, 0);
+    expect(formatScreenshotFilename(null, d)).toBe(
+      "screenshot_viewer_20260101_000000.png",
+    );
+  });
+
+  it("falls back to 'viewer' when the slug is undefined", () => {
+    const d = new Date(2026, 0, 1, 0, 0, 0);
+    expect(formatScreenshotFilename(undefined, d)).toBe(
+      "screenshot_viewer_20260101_000000.png",
+    );
+  });
+
+  it("falls back to 'viewer' when the slug is the empty string", () => {
+    const d = new Date(2026, 0, 1, 0, 0, 0);
+    expect(formatScreenshotFilename("", d)).toBe(
+      "screenshot_viewer_20260101_000000.png",
+    );
+  });
+
+  it("zero-pads single-digit hours, minutes, seconds", () => {
+    const d = new Date(2026, 0, 1, 1, 2, 3);
+    expect(formatScreenshotFilename("x", d)).toBe(
+      "screenshot_x_20260101_010203.png",
+    );
+  });
+});

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -1,6 +1,23 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
+/**
+ * Wrap `invoke` with a `performance.now()` delta. Logs a `[perf]` line to
+ * the console (captured by tauri-plugin-log -> app.log) whenever a command
+ * takes longer than 50ms. Sub-50ms calls are cheap enough to skip logging.
+ */
+async function timedInvoke<T>(name: string, args?: unknown): Promise<T> {
+  const t0 = performance.now();
+  try {
+    return await invoke<T>(name, args as Record<string, unknown>);
+  } finally {
+    const dt = performance.now() - t0;
+    if (dt > 50) {
+      console.info(`[perf] invoke:${name} ${dt.toFixed(0)}ms`);
+    }
+  }
+}
+
 export interface DiscoverResult {
   path: string;
   source: string;
@@ -437,3 +454,277 @@ export async function extractP4kFile(
 ): Promise<void> {
   return invoke<void>("extract_p4k_file", { path, outputPath });
 }
+
+// ── Decomposed export browsing ──
+//
+// The decomposed export contract is documented in
+// `docs/decomposed-export-contract.md`. The Rust exporter emits dynamic
+// JSON, not strongly-typed structs, so wrappers below return `unknown`
+// for manifests and `ArrayBuffer` for binary payloads. The scene-viewer
+// loader knows the shape and reads the fields it needs.
+
+export interface DecomposedPackageInfo {
+  package_dir: string;
+  export_root: string;
+  package_name: string;
+  has_scene_manifest: boolean;
+}
+
+/**
+ * List decomposed packages under a root. Accepts an export root, a
+ * `Packages/` directory, or a single package directory (returns just that
+ * one).
+ */
+export async function listDecomposedPackages(
+  root: string,
+): Promise<DecomposedPackageInfo[]> {
+  return invoke<DecomposedPackageInfo[]>("list_decomposed_packages", { root });
+}
+
+/** Load `scene.json` from a decomposed package directory. */
+export async function loadDecomposedScene(
+  packagePath: string,
+): Promise<unknown> {
+  return timedInvoke<unknown>("load_decomposed_scene", { packagePath });
+}
+
+/**
+ * Load `palettes.json` from a decomposed package directory. Returns
+ * `null` when the file is absent (palette-less exports).
+ */
+export async function loadDecomposedPalettes(
+  packagePath: string,
+): Promise<unknown> {
+  return invoke<unknown>("load_decomposed_palettes", { packagePath });
+}
+
+/** Load `liveries.json` from a decomposed package directory, or null. */
+export async function loadDecomposedLiveries(
+  packagePath: string,
+): Promise<unknown> {
+  return invoke<unknown>("load_decomposed_liveries", { packagePath });
+}
+
+/**
+ * Load `paints.json` from a decomposed package directory. Returns null
+ * when the file is absent (older exports, or entities with no paint
+ * variants in DataCore).
+ *
+ * No dedicated Rust command exists for `paints.json`; we lean on the
+ * generic `load_decomposed_json` and treat any read error as "absent".
+ * This keeps the change UI-only — adding a Tauri command would force a
+ * cargo rebuild for what is effectively a one-line file read.
+ */
+export async function loadDecomposedPaints(
+  packagePath: string,
+): Promise<unknown> {
+  // Forward slashes work on every OS the Tauri command tolerates.
+  const path = `${packagePath.replace(/[\\/]+$/, "")}/paints.json`;
+  try {
+    return await loadDecomposedJson(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load any JSON file under the export root. Used for material sidecars
+ * (`*.materials.json`) referenced from `scene.json`.
+ */
+export async function loadDecomposedJson(path: string): Promise<unknown> {
+  return timedInvoke<unknown>("load_decomposed_json", { path });
+}
+
+/**
+ * Read a binary file under the export root (GLB / PNG / DDS). Returns
+ * an `ArrayBuffer` so callers can hand it directly to GLTFLoader,
+ * THREE.TextureLoader, or `URL.createObjectURL`.
+ */
+export async function readDecomposedFile(path: string): Promise<ArrayBuffer> {
+  const bytes = await timedInvoke<number[]>("read_decomposed_file", { path });
+  return new Uint8Array(bytes).buffer;
+}
+
+/** Open a directory picker for an export root. Returns null if cancelled. */
+export async function browseDecomposedRoot(): Promise<string | null> {
+  const { open } = await import("@tauri-apps/plugin-dialog");
+  const result = await open({
+    title: "Select decomposed export package",
+    directory: true,
+    multiple: false,
+  });
+  return result ?? null;
+}
+
+// ── Scene Viewer self-service exporter ──
+//
+// Mirror of `SceneExportOpts` in `decomposed_commands.rs`. Every field
+// that affects on-disk output is part of the cache key, so changing any
+// of these forces a re-export.
+
+export interface SceneExportOpts {
+  lod: number;
+  mip: number;
+  /** "none" | "colors" | "textures" | "all" */
+  material_mode: string;
+  include_attachments: boolean;
+  include_interior: boolean;
+  include_lights: boolean;
+  include_nodraw: boolean;
+}
+
+/** Defaults used when the user hasn't tweaked anything. Match Rust side. */
+export const DEFAULT_SCENE_EXPORT_OPTS: SceneExportOpts = {
+  lod: 1,
+  mip: 2,
+  material_mode: "textures",
+  include_attachments: true,
+  include_interior: true,
+  include_lights: true,
+  include_nodraw: false,
+};
+
+export interface SceneEntityDto {
+  entity_name: string;
+  display_name: string | null;
+  category: string;
+  cached: boolean;
+}
+
+export interface SceneCachePath {
+  export_root: string;
+  /** Null when no scene.json has been written yet. */
+  package_dir: string | null;
+  cached: boolean;
+}
+
+export interface SceneExportProgress {
+  fraction: number;
+  stage: string;
+  entity_name: string;
+}
+
+export interface SceneExportDone {
+  entity_name: string;
+  package_dir: string | null;
+  error: string | null;
+}
+
+/** List ships/vehicles available for the Scene Viewer. */
+export async function listSceneEntities(
+  opts?: SceneExportOpts,
+): Promise<SceneEntityDto[]> {
+  return invoke<SceneEntityDto[]>("list_scene_entities", {
+    opts: opts ?? null,
+  });
+}
+
+/** Resolve the cache slot for an (entity, opts) pair. */
+export async function getSceneCachePath(
+  entityName: string,
+  opts: SceneExportOpts,
+): Promise<SceneCachePath> {
+  return invoke<SceneCachePath>("get_scene_cache_path", {
+    entityName,
+    opts,
+  });
+}
+
+/** Delete the on-disk cache slot for an (entity, opts) pair. */
+export async function clearSceneCache(
+  entityName: string,
+  opts: SceneExportOpts,
+): Promise<void> {
+  return invoke<void>("clear_scene_cache", { entityName, opts });
+}
+
+/**
+ * Decomposed-export contract version this frontend was built against.
+ * Mirror of `starbreaker_3d::DECOMPOSED_CONTRACT_VERSION`. Bump in
+ * lockstep with the Rust constant. Used as the argument to
+ * `pruneStaleCache` so the prune pass keeps slots stamped with the
+ * current version and discards every other slot.
+ */
+export const DECOMPOSED_CONTRACT_VERSION = 2;
+
+export interface ClearAllResult {
+  entries_removed: number;
+  bytes_freed: number;
+}
+
+/**
+ * Wipe every entry under the per-user `decomposed_cache/` directory.
+ * Defensively only deletes immediate children of the cache root; never
+ * follows symlinks out, never accepts arbitrary paths. Returns the
+ * number of entries removed and bytes freed.
+ */
+export async function clearAllSceneCache(): Promise<ClearAllResult> {
+  return invoke<ClearAllResult>("clear_all_scene_cache");
+}
+
+export interface CacheStats {
+  entry_count: number;
+  total_bytes: number;
+  /** Absolute path to the cache root on disk. */
+  cache_root: string;
+}
+
+/** Walk `decomposed_cache/` and return entry count + total size. */
+export async function cacheStats(): Promise<CacheStats> {
+  return invoke<CacheStats>("cache_stats");
+}
+
+export interface PruneStaleResult {
+  entries_removed: number;
+  bytes_freed: number;
+}
+
+/**
+ * Remove cache slots whose contract-version segment does not match
+ * `currentVersion`. Safe to call on app start from `useEffect`. Slots
+ * stamped with the current version are preserved; everything else
+ * (legacy unversioned slots, slots from older contracts) is deleted.
+ */
+export async function pruneStaleCache(
+  currentVersion: number,
+): Promise<PruneStaleResult> {
+  return invoke<PruneStaleResult>("prune_stale_cache", { currentVersion });
+}
+
+/**
+ * Run the decomposed exporter for a single entity in-process. Progress
+ * is emitted on `scene-export-progress`; completion (success or error)
+ * is emitted on `scene-export-done`.
+ */
+export async function startSceneExport(
+  entityName: string,
+  opts: SceneExportOpts,
+): Promise<void> {
+  return timedInvoke<void>("start_scene_export", { entityName, opts });
+}
+
+/** Cancel the in-flight scene export, if any. */
+export async function cancelSceneExport(): Promise<void> {
+  return timedInvoke<void>("cancel_scene_export");
+}
+
+/** Listen for scene export progress events. */
+export function onSceneExportProgress(
+  callback: (progress: SceneExportProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<SceneExportProgress>("scene-export-progress", (event) => {
+    callback(event.payload);
+  });
+}
+
+/** Listen for scene export completion events. */
+export function onSceneExportDone(
+  callback: (result: SceneExportDone) => void,
+): Promise<UnlistenFn> {
+  return listen<SceneExportDone>("scene-export-done", (event) => {
+    callback(event.payload);
+  });
+}
+
+// ── Diagnostic file capture ──
+

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 /**
@@ -723,6 +723,223 @@ export function onSceneExportDone(
 ): Promise<UnlistenFn> {
   return listen<SceneExportDone>("scene-export-done", (event) => {
     callback(event.payload);
+  });
+}
+
+// ── SOC scene loader (Maps tab) ──
+
+/**
+ * Response payload for `loadSceneToGltf`. Mirrors the Rust
+ * `LoadSceneResponse` struct; the GLB is materialised on disk under
+ * `%LOCALAPPDATA%/app.starbreaker/scene_cache/<key>/scene.glb`,
+ * with a sibling `manifest.json` carrying the same summary fields.
+ */
+export interface LoadSceneResponse {
+  glb_path: string;
+  manifest_path: string;
+  cache_hit: boolean;
+  mesh_count: number;
+  placement_count: number;
+  /** Lights actually present in the GLB (after the renderer-friendly cap). */
+  light_count: number;
+  /** Lights skipped because the cap was reached. `light_count + lights_dropped`
+   *  equals the total light count in the source SOC scene. */
+  lights_dropped: number;
+  aabb_min: [number, number, number] | null;
+  aabb_max: [number, number, number] | null;
+  glb_bytes: number;
+  dropped_placements: number;
+  failed_mesh_paths: number;
+  materials_resolved: number;
+  materials_default: number;
+}
+
+/**
+ * Walk a top-level socpak's child graph, resolve every brush mesh
+ * against the loaded P4k, and emit a single self-contained `.glb`.
+ * The cache is keyed on (socpak_path, max_depth, p4k_identity,
+ * contract_version) so subsequent calls with the same arguments
+ * return the cached file without re-emitting. `max_depth` defaults
+ * to 4 — sufficient for the observed assembly / interior / module
+ * hierarchies.
+ */
+export async function loadSceneToGltf(
+  socpakPath: string,
+  maxDepth?: number,
+): Promise<LoadSceneResponse> {
+  return timedInvoke<LoadSceneResponse>("load_scene_to_gltf", {
+    socpakPath,
+    maxDepth: maxDepth ?? null,
+  });
+}
+
+/**
+ * Progress event payload from `load_scene_to_gltf`. Phases progress
+ * through compose -> resolve -> emit -> cache_write. Throttled to
+ * roughly 10 Hz on the backend.
+ */
+export interface SceneLoadProgress {
+  phase: "compose" | "resolve" | "emit" | "cache_write";
+  current: number;
+  total: number;
+  message: string;
+}
+
+/** Listen for SOC scene load progress events. */
+export function onSceneLoadProgress(
+  callback: (progress: SceneLoadProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<SceneLoadProgress>("scene-load-progress", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Read a SOC scene GLB from the cache and return its bytes.
+ *
+ * Deprecated: shipping a 200+ MB GLB across the IPC channel as a
+ * `number[]` blew up the WebView with `STATUS_BREAKPOINT` once the
+ * payload fell back to `postMessage` (each byte serialises to a
+ * decimal string + comma, inflating ~272 MB to ~800 MB of JSON before
+ * the browser parses it back into a `Uint8Array`). The viewer now
+ * builds an `asset://` URL via {@link sceneGlbAssetUrl} and lets
+ * Three.js's GLTFLoader fetch the file directly through the webview's
+ * own HTTP path, which avoids both the marshalling cost and the
+ * blocking parse on the renderer thread.
+ *
+ * Kept exported because the Rust command is still registered (it has
+ * a path-validation guard that would otherwise be unreachable test
+ * surface); a future caller that needs the bytes in JS can still use
+ * it. Do not call it for files larger than a few megabytes.
+ */
+export async function readSceneGlb(glbPath: string): Promise<ArrayBuffer> {
+  const bytes = await timedInvoke<number[]>("read_scene_glb", { glbPath });
+  return new Uint8Array(bytes).buffer;
+}
+
+/**
+ * Convert a cached SOC scene GLB path on disk into an `asset://` URL
+ * the webview can load directly with `fetch` / `GLTFLoader.load`. The
+ * asset protocol is gated by the `assetProtocol.scope` in
+ * `tauri.conf.json`; the only paths it accepts are children of
+ * `$APPLOCALDATA/scene_cache/`, which matches the cache root the
+ * `load_scene_to_gltf` command writes to.
+ *
+ * `convertFileSrc` is a pure path-mangling function (no IPC round
+ * trip), so this is cheap to call on every render.
+ */
+export function sceneGlbAssetUrl(glbPath: string): string {
+  return convertFileSrc(glbPath, "asset");
+}
+
+// ── Scene catalog (Maps tab list) ──
+
+/**
+ * One catalog entry surfaced to the Maps tab. Mirrors the Rust
+ * `SceneCatalogEntryDto` -- one root socpak that the user can pick
+ * to load through `loadSceneToGltf`.
+ *
+ * `source_kind` is a snake_case string so the backend can introduce
+ * new provenance variants without forcing a TypeScript-side enum
+ * bump. Today every entry is `"graph_root"` (in-degree-zero in the
+ * socpak reference graph).
+ */
+export interface SceneCatalogEntry {
+  path: string;
+  display_name: string;
+  /**
+   * Count of socpaks transitively reachable through `<Child>` refs.
+   * Useful as a rough complexity hint; leaf modules report 0,
+   * assemblies report a few, multi-zone hangars report dozens.
+   */
+  sub_zone_count: number;
+  source_kind: "graph_root" | "other" | string;
+}
+
+/**
+ * Walk the loaded P4k for socpak scene roots. Returns the entries
+ * sorted alphabetically by display name. The first call is slow
+ * (cold enumeration; ~5-15 seconds against HOTFIX) and subsequent
+ * calls hit the on-disk cache under
+ * `%LOCALAPPDATA%/app.starbreaker/scene_catalog/`.
+ *
+ * `channel` is reserved for future channel-switching without a
+ * full P4k reload; the current backend ignores it and operates on
+ * the active loaded P4k.
+ *
+ * Note: as of the lazy directory tree iteration, the Maps tab no
+ * longer drives off this command -- it calls {@link listSocpakDir}
+ * one prefix at a time. The wrapper is kept here for opt-in callers
+ * (smoke tests, fallback paths, future "search globally" affordances)
+ * that still want the full in-degree-zero set.
+ */
+export async function enumerateScenes(
+  channel?: string,
+): Promise<SceneCatalogEntry[]> {
+  return timedInvoke<SceneCatalogEntry[]>("enumerate_scenes", {
+    channel: channel ?? null,
+  });
+}
+
+// ── Lazy socpak directory tree (Maps tab) ──
+
+/**
+ * One node in the socpak directory tree. Either a subdirectory the
+ * caller can expand by passing `path` back into {@link listSocpakDir},
+ * or a `.socpak` file the caller can hand to {@link loadSceneToGltf}.
+ *
+ * The Rust command emits `kind` as a snake_case string so future kinds
+ * can land without forcing a TypeScript-side enum bump.
+ */
+export interface SocpakDirEntry {
+  /**
+   * Full p4k path. For directories this is the prefix to expand,
+   * terminated with a trailing backslash. For socpak files this is
+   * the full file path that {@link loadSceneToGltf} consumes.
+   */
+  path: string;
+  /** Last path segment, suitable for direct rendering. */
+  display_name: string;
+  kind: "directory" | "socpak_file";
+  /**
+   * For directories: count of immediate subdir + `.socpak` children.
+   * For socpak files: file size in bytes (compressed on-disk size).
+   */
+  size_or_count: number;
+}
+
+/**
+ * List the immediate children of a p4k directory prefix as
+ * directories + `.socpak` files. Used by the Maps tab to expand
+ * one tree branch on click rather than paying the multi-second cost
+ * of a full socpak-graph traversal.
+ *
+ * `prefix` may use forward or back slashes and may or may not have a
+ * trailing separator -- the backend normalises both.
+ */
+export async function listSocpakDir(
+  prefix: string,
+): Promise<SocpakDirEntry[]> {
+  return timedInvoke<SocpakDirEntry[]>("list_socpak_dir_cmd", { prefix });
+}
+
+/**
+ * Walk the loaded p4k once and return the path of every `.socpak` file
+ * under `searchRoots` (defaults to `["Data/ObjectContainers/"]`). Used
+ * by the Maps tab to seed a global search index so the user can find a
+ * scene without expanding the right tree branch first.
+ *
+ * Cold call: a few hundred ms against the live archive. Cached call: a
+ * JSON read off `%LOCALAPPDATA%/app.starbreaker/scene_index/`. The
+ * cache key folds in the loaded p4k's identity (mtime + size), so a
+ * channel switch or post-update file replacement invalidates stale
+ * slots automatically.
+ */
+export async function listAllSocpaks(
+  searchRoots?: string[],
+): Promise<string[]> {
+  return timedInvoke<string[]>("list_all_socpaks_cmd", {
+    searchRoots: searchRoots ?? null,
   });
 }
 

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -728,3 +728,26 @@ export function onSceneExportDone(
 
 // ── Diagnostic file capture ──
 
+/**
+ * Write a JSON diagnostic capture under the app's data directory.
+ * `subdir` is a single-segment subdirectory under the app data dir
+ * (created if absent); `filename` is the bare filename with extension.
+ * Returns the absolute path of the written file.
+ */
+export async function writeDiagFile(
+  subdir: string,
+  filename: string,
+  content: string,
+): Promise<string> {
+  return timedInvoke<string>("write_diag_file", { subdir, filename, content });
+}
+
+/**
+ * List filenames in a subdirectory of the app data dir. Empty if the
+ * subdirectory doesn't exist. Used to compute the next auto-increment
+ * counter for capture filenames.
+ */
+export async function listDiagDir(subdir: string): Promise<string[]> {
+  return timedInvoke<string[]>("list_diag_dir", { subdir });
+}
+

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -571,6 +571,11 @@ export interface SceneExportOpts {
   include_interior: boolean;
   include_lights: boolean;
   include_nodraw: boolean;
+  /** When true, `listSceneEntities` also returns CIG-internal /
+   *  in-development entities (inclusionMode != "ReadyToInclude").
+   *  These get tagged `is_wip: true` in the DTO so the UI marks them.
+   *  Does not affect the export cache key. */
+  include_wip: boolean;
 }
 
 /** Defaults used when the user hasn't tweaked anything. Match Rust side. */
@@ -582,6 +587,7 @@ export const DEFAULT_SCENE_EXPORT_OPTS: SceneExportOpts = {
   include_interior: true,
   include_lights: true,
   include_nodraw: false,
+  include_wip: false,
 };
 
 export interface SceneEntityDto {
@@ -589,6 +595,11 @@ export interface SceneEntityDto {
   display_name: string | null;
   category: string;
   cached: boolean;
+  /** True when the entity is flagged `inclusionMode != "ReadyToInclude"`
+   *  in the DataCore -- WIP capital ships, NPC variants, derelicts,
+   *  mission objectives. Only present when the caller passed
+   *  `include_wip = true`. The UI renders a [WIP] badge for these. */
+  is_wip: boolean;
 }
 
 export interface SceneCachePath {

--- a/app/src/lib/decomposed-loader.ts
+++ b/app/src/lib/decomposed-loader.ts
@@ -627,7 +627,8 @@ export type RenderStyle =
   | "opaque"
   | "metallic"
   | "glass"
-  | "holographic";
+  | "holographic"
+  | "mobiglas";
 
 export const RENDER_STYLES: { value: RenderStyle; label: string }[] = [
   { value: "textured", label: "Textured" },
@@ -635,6 +636,7 @@ export const RENDER_STYLES: { value: RenderStyle; label: string }[] = [
   { value: "metallic", label: "Metallic" },
   { value: "glass", label: "Glass" },
   { value: "holographic", label: "Holographic" },
+  { value: "mobiglas", label: "MobiGlas" },
 ];
 
 /** Stable cache key for a (submaterial, style) pair. Two instances of the
@@ -1527,8 +1529,17 @@ export function buildMaterial(
   // submaterials so a Mustang in Metallic style still reads as the painted
   // hull colour rather than reverting to the diagnostic grey.
   if (style !== "textured") {
+    const styledMaterial = buildStyledMaterial(name, family, style, submaterial);
+    // MobiGlas returns a ShaderMaterial with a `baseColor` Vector3 uniform.
+    // Wire it into the same DBG-toggle path holograms use so the diagnostic
+    // override functions consistently across all hologram-style materials.
+    if (style === "mobiglas") {
+      styledMaterial.userData.fallbackKind = FALLBACK_KINDS.HOLOGRAM_STUB;
+      tagOriginalColor(styledMaterial);
+      applyDebugFallbackToMaterial(styledMaterial);
+    }
     return {
-      material: buildStyledMaterial(name, family, style, submaterial),
+      material: styledMaterial,
       texturePromises: [],
     };
   }
@@ -1732,6 +1743,137 @@ function buildHologramMaterial(
   return { material, texturePromises: [] };
 }
 
+// ────────────────────────────────────────────────────────────
+// MobiGlas render style
+// ────────────────────────────────────────────────────────────
+
+/** Vertex stage for the MobiGlas style: emits view-space normal and
+ *  view direction so the fragment stage can compute Fresnel. The
+ *  instancing branch keeps it valid when the loader stamps geometry
+ *  with InstancedMesh; the non-instancing branch is the common path. */
+const MOBIGLAS_VERTEX_SHADER = /* glsl */ `
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+  void main() {
+    #ifdef USE_INSTANCING
+      vec4 mvPos = modelViewMatrix * instanceMatrix * vec4(position, 1.0);
+      vNormal = normalize(normalMatrix * mat3(instanceMatrix) * normal);
+    #else
+      vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
+      vNormal = normalize(normalMatrix * normal);
+    #endif
+    vViewDir = normalize(-mvPos.xyz);
+    gl_Position = projectionMatrix * mvPos;
+  }
+`;
+
+/** Fragment stage for the MobiGlas style: rim brightening from Fresnel
+ *  combined with a screen-space scanline pattern and a gentle time-driven
+ *  shimmer. Output uses additive blending so the surface reads as
+ *  emissive holographic glass rather than as a lit material. */
+const MOBIGLAS_FRAGMENT_SHADER = /* glsl */ `
+  uniform float time;
+  uniform vec3 baseColor;
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+  void main() {
+    float fresnel = pow(1.0 - abs(dot(vNormal, vViewDir)), 2.5);
+    float scanline = 0.85 + 0.15 * sin(gl_FragCoord.y * 2.0);
+    float shimmer = 0.95 + 0.05 * sin(time * 3.0 + gl_FragCoord.x * 0.1);
+    vec3 color = baseColor * (0.15 + fresnel * 0.6) * scanline * shimmer;
+    float alpha = (0.08 + fresnel * 0.5) * scanline;
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+/** Result of biasing an arbitrary input colour toward the MobiGlas
+ *  cyan-blue palette. Pure function so the render-style colour math is
+ *  testable without instantiating a Three.js material. The input is an
+ *  RGB hex; the output is a triplet in the 0..1 range. */
+export function blendTowardCyan(inputColorHex: number): {
+  r: number;
+  g: number;
+  b: number;
+} {
+  const input = new THREE.Color(inputColorHex);
+  const hsl = { h: 0, s: 0, l: 0 };
+  input.getHSL(hsl);
+  const TARGET_HUE = 0.52;
+  const HUE_BLEND = 0.15;
+  const TARGET_SATURATION = 0.7;
+  const TARGET_LIGHTNESS = 0.55;
+  // Hue interpolation is on the linear hue line (no shortest-path wrap).
+  // The source uses the same form; matching it keeps the visual identical.
+  const blendedHue = TARGET_HUE + (hsl.h - TARGET_HUE) * HUE_BLEND;
+  const out = new THREE.Color().setHSL(
+    blendedHue,
+    TARGET_SATURATION,
+    TARGET_LIGHTNESS,
+  );
+  return { r: out.r, g: out.g, b: out.b };
+}
+
+/** Live MobiGlas materials whose `time` uniform must be advanced once
+ *  per animation frame. Materials register themselves on construction
+ *  and the scene-viewer's animate loop calls `updateMobiGlasTime` with
+ *  the elapsed-seconds value. The set is cleared per scene load so
+ *  orphaned materials from prior packages don't accumulate. */
+const mobiGlasMaterials: Set<THREE.ShaderMaterial> = new Set();
+
+/** Advance the `time` uniform on every registered MobiGlas material.
+ *  Called once per frame from the scene-viewer animate loop. */
+export function updateMobiGlasTime(elapsedSec: number): void {
+  for (const mat of mobiGlasMaterials) {
+    const u = mat.uniforms.time;
+    if (u) u.value = elapsedSec;
+  }
+}
+
+/** Drop every registered MobiGlas material. Called when the scene is
+ *  rebuilt so the per-frame tick doesn't touch ShaderMaterials whose
+ *  underlying GPU resources have been disposed. */
+export function clearMobiGlasMaterials(): void {
+  mobiGlasMaterials.clear();
+}
+
+/** True when a material is currently in the live MobiGlas set. Exists
+ *  for tests; production code should use the lifecycle helpers. */
+export function isMobiGlasMaterialRegistered(
+  material: THREE.ShaderMaterial,
+): boolean {
+  return mobiGlasMaterials.has(material);
+}
+
+/** Construct a MobiGlas ShaderMaterial. The input colour is biased
+ *  toward cyan-blue so a wide variety of starting tints all read as
+ *  the same holographic family. Returns the material plus a deregister
+ *  callback the caller may invoke when the material is being disposed
+ *  outside the standard scene-load lifecycle. */
+export function makeMobiGlasMaterial(inputColorHex: number): {
+  material: THREE.ShaderMaterial;
+  unregister: () => void;
+} {
+  const blended = blendTowardCyan(inputColorHex);
+  const baseColorVec = new THREE.Vector3(blended.r, blended.g, blended.b);
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      time: { value: 0.0 },
+      baseColor: { value: baseColorVec },
+    },
+    vertexShader: MOBIGLAS_VERTEX_SHADER,
+    fragmentShader: MOBIGLAS_FRAGMENT_SHADER,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+  });
+  mobiGlasMaterials.add(material);
+  const unregister = (): void => {
+    mobiGlasMaterials.delete(material);
+  };
+  return { material, unregister };
+}
+
 /** Layer / LayerBlend_V2: same backbone as HardSurface but the
  *  `layer_manifest` may publish multiple wear/damage layers. SD's
  *  `layered_wear` template blends Primary + Wear via a per-pixel mask;
@@ -1914,6 +2056,11 @@ function buildStyledMaterial(
         opacity: 0.35,
         depthWrite: false,
       });
+    case "mobiglas": {
+      const result = makeMobiGlasMaterial(baseColour.getHex());
+      result.material.name = name;
+      return result.material;
+    }
     case "holographic":
     default:
       return new THREE.MeshBasicMaterial({

--- a/app/src/lib/decomposed-loader.ts
+++ b/app/src/lib/decomposed-loader.ts
@@ -1,0 +1,2585 @@
+// Pure conversion logic for decomposed-export records into Three.js objects.
+//
+// This file knows the shape of the `scene.json` / material-sidecar / light
+// records emitted by `crates/starbreaker-3d/src/decomposed.rs`. It owns
+// matrix conversion, light type mapping, and a generic PBR material builder.
+// Keeping this logic out of `scene-viewer.tsx` lets the viewer stay thin.
+//
+// All paths in the contract are relative to the *export root* (the parent
+// of `Packages/`), use forward slashes, and start with `Data/...` for
+// shared assets or `Packages/...` for per-package files.
+
+import * as THREE from "three";
+
+// ────────────────────────────────────────────────────────────
+// Coordinate-system conversion
+// ────────────────────────────────────────────────────────────
+//
+// Star Citizen is right-handed Z-up; Three.js is right-handed Y-up. The
+// exporter writes `local_transform_sc`, bone matrices, and interior
+// container/placement transforms in CryEngine basis (Z-up). Every GLB
+// emitted by `crates/starbreaker-3d/src/gltf` ALSO wraps its content in
+// a top-level `CryEngine_Z_up` node that performs the Z-up -> Y-up
+// rotation, so a single GLB opens correctly in any glTF viewer (Blender,
+// gltf-viewer, etc.).
+//
+// In the scene viewer we compose many GLBs into one tree, with
+// CryEngine-basis transforms between them (`local_transform_sc`,
+// `container_transform`, `placement.transform`). If every GLB does its
+// own basis flip at its root, those Z-up inter-mesh transforms get
+// applied to already-Y-up subtrees and produce visible artifacts: ground
+// vehicles render nose-down, interior containers fly off-axis. To get a
+// consistent assembled scene we strip each loaded GLB's CryEngine_Z_up
+// wrapper at load time (see `stripCryEngineZUp`) so all geometry stays
+// in raw Z-up, then apply the basis change exactly once at the scene
+// root via `applySCBasisToObject`.
+
+const SC_TO_THREE = new THREE.Matrix4().makeRotationX(-Math.PI / 2);
+
+/** Wrap a SC-basis Object3D in a Y-up basis change so it renders correctly. */
+export function applySCBasisToObject(obj: THREE.Object3D): void {
+  obj.matrixAutoUpdate = false;
+  obj.matrix.premultiply(SC_TO_THREE);
+}
+
+/**
+ * Remove the GLB-level `CryEngine_Z_up` wrapper from a loaded glTF
+ * scene, leaving its inner content reparented directly to `scene`. This
+ * normalises every loaded mesh into raw CryEngine (Z-up) basis so that
+ * the inter-mesh transforms recorded in `scene.json` (which are also in
+ * CryEngine basis) compose cleanly. The scene viewer applies the single
+ * Z-up -> Y-up rotation at the scene root.
+ *
+ * Idempotent: returns the input unchanged if no `CryEngine_Z_up` node is
+ * present (e.g. if a future exporter version drops the wrapper).
+ */
+export function stripCryEngineZUp(scene: THREE.Object3D): THREE.Object3D {
+  // Walk the scene's direct children looking for the wrapper. The
+  // exporter places it as the sole top-level node in the gltf scene
+  // graph (`glb_builder.rs::finalize`), but defensively scan in case the
+  // structure ever gains siblings. Snapshot the children arrays before
+  // iterating: `scene.remove` / `scene.add` mutate them in place.
+  // oxlint-disable-next-line unicorn/no-useless-spread
+  const topLevel = [...scene.children];
+  for (const child of topLevel) {
+    if (child.name === "CryEngine_Z_up") {
+      // Reparent the wrapper's children to its parent. We discard the
+      // wrapper's matrix because its sole purpose was to rotate Z-up to
+      // Y-up, which we no longer want at this layer.
+      // oxlint-disable-next-line unicorn/no-useless-spread
+      const inner = [...child.children];
+      scene.remove(child);
+      for (const node of inner) {
+        scene.add(node);
+      }
+    }
+  }
+  return scene;
+}
+
+/**
+ * Convert a 4x4 row-major matrix from `local_transform_sc` (or any
+ * exporter-emitted matrix field) into a `THREE.Matrix4`. The exporter
+ * emits row-major data, while `Matrix4.set` also takes row-major args,
+ * so the transcription is direct.
+ */
+export function matrixFromRows(rows: number[][]): THREE.Matrix4 {
+  // rows is a 4x4 nested array. Defensive: tolerate fewer rows by
+  // padding with identity rows. Three.js Matrix4.set takes the elements
+  // in row-major order.
+  const m = new THREE.Matrix4();
+  if (
+    !Array.isArray(rows) ||
+    rows.length < 4 ||
+    rows.some((r) => !Array.isArray(r) || r.length < 4)
+  ) {
+    return m; // identity
+  }
+  m.set(
+    rows[0][0], rows[0][1], rows[0][2], rows[0][3],
+    rows[1][0], rows[1][1], rows[1][2], rows[1][3],
+    rows[2][0], rows[2][1], rows[2][2], rows[2][3],
+    rows[3][0], rows[3][1], rows[3][2], rows[3][3],
+  );
+  return m;
+}
+
+/**
+ * Build a fallback transform from the legacy `offset_position` /
+ * `offset_rotation` (Euler degrees) fields when `local_transform_sc` is
+ * absent. The exporter prefers the resolved matrix path but old sidecars
+ * may not have it.
+ */
+export function matrixFromOffsetEuler(
+  offsetPosition: number[] | undefined,
+  offsetRotationDeg: number[] | undefined,
+): THREE.Matrix4 {
+  const pos = new THREE.Vector3(
+    offsetPosition?.[0] ?? 0,
+    offsetPosition?.[1] ?? 0,
+    offsetPosition?.[2] ?? 0,
+  );
+  const eulerDeg = offsetRotationDeg ?? [0, 0, 0];
+  const euler = new THREE.Euler(
+    THREE.MathUtils.degToRad(eulerDeg[0] ?? 0),
+    THREE.MathUtils.degToRad(eulerDeg[1] ?? 0),
+    THREE.MathUtils.degToRad(eulerDeg[2] ?? 0),
+    "XYZ",
+  );
+  const quat = new THREE.Quaternion().setFromEuler(euler);
+  return new THREE.Matrix4().compose(pos, quat, new THREE.Vector3(1, 1, 1));
+}
+
+// ────────────────────────────────────────────────────────────
+// Manifest types — minimal surface, just what we read.
+// ────────────────────────────────────────────────────────────
+
+export interface SceneManifest {
+  version?: number;
+  /** Decomposed-export contract revision the writer used. Bumped in
+   *  lockstep with `starbreaker_3d::DECOMPOSED_CONTRACT_VERSION` whenever
+   *  on-disk semantics change (sidecar layout, GLB extras, palette
+   *  contract). The loader compares this against its own
+   *  `DECOMPOSED_CONTRACT_VERSION` and refuses to load mismatched packages
+   *  rather than silently rendering against stale data. Absent on
+   *  pre-contract-v2 exports — those are treated as v0 (mismatch). */
+  contract_version?: number;
+  package_rule?: {
+    package_dir?: string;
+    shared_asset_root?: string;
+  };
+  root_entity?: {
+    entity_name?: string;
+    /** Always 0 for the root entity; present in exports >= the
+     *  instance-id contract addition. Children reference this via
+     *  `parent_instance_id`. */
+    instance_id?: number;
+    geometry_path?: string;
+    mesh_asset?: string;
+    material_sidecar?: string | null;
+    palette_id?: string | null;
+  };
+  children?: SceneInstance[];
+  interiors?: InteriorContainer[];
+  export_options?: Record<string, unknown>;
+}
+
+export interface SceneInstance {
+  entity_name?: string;
+  /** Unique per-export id for this child placement. Disambiguates
+   *  sibling placements that share the same `entity_name` (e.g. paired
+   *  weapon mounts on a Nox). Loaders should prefer this over
+   *  `entity_name` when keying a parent-attach registry. Optional for
+   *  backward compatibility with older exports; absent fields fall back
+   *  to `entity_name`-based matching with a console warning. */
+  instance_id?: number;
+  /** Instance id of the parent placement (root or another child). When
+   *  present, takes precedence over `parent_entity_name` for resolving
+   *  the attach target. */
+  parent_instance_id?: number;
+  geometry_path?: string;
+  mesh_asset?: string;
+  material_sidecar?: string | null;
+  palette_id?: string | null;
+  parent_node_name?: string | null;
+  parent_entity_name?: string | null;
+  source_transform_basis?: string | null;
+  local_transform_sc?: number[][] | null;
+  resolved_no_rotation?: boolean;
+  no_rotation?: boolean;
+  offset_position?: number[];
+  offset_rotation?: number[];
+}
+
+export interface InteriorContainer {
+  name?: string;
+  palette_id?: string | null;
+  container_transform?: number[][];
+  placements?: InteriorPlacement[];
+  lights?: LightRecord[];
+}
+
+export interface InteriorPlacement {
+  cgf_path?: string;
+  mesh_asset?: string;
+  material_sidecar?: string | null;
+  entity_class_guid?: string | null;
+  transform?: number[][];
+  palette_id?: string | null;
+}
+
+/** Known CryEngine light kinds emitted by the exporter. The wider `string`
+ *  fallback keeps the field tolerant of new types (e.g. future area-light
+ *  variants) without breaking the build. Match the runtime switch in
+ *  `buildLight` against the lower-cased value before relying on the literal. */
+export type LightTypeName =
+  | "Omni"
+  | "SoftOmni"
+  | "Projector"
+  | "Planar"
+  | "Ambient";
+
+export interface LightRecord {
+  name?: string;
+  position?: number[];
+  rotation?: number[];
+  direction_sc?: number[] | null;
+  color?: number[]; // linear RGB
+  light_type?: LightTypeName | string;
+  semantic_light_kind?: string | null;
+  intensity?: number;
+  intensity_raw?: number;
+  intensity_candela_proxy?: number | null;
+  radius?: number;
+  radius_m?: number | null;
+  inner_angle?: number | null;
+  outer_angle?: number | null;
+  projector_texture?: string | null;
+  active_state?: string | null;
+  states?: Record<string, LightStateRecord>;
+}
+
+export interface LightStateRecord {
+  intensity_raw?: number;
+  intensity_cd?: number | null;
+  intensity_candela_proxy?: number | null;
+  temperature?: number | null;
+  use_temperature?: boolean;
+  color?: number[];
+}
+
+// Material sidecar — minimal subset. Captures enough to build a
+// PBR material from one of the submaterials.
+export interface MaterialSidecar {
+  version?: number;
+  source_material_path?: string;
+  submaterials?: SubmaterialRecord[];
+}
+
+/** A single paint / livery variant available for the loaded ship. The
+ *  exporter writes one of these per `<SubGeometry>` paint slot it found
+ *  on the entity (Beta / Delta / Murray Cup / IAE2951 / etc.). The
+ *  variant either ships a substitute exterior `*.materials.json`
+ *  sidecar or shares the default sidecar and only swaps the palette.
+ *  See `liveries.json` / `paints.json` in `_*_export/Packages/<name>/`. */
+export interface PaintVariant {
+  /** Palette identifier (e.g. `palette/cnou_mustang_alpha`). Stable
+   *  per-export and used as the dropdown's selection key. The default
+   *  livery is selected when no variant is active. */
+  palette_id: string;
+  /** Authored CryEngine `<SubGeometry>` tag the variant maps to (e.g.
+   *  `Beta`, `Paint_Mustang_IAE2951_Grey_White`). Used as the dropdown
+   *  label fallback when `display_name` is null. */
+  subgeometry_tag?: string | null;
+  /** Human-readable label from DataCore (`PaintVariantParams.displayName`).
+   *  Often null for default-baked variants like Beta/Delta which only
+   *  exist as authoring tags. */
+  display_name?: string | null;
+  /** Substitute `*.materials.json` sidecar to use for the entity's
+   *  exterior submaterials when this variant is active. Null when the
+   *  variant only swaps the palette and reuses the default sidecar's
+   *  textures. Path is relative to the export root. */
+  exterior_material_sidecar?: string | null;
+}
+
+/** `paints.json` schema. Lists every paint variant the exporter
+ *  resolved off the entity's `Components[SCItemPaintParams]` table.
+ *  Variant set is per-ship — populates the livery dropdown without
+ *  any per-ship hardcoding. */
+export interface PaintsManifest {
+  version?: number;
+  paint_variants?: PaintVariant[];
+}
+
+/** Known shader_family values emitted by the exporter. The wider `string`
+ *  fallback keeps the union forward-compatible: new families added on the
+ *  Rust side won't fail the type check, but they fall through to the
+ *  generic HardSurface / Illum branch in `buildMaterial`. The literal
+ *  members exist to catch typos in switch statements at compile time. */
+export type ShaderFamilyName =
+  | "DisplayScreen"
+  | "GlassPBR"
+  | "HardSurface"
+  | "Hologram"
+  | "HologramCIG"
+  | "Illum"
+  | "Layer"
+  | "LayerBlend_V2"
+  | "MeshDecal"
+  | "Monitor"
+  | "Shield_Holo"
+  | "UIMesh"
+  | "UIPlane";
+
+export interface SubmaterialRecord {
+  index?: number;
+  /** Authored material name (e.g. "Damage_Internal_Tile_Alpha"). */
+  submaterial_name?: string;
+  /**
+   * Stable Blender slot name (e.g. "rsi_polaris_ext:Damage_Internal_Tile_Alpha").
+   * The Rust GLB writer uses this same string as the glTF material name,
+   * so it is the most reliable key for matching exporter materials to
+   * sidecar entries.
+   */
+  blender_material_name?: string;
+  /** Raw shader string (e.g. "Illum", "HardSurface"). */
+  shader?: string | null;
+  /** Normalized shader family classification, when known. */
+  shader_family?: ShaderFamilyName | string | null;
+  /** Decoded CryEngine StringGenMask flags. The Rust exporter parses tokens
+   *  like `DECAL`, `STENCIL_MAP`, `VERTCOLORS`, `PARALLAX_OCCLUSION_MAPPING`
+   *  out of the `%TOKEN1%TOKEN2` mask and surfaces them here. The decal
+   *  pipeline keys off `has_decal` / `has_stencil_map` rather than
+   *  `shader_family` because Illum, HardSurface, and Layer materials can
+   *  all be decals depending on their authored mask. */
+  decoded_feature_flags?: DecodedFeatureFlags | null;
+  texture_slots?: TextureSlotRecord[];
+  direct_textures?: DirectTextureRecord[];
+  /** Per-submaterial palette tint baked by the exporter (HardSurface only).
+   *  Null for non-tinted submaterials. When `assigned_channel` resolves to
+   *  one of `entries`, the matching `tint_color` is multiplied with the
+   *  diffuse map (`final_albedo = tint_color × diffuse_sample`). */
+  tint_palette?: SubmaterialPalette | null;
+  /** Palette-channel routing for layered HardSurface submaterials.
+   *  `material_channel` is the channel this submaterial as a whole reads
+   *  from; `layer_channels` enumerates per-layer channel assignments and
+   *  is used to pick the layer that owns the visible diffuse/normal pair. */
+  palette_routing?: PaletteRouting | null;
+  /** Resolved per-layer texture pointers for layered HardSurface
+   *  submaterials. The visible "paint" tiling diffuse / normal live here
+   *  rather than in the top-level `texture_slots`, because the authored
+   *  layer chain (Primary, Wear, etc.) is preserved for future blending
+   *  work. The frontend currently picks the first layer matching the
+   *  submaterial's `material_channel`. */
+  layer_manifest?: LayerManifestEntry[];
+  /** Loader-derived activation state. "active" means the material is
+   *  renderable; "inactive" means the mesh should be hidden (e.g. a
+   *  stencil-float decal whose base colour texture is absent, or a
+   *  nodraw slot). Set by the Rust exporter in `material.extras.semantic`. */
+  activation_state?: { state: "active" | "inactive"; reason?: string } | null;
+  // Many other fields exist (public_params, paint_override,
+  // material_set_identity, etc.). Frontend ignores them for the POC.
+}
+
+export interface DecodedFeatureFlags {
+  has_decal?: boolean;
+  has_iridescence?: boolean;
+  has_parallax_occlusion_mapping?: boolean;
+  has_stencil_map?: boolean;
+  has_vertex_colors?: boolean;
+  tokens?: string[];
+}
+
+export interface TintPaletteEntry {
+  channel: string;
+  /** Linear-space RGB tint (sRGB→linear conversion already applied on the
+   *  Rust side). Feed directly into `THREE.Color` without further conversion. */
+  tint_color: [number, number, number];
+  spec_color: [number, number, number] | null;
+  glossiness: number | null;
+}
+
+export interface SubmaterialPalette {
+  palette_id: string;
+  palette_source_name: string | null;
+  /** Which channel of `entries` this submaterial actually reads. Null when
+   *  the routing could not be resolved on the Rust side; the frontend
+   *  treats null as "leave material.color at the family default". */
+  assigned_channel: string | null;
+  entries: TintPaletteEntry[];
+}
+
+export interface PaletteChannel {
+  index: number;
+  name: string;
+}
+
+export interface PaletteRouting {
+  material_channel: PaletteChannel | null;
+  layer_channels: { index: number; channel: PaletteChannel | null }[];
+}
+
+export interface LayerManifestEntry {
+  index?: number;
+  name?: string;
+  diffuse_export_path?: string | null;
+  normal_export_path?: string | null;
+  palette_channel?: PaletteChannel | null;
+}
+
+export interface TextureTransformRecord {
+  /** [tileU, tileV] from CryEngine TexMod. Maps to THREE.Texture.repeat. */
+  scale?: number[];
+  /** [offsetU, offsetV] from CryEngine TexMod. Maps to THREE.Texture.offset. */
+  offset?: number[];
+  /** Rotation in radians (currently unused; CryEngine emits TexMod_RotateType
+   *  which we treat as advisory until a concrete mapping is needed). */
+  rotation?: number | null;
+  attributes?: Record<string, unknown>;
+}
+
+export interface TextureSlotRecord {
+  role?: string;
+  /** TexSlotN identifier (e.g. "TexSlot1", "TexSlot7"). Used to spot
+   *  decal stencils when the role enum is `unknown`. */
+  slot?: string;
+  source_path?: string;
+  export_path?: string;
+  alpha_semantic?: string | null;
+  texture_transform?: TextureTransformRecord | null;
+}
+
+export interface DirectTextureRecord {
+  role?: string;
+  slot?: string;
+  source_path?: string;
+  export_path?: string;
+  alpha_semantic?: string | null;
+  texture_transform?: TextureTransformRecord | null;
+}
+
+// ────────────────────────────────────────────────────────────
+// Light conversion
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Per-type intensity scalars for converting CryEngine candela values to
+ * Three.js-friendly intensities. CryEngine candela values are emitted in
+ * physical units (cd) while Three.js non-physical lights treat intensity
+ * as a unitless multiplier; the mapping is purely visual. Tuned by eye on
+ * Mustang / Nox / Polaris fixtures: omnis dominate cabin lighting and
+ * shouldn't blow out, projectors are cone-narrow and need more cd to
+ * register, ambient is global fill so it scales lowest.
+ */
+const LIGHT_INTENSITY_SCALARS: Record<string, number> = {
+  omni: 0.008,
+  softomni: 0.008,
+  point: 0.008,
+  projector: 0.02,
+  spot: 0.02,
+  ambient: 0.05,
+  ambient_proxy: 0.05,
+};
+/** Scalar applied when we fall back to `intensity_raw` (unitless gameplay
+ *  value, much hotter than candela). Roughly the ratio observed on
+ *  contract samples between intensity_raw and intensity_candela_proxy. */
+const INTENSITY_RAW_SCALAR = 0.001;
+
+/**
+ * Convert one exporter `LightRecord` into a Three.js light. Returns null
+ * when the type is unrecognized (we log so operators can spot it).
+ *
+ * Intensity is normalized to a Three.js-friendly range using per-type
+ * heuristic scalars. Different light types fill different roles in a
+ * scene, so a single blanket scalar (the previous 0.01) over-lit cabin
+ * point lights and under-lit spotlights. See `LIGHT_INTENSITY_SCALARS`.
+ */
+export function buildLight(record: LightRecord): THREE.Light | null {
+  const color = colorFromLinearRGB(record.color, record.states, record.active_state);
+  const kind = (record.semantic_light_kind ?? record.light_type ?? "").toLowerCase();
+
+  // Pick base candela. If `intensity_candela_proxy` is missing or zero,
+  // fall back to the raw CryEngine intensity scaled down to the same
+  // order of magnitude.
+  const candela = pickIntensity(record);
+  let baseIntensity = candela;
+  if (!Number.isFinite(candela) || candela <= 0) {
+    const raw = typeof record.intensity_raw === "number" ? record.intensity_raw : 0;
+    baseIntensity = Math.max(0, raw) * INTENSITY_RAW_SCALAR / scalarForKind(kind);
+  }
+  const scalar = scalarForKind(kind);
+  const intensity = Math.max(0, baseIntensity * scalar);
+
+  const radius = record.radius_m ?? record.radius ?? 10.0;
+  const distance = Math.max(radius, 0.01);
+
+  let light: THREE.Light | null = null;
+
+  switch (kind) {
+    case "ambient":
+    case "ambient_proxy":
+      light = new THREE.AmbientLight(color, intensity);
+      break;
+    case "spot":
+    case "projector": {
+      const outer = degToRadOrDefault(record.outer_angle, 30);
+      // If inner_angle is missing on a Projector, default to half the
+      // outer angle (matches CryEngine's "soft cone" convention for
+      // projector lights when no explicit inner angle is authored).
+      const innerDeg =
+        typeof record.inner_angle === "number"
+          ? record.inner_angle
+          : (typeof record.outer_angle === "number" ? record.outer_angle * 0.5 : 15);
+      const inner = THREE.MathUtils.degToRad(innerDeg);
+      const spot = new THREE.SpotLight(color, intensity, distance, outer);
+      spot.penumbra = Math.max(0, 1 - inner / outer);
+      light = spot;
+      break;
+    }
+    case "point":
+    case "omni":
+    case "softomni":
+    default:
+      light = new THREE.PointLight(color, intensity, distance, 2);
+      break;
+  }
+
+  if (record.position && light) {
+    light.position.set(
+      record.position[0] ?? 0,
+      record.position[1] ?? 0,
+      record.position[2] ?? 0,
+    );
+  }
+  if (light) {
+    light.name = record.name ?? "light";
+    // Spotlights default-orient down -Z in Three.js. The exporter's
+    // `direction_sc` field, when present, is the forward direction in SC
+    // basis. We use a target object set to position + direction.
+    if (light instanceof THREE.SpotLight && record.direction_sc) {
+      const dir = new THREE.Vector3(
+        record.direction_sc[0] ?? 0,
+        record.direction_sc[1] ?? 0,
+        record.direction_sc[2] ?? -1,
+      ).normalize();
+      const target = new THREE.Object3D();
+      target.position.copy(light.position).add(dir);
+      light.target = target;
+    }
+  }
+  return light;
+}
+
+function scalarForKind(kind: string): number {
+  return LIGHT_INTENSITY_SCALARS[kind] ?? 0.01;
+}
+
+function pickIntensity(record: LightRecord): number {
+  // Priority: explicit intensity_candela_proxy on the record, then
+  // intensity, then walk states by priority order.
+  if (typeof record.intensity_candela_proxy === "number") {
+    return record.intensity_candela_proxy;
+  }
+  if (typeof record.intensity === "number") return record.intensity;
+  if (typeof record.intensity_raw === "number") return record.intensity_raw;
+  const states = record.states ?? {};
+  for (const key of [
+    record.active_state ?? "",
+    "defaultState",
+    "auxiliaryState",
+    "emergencyState",
+    "cinematicState",
+  ]) {
+    const s = states[key];
+    if (s && typeof s.intensity_candela_proxy === "number") {
+      return s.intensity_candela_proxy;
+    }
+    if (s && typeof s.intensity_cd === "number") return s.intensity_cd;
+    if (s && typeof s.intensity_raw === "number") return s.intensity_raw;
+  }
+  return 1.0;
+}
+
+function colorFromLinearRGB(
+  rgb: number[] | undefined,
+  states: Record<string, LightStateRecord> | undefined,
+  active: string | null | undefined,
+): THREE.Color {
+  let arr = rgb;
+  if (!arr && states) {
+    for (const key of [
+      active ?? "",
+      "defaultState",
+      "auxiliaryState",
+      "emergencyState",
+      "cinematicState",
+    ]) {
+      const s = states[key];
+      if (s?.color && s.color.length >= 3) {
+        arr = s.color;
+        break;
+      }
+    }
+  }
+  return new THREE.Color(
+    Math.max(0, arr?.[0] ?? 1),
+    Math.max(0, arr?.[1] ?? 1),
+    Math.max(0, arr?.[2] ?? 1),
+  );
+}
+
+function degToRadOrDefault(value: number | null | undefined, fallbackDeg: number): number {
+  const deg = typeof value === "number" ? value : fallbackDeg;
+  return THREE.MathUtils.degToRad(deg);
+}
+
+// ────────────────────────────────────────────────────────────
+// Material building
+// ────────────────────────────────────────────────────────────
+
+/** User-selectable presentation modes. `Textured` is the default and the
+ *  only one that consults sidecar textures; the others are diagnostic /
+ *  artistic overlays that ignore textures so they work uniformly across
+ *  all entities even when texture loads are incomplete. */
+export type RenderStyle =
+  | "textured"
+  | "opaque"
+  | "metallic"
+  | "glass"
+  | "holographic";
+
+export const RENDER_STYLES: { value: RenderStyle; label: string }[] = [
+  { value: "textured", label: "Textured" },
+  { value: "opaque", label: "Opaque Lit" },
+  { value: "metallic", label: "Metallic" },
+  { value: "glass", label: "Glass" },
+  { value: "holographic", label: "Holographic" },
+];
+
+/** Stable cache key for a (submaterial, style) pair. Two instances of the
+ *  same submaterial at the same style share one Three.js Material, which
+ *  collapses draw-call overhead and shader-program count. */
+export function materialCacheKey(
+  submaterial: SubmaterialRecord,
+  style: RenderStyle,
+): string {
+  const name =
+    submaterial.blender_material_name ??
+    submaterial.submaterial_name ??
+    `idx:${submaterial.index ?? "?"}`;
+  // Debug-fallback mode is NOT in the cache key — toggling DBG mutates
+  // existing materials in place via `applyDebugFallbackToMaterial`,
+  // avoiding the rebuild + shader-recompile storm a fresh-material
+  // path triggers on big ships (Aurora has ~1000 unique submats; one
+  // shader compile per material × 1000 = multi-second main-thread
+  // freeze). Color swaps don't recompile shaders.
+  return `${style}|${name}`;
+}
+
+/** Diagnostic colours for fallback / stand-in material paths. When
+ *  `debugFallbackMode` is on, each builder swaps its base colour for the
+ *  neon corresponding to the path it took, so the user can visually
+ *  identify which fallback is firing on each surface.
+ *
+ *  Two design rules:
+ *    1. Only paths that are *guesses* or *stand-ins* get coloured.
+ *       A correctly-resolved palette tint or a properly-authored
+ *       decal/glass/skin material renders normally — neoning it would
+ *       create false positives.
+ *    2. The neon multiplies with whatever diffuse texture the slot
+ *       resolution produces, so a green-coloured "no palette but has
+ *       diffuse" panel still shows the texture detail (just tinted
+ *       green). Pure neon = no diffuse loaded either. */
+export const FALLBACK_KINDS = {
+  HARDSURFACE_PALETTE_RESOLVED: "hardsurface_palette_resolved",
+  HARDSURFACE_PALETTE_HEURISTIC: "hardsurface_palette_heuristic",
+  HARDSURFACE_NO_PALETTE: "hardsurface_no_palette",
+  FAMILY_UNKNOWN_DEFAULT: "family_unknown_default",
+  HOLOGRAM_STUB: "hologram_stub",
+  SCREEN_STUB: "screen_stub",
+  SKIN_DEFAULT: "skin_default",
+} as const;
+
+export type FallbackKind =
+  (typeof FALLBACK_KINDS)[keyof typeof FALLBACK_KINDS];
+
+const FALLBACK_NEONS: Partial<Record<FallbackKind, number>> = {
+  hardsurface_palette_resolved: 0x0080ff, // bright blue: routed-channel palette resolved correctly
+  hardsurface_palette_heuristic: 0x00ffff, // cyan: heuristic entryA fallback fired
+  hardsurface_no_palette: 0x00ff00, // green: no tint_palette at all (multiplied with diffuse)
+  family_unknown_default: 0xff0000, // red: shader_family didn't match any builder
+  hologram_stub: 0xffff00, // yellow: Hologram emissive-stub stand-in
+  screen_stub: 0xff00aa, // magenta-violet: DisplayScreen / RTT stub
+  skin_default: 0xff80c0, // pink: HumanSkin stand-in (no proper SSS)
+};
+
+let debugFallbackMode = false;
+
+export function setDebugFallbackMode(on: boolean): void {
+  debugFallbackMode = on;
+}
+
+export function isDebugFallbackMode(): boolean {
+  return debugFallbackMode;
+}
+
+/** Resolve the neon colour for a given fallback kind, or null if the
+ *  kind has no entry in `FALLBACK_NEONS`. Does NOT consult
+ *  `debugFallbackMode` — callers are responsible for honouring it.
+ *  (Build-time callers want the neon eagerly when debug mode is on at
+ *  build time; the in-place toggle path consults this helper directly
+ *  and mutates `material.color` based on it.) */
+function debugColorFor(kind: FallbackKind): THREE.Color | null {
+  const hex = FALLBACK_NEONS[kind];
+  return hex == null ? null : new THREE.Color(hex);
+}
+
+/** Stash a material's original (non-debug) colour state so the DBG
+ *  toggle can restore it without a rebuild. Captures `.color` plus
+ *  `.emissive` / `.emissiveIntensity` for PBR materials (so the
+ *  emissive override the toggle layers in can be reverted). For the
+ *  Hologram ShaderMaterial, captures the `baseColor` uniform Vector3.
+ *  Idempotent — safe to call multiple times. */
+function tagOriginalColor(material: THREE.Material): void {
+  if (material.userData.originalColor) return;
+  if (material.userData.originalBaseColor) return;
+  if ("color" in material && material.color instanceof THREE.Color) {
+    material.userData.originalColor = (material.color as THREE.Color).clone();
+    if ("emissive" in material && material.emissive instanceof THREE.Color) {
+      material.userData.originalEmissive = (
+        material.emissive as THREE.Color
+      ).clone();
+      material.userData.originalEmissiveIntensity = (
+        material as THREE.MeshStandardMaterial
+      ).emissiveIntensity;
+    }
+    return;
+  }
+  if (material instanceof THREE.ShaderMaterial) {
+    const u = material.uniforms?.baseColor?.value;
+    if (u instanceof THREE.Vector3) {
+      material.userData.originalBaseColor = u.clone();
+    }
+  }
+}
+
+/** Swap a material's colour to/from its debug neon based on the global
+ *  flag and the material's `userData.fallbackKind`. Mutates in place
+ *  — no new material, no shader recompile.
+ *
+ *  PBR materials get BOTH `.color` AND `.emissive` set to the neon, so
+ *  the override is visible even when bright IBL + clearcoat reflection
+ *  would otherwise wash out a pure base-colour swap. Initial attempt
+ *  set only `.color`, which made exterior hull panels (heavy IBL +
+ *  clearcoat = 1.0) appear unchanged — the reflective specular layer
+ *  was hiding the colour shift. Emissive is unaffected by lighting,
+ *  so it self-illuminates the surface in the diagnostic colour. */
+export function applyDebugFallbackToMaterial(material: THREE.Material): void {
+  const kind = material.userData.fallbackKind as FallbackKind | undefined;
+  if (!kind) return;
+  const neon = debugColorFor(kind);
+  if (debugFallbackMode && neon) {
+    if ("color" in material && material.color instanceof THREE.Color) {
+      (material.color as THREE.Color).copy(neon);
+      // Also light up via emissive so the neon survives clearcoat /
+      // IBL reflections on PBR materials.
+      if ("emissive" in material && material.emissive instanceof THREE.Color) {
+        (material.emissive as THREE.Color).copy(neon);
+        (material as THREE.MeshStandardMaterial).emissiveIntensity = 1.0;
+      }
+    } else if (
+      material instanceof THREE.ShaderMaterial &&
+      material.uniforms?.baseColor?.value instanceof THREE.Vector3
+    ) {
+      (material.uniforms.baseColor.value as THREE.Vector3).set(
+        neon.r,
+        neon.g,
+        neon.b,
+      );
+    }
+  } else {
+    // Restore original. tagOriginalColor must have run at build time.
+    if (
+      "color" in material &&
+      material.color instanceof THREE.Color &&
+      material.userData.originalColor instanceof THREE.Color
+    ) {
+      (material.color as THREE.Color).copy(material.userData.originalColor);
+      if (
+        "emissive" in material &&
+        material.emissive instanceof THREE.Color &&
+        material.userData.originalEmissive instanceof THREE.Color
+      ) {
+        (material.emissive as THREE.Color).copy(
+          material.userData.originalEmissive,
+        );
+        (material as THREE.MeshStandardMaterial).emissiveIntensity =
+          (material.userData.originalEmissiveIntensity as number | undefined) ??
+          1.0;
+      }
+    } else if (
+      material instanceof THREE.ShaderMaterial &&
+      material.uniforms?.baseColor?.value instanceof THREE.Vector3 &&
+      material.userData.originalBaseColor instanceof THREE.Vector3
+    ) {
+      (material.uniforms.baseColor.value as THREE.Vector3).copy(
+        material.userData.originalBaseColor,
+      );
+    }
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// Sidecar matcher
+// ────────────────────────────────────────────────────────────
+//
+// The Rust GLB writer at `crates/starbreaker-3d/src/gltf/glb_builder.rs`
+// (~line 2174) names each glTF material as:
+//
+//   {mtl_stem}_mtl_{material.name}_0{material_id}
+//
+// where `mtl_stem` is the basename (sans `.mtl`) of the source MTL file
+// (e.g. `CNOU_Mustang_Alpha`), `material.name` is the authored
+// SubMaterial name (e.g. `metal_a`), and `material_id` is the zero-based
+// integer index of the submaterial inside the MTL — written WITHOUT
+// padding but WITH a literal leading `0`, so idx 0 → `_00`, idx 11 →
+// `_011`, idx 100 → `_0100`.
+//
+// The decomposed sidecar `*.materials.json` keeps the same material
+// list and assigns each entry the same integer in `index`. The sidecar
+// also exposes:
+//
+//   - `submaterial_name` = `material.name` (raw authored name)
+//   - `blender_material_name` = `{mtl_stem}:{material.name}` (or
+//     `{mtl_stem}:{material.name}_{index}` when `material.name` is not
+//     unique within the MTL — see `preferred_blender_material_names`
+//     in `crates/starbreaker-3d/src/decomposed.rs`).
+//
+// Strict equality of `blender_material_name` against the GLB material
+// name therefore NEVER succeeds for the current writer — the GLB uses
+// underscores and a numeric suffix, the sidecar uses a colon. The
+// matcher below first tries strict equality (cheap, future-proof in
+// case the writer is ever changed to align), then falls back to
+// parsing the GLB suffix and matching on `(submaterial_name, index)`,
+// then on `submaterial_name` alone (case-insensitive) when the suffix
+// can't be parsed.
+
+interface ParsedGlbMaterialName {
+  baseName: string;
+  index: number;
+}
+
+/** Parse a glTF material name written by the Rust GLB builder.
+ *
+ *  Primary format (underscore): `{stem}_mtl_{name}_0{digits}$`
+ *  Returns the submaterial name and integer index.
+ *
+ *  Secondary format (colon): `{stem}:{name}` — emitted by older exports
+ *  that pre-date the `_mtl_` normalisation (pre contract v2). Returns
+ *  `index: -1` as a sentinel; the caller skips index-based strategies
+ *  and relies on strategy (1) / (2) name equality instead.
+ *
+ *  Returns null if neither format matches. */
+export function parseGlbMaterialName(
+  name: string,
+): ParsedGlbMaterialName | null {
+  if (!name) return null;
+
+  // Primary: anchored trailing `_0<digits>` AFTER an `_mtl_` separator.
+  // Both must be present together — otherwise the trailing `_01` could be
+  // a coincidental tail of an MTL submat name like `parkerized_metal_01`,
+  // and we'd misparse a colon-format name as having an index. Critically,
+  // a partial match here MUST fall through to the colon-format secondary
+  // check below rather than returning null.
+  const tail = /_0(\d+)$/.exec(name);
+  if (tail) {
+    const idx = Number.parseInt(tail[1], 10);
+    const before = name.slice(0, tail.index);
+    const sep = before.indexOf("_mtl_");
+    if (Number.isFinite(idx) && sep >= 0) {
+      const baseName = before.slice(sep + "_mtl_".length);
+      if (baseName) return { baseName, index: idx };
+    }
+    // Partial match — fall through to colon check.
+  }
+
+  // Secondary: colon-separated `{stem}:{name}`. The stem may be a ship
+  // stem, an MTL filename stem, or a generic component prefix.
+  // index: -1 signals no index is available; index-based strategies
+  // (3) and (5) are skipped for these names.
+  const colonIdx = name.indexOf(":");
+  if (colonIdx >= 0) {
+    const baseName = name.slice(colonIdx + 1);
+    if (baseName) return { baseName, index: -1 };
+  }
+
+  return null;
+}
+
+/** Locate the sidecar submaterial that corresponds to a glTF material
+ *  loaded from a GLB. Returns the sidecar entry plus the authoritative
+ *  index into `submats` (the caller wires materials by index). When no
+ *  match is possible, returns null and emits a single `console.warn`
+ *  with both the GLB name and the candidate sidecar names so the
+ *  mismatch is debuggable from the browser console without re-running
+ *  the export.
+ *
+ *  Match order:
+ *    1. Strict equality against `blender_material_name` (cheap; works
+ *       if the GLB writer is ever changed to use the same key).
+ *    2. Strict equality against `submaterial_name`.
+ *    3. Parse `..._mtl_<name>_0<index>$` from the GLB name and match
+ *       against `(submaterial_name, index)`.
+ *    4. Same as (3) but `submaterial_name` only, case-insensitive — a
+ *       last-chance fallback when sidecar `index` and GLB suffix have
+ *       drifted but names still align unambiguously.
+ *    5. Index-only fallback: parsed GLB index matched against the
+ *       sidecar entry whose `index` field equals it. This is the
+ *       generic bridge between GLB material names that come from one
+ *       MTL's source naming space (`pom_decals`, `graphic_decals`)
+ *       and sidecar entries that come from a Blender-semantic naming
+ *       space (`Decal_POM`, `Decal_DIFF`) — when the resolved sidecar
+ *       was authored against a different MTL than the GLB but the
+ *       loader still picks it (e.g. the KLWE laser merged-weapon GLBs
+ *       resolving to `component_master_01_TEX2.materials.json`). The
+ *       GLB writer at `gltf/glb_builder.rs` and the sidecar writer at
+ *       `decomposed.rs` both emit submaterials in
+ *       `materials.materials.iter().enumerate()` order, so positional
+ *       index is preserved across the two. Logged at warn so operators
+ *       can see when the names diverged enough that we resorted to
+ *       positional matching.
+ *
+ *  Generic by category: no per-ship branches, no hardcoded names. */
+export function findSubmaterialIndexForGlbName(
+  glbMaterialName: string,
+  submats: SubmaterialRecord[],
+): number {
+  if (!glbMaterialName || submats.length === 0) return -1;
+
+  // Name-only fallback. The primary binding path reads the Rust-emitted
+  // `material.extras.submat_index` directly (see scene-viewer.tsx); this
+  // function only runs for older cached GLBs produced before that field
+  // existed (pre contract v2). Those slots are auto-orphaned on the
+  // next app mount, so this whole ladder exists mostly to make stale
+  // cache hits render *something* during the brief overlap before the
+  // re-export completes.
+
+  // (1) strict equality on blender_material_name.
+  let idx = submats.findIndex(
+    (sm) => sm.blender_material_name === glbMaterialName,
+  );
+  if (idx >= 0) return idx;
+
+  // (2) strict equality on submaterial_name (covers exporter variants
+  //     that emit just the bare name as the glTF material name).
+  idx = submats.findIndex((sm) => sm.submaterial_name === glbMaterialName);
+  if (idx >= 0) return idx;
+
+  // (3) parse the GLB suffix and match on (name, index).
+  //     Skipped when parsed.index === -1 (colon-format, no index available).
+  const parsed = parseGlbMaterialName(glbMaterialName);
+  if (parsed) {
+    if (parsed.index >= 0) {
+      idx = submats.findIndex(
+        (sm) =>
+          sm.submaterial_name === parsed.baseName && sm.index === parsed.index,
+      );
+      if (idx >= 0) return idx;
+    }
+
+    // (4) name-only fallback, case-insensitive. Only commit if the
+    //     match is unambiguous — multiple hits means we can't decide.
+    const lower = parsed.baseName.toLowerCase();
+    const candidates: number[] = [];
+    for (let i = 0; i < submats.length; i += 1) {
+      const smName = submats[i].submaterial_name;
+      if (smName && smName.toLowerCase() === lower) candidates.push(i);
+    }
+    if (candidates.length === 1) return candidates[0];
+
+    // (5) index-only fallback. Names diverged entirely (different
+    //     naming spaces — MTL-source vs Blender-semantic), but both
+    //     writers enumerate submaterials in source order, so positional
+    //     alignment still matches like-for-like slot. Surface the bind
+    //     so operators can see the names diverged.
+    //     Skipped when parsed.index === -1 (colon-format, no index available).
+    if (parsed.index >= 0) {
+      const positional = submats.findIndex((sm) => sm.index === parsed.index);
+      if (positional >= 0) {
+        const boundName =
+          submats[positional].submaterial_name ??
+          submats[positional].blender_material_name ??
+          `idx:${parsed.index}`;
+        console.warn(
+          `[decomposed-loader] index-fallback: GLB material ` +
+            `'${glbMaterialName}' bound to sidecar entry ` +
+            `'${boundName}' by parsed index ${parsed.index} ` +
+            `(names diverged across naming spaces).`,
+        );
+        return positional;
+      }
+    }
+  }
+
+  // No match: leave the GLB's default material in place. Log enough
+  // context to debug from the browser console.
+  const sidecarNames = submats
+    .map((sm) => sm.submaterial_name ?? sm.blender_material_name ?? "?")
+    .slice(0, 16)
+    .join(", ");
+  const more = submats.length > 16 ? ` (+${submats.length - 16} more)` : "";
+  console.warn(
+    `[decomposed-loader] no sidecar submaterial matches GLB material ` +
+      `'${glbMaterialName}'. Sidecar candidates: [${sidecarNames}]${more}`,
+  );
+  return -1;
+}
+
+/**
+ * Apply a TexMod-derived UV transform to a Three.js texture. CryEngine
+ * `TileU/TileV` map directly to `texture.repeat`; `OffsetU/OffsetV` to
+ * `texture.offset`. Rotation pivots around the UV centre to match
+ * authoring expectations (Three.js otherwise rotates around (0,0)).
+ *
+ * The texture cache returns the SAME `THREE.Texture` instance for every
+ * call to `loadTexture(path)`. Mutating that shared instance leaks UV
+ * transforms across submaterials: the Mustang Beta `decals` submaterial
+ * sets `repeat=(1,1)` while a sibling submaterial that reuses the same
+ * source paint sets `repeat=(2,2)` — and whichever assigns last wins for
+ * every other consumer. The viewer renders the wrong stickers in the
+ * wrong tiles. To stay correct, callers MUST clone the source texture
+ * via `cloneTextureForSubmaterial` before applying any transform; this
+ * helper otherwise treats a missing transform as identity (leaves the
+ * texture unchanged).
+ */
+export function applyTextureTransform(
+  texture: THREE.Texture,
+  transform: TextureTransformRecord | null | undefined,
+): void {
+  if (!transform) return;
+  if (Array.isArray(transform.scale) && transform.scale.length >= 2) {
+    const sx = Number(transform.scale[0]) || 1;
+    const sy = Number(transform.scale[1]) || 1;
+    texture.repeat.set(sx, sy);
+    if (sx !== 1 || sy !== 1) {
+      // Tiling implies the texture should wrap; without this the GPU
+      // clamps and the second tile reads transparent on the edges.
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+    }
+  }
+  if (Array.isArray(transform.offset) && transform.offset.length >= 2) {
+    const tx = Number(transform.offset[0]) || 0;
+    const ty = Number(transform.offset[1]) || 0;
+    texture.offset.set(tx, ty);
+  }
+  const rot = typeof transform.rotation === "number" ? transform.rotation : 0;
+  if (rot !== 0) {
+    texture.rotation = rot;
+    texture.center.set(0.5, 0.5);
+  }
+}
+
+/**
+ * Return a per-submaterial copy of a cached source texture so that
+ * mutations (`repeat`, `offset`, `wrapS/T`, `colorSpace`, `rotation`,
+ * `center`) stay scoped to one material. The clone shares the underlying
+ * GPU image (via `texture.image`) — only the sampler state is duplicated,
+ * which is cheap. Without this, the texture cache's promise-dedup means
+ * every submaterial that loads the same source path receives the same
+ * `THREE.Texture` instance, and per-slot state set by one bleed into all
+ * the others.
+ *
+ * Three.js's `Texture.clone()` deep-copies the `Source` reference and
+ * sampler/transform state. We additionally reset `needsUpdate` because
+ * the parent texture is already uploaded to the GPU; the clone reuses
+ * the same `Source` so it never needs an upload.
+ */
+export function cloneTextureForSubmaterial(texture: THREE.Texture): THREE.Texture {
+  const clone = texture.clone();
+  // The cloned sampler state defaults to the parent's mutated values.
+  // Reset to identity so callers that DON'T have a `texture_transform`
+  // get a clean slate, and so consumers don't accidentally inherit an
+  // `offset` / `repeat` set by a prior consumer of the source texture.
+  clone.repeat.set(1, 1);
+  clone.offset.set(0, 0);
+  clone.rotation = 0;
+  clone.center.set(0, 0);
+  clone.wrapS = texture.wrapS;
+  clone.wrapT = texture.wrapT;
+  // Three.js needs to know the clone is ready to render without a
+  // re-upload because the underlying Source is shared with the parent.
+  clone.needsUpdate = false;
+  return clone;
+}
+
+/** Roles that contribute to a colour map. Detection is by the
+ *  exporter-emitted role enum; the `unknown` slot fallback is handled
+ *  separately by checking the TexSlotN identifier (TexSlot1 = base map). */
+function isBaseColorRole(role: string): boolean {
+  return (
+    role === "base_color" ||
+    role === "alternate_base_color" ||
+    role === "decal_sheet" ||
+    role.includes("diffuse") ||
+    role.includes("color") ||
+    role.includes("albedo")
+  );
+}
+
+function isNormalRole(role: string): boolean {
+  return role === "normal_gloss" || role.includes("normal");
+}
+
+function isSpecularRole(role: string): boolean {
+  return (
+    role === "specular_support" ||
+    role.includes("metal") ||
+    role.includes("specular")
+  );
+}
+
+function isEmissiveRole(role: string): boolean {
+  return role.includes("emissive") || role.includes("emit");
+}
+
+function isStencilRole(role: string, slotName: string): boolean {
+  // `stencil` is the explicit role; `tint_palette_decal` is the role the
+  // exporter assigns to MeshDecal `$TintPaletteDecal` virtual TexSlot7;
+  // some MeshDecal submaterials carry their stencil in TexSlot7 with
+  // role `unknown` for older sidecars.
+  return (
+    role === "stencil" ||
+    role === "tint_palette_decal" ||
+    slotName.toUpperCase() === "TEXSLOT7"
+  );
+}
+
+/** Recognise CryEngine height / displacement texture roles. The exporter
+ *  assigns `height` for explicit `HeightMap` slots and may use `displacement`
+ *  for the same slot in some material variants. POM (parallax occlusion
+ *  mapping) consumes this texture as the per-pixel ray-march source. */
+function isHeightRole(role: string, slotName: string): boolean {
+  return (
+    role === "height" ||
+    role === "displacement" ||
+    role.includes("height") ||
+    slotName.toUpperCase() === "TEXSLOT3"
+  );
+}
+
+/** Recognise CryEngine detail / breakup / dirt overlay roles. SD wires
+ *  these as multiplied surface variation in his `physical_surface`
+ *  template (sd_addon_rendering_map.md §E). Three.js doesn't have a
+ *  native overlay slot; we inject a multiply onto diffuseColor via
+ *  `onBeforeCompile`. The slot is informational — the actual shader
+ *  patch lives in `applyDirtOverlayShader`. */
+function isDirtOverlayRole(role: string, slotName: string): boolean {
+  return (
+    role === "dirt" ||
+    role === "detail" ||
+    role === "breakup" ||
+    role.includes("dirt") ||
+    role.includes("detail") ||
+    role.includes("breakup") ||
+    // Common CryEngine slots for surface variation.
+    slotName.toUpperCase() === "TEXSLOT4" ||
+    slotName.toUpperCase() === "TEXSLOT5"
+  );
+}
+
+/** Per-material shader extras: composable hooks queued during the
+ *  texture-load phase and applied once when promises settle. The patches
+ *  are stacked rather than overwriting `onBeforeCompile` directly so
+ *  multiple effects (DDNA roughness + POM + dirt overlay + system-B
+ *  iridescence + ...) coexist without clobbering each other. */
+interface MaterialShaderHooks {
+  ddnaRoughness?: boolean;
+  pomHeightMap?: THREE.Texture;
+  pomScale?: number;
+  dirtOverlayMap?: THREE.Texture;
+  /** Fresnel-blended secondary/tertiary palette colours used by the
+   *  iridescent paint variants. Activated when the submat's source MTL
+   *  filename ends in `_i` (gated upstream in
+   *  `buildHardSurfaceMaterial`). Mirrors the Fresnel-blend node group
+   *  used by the Blender importer. */
+  systemBSecondary?: THREE.Color;
+  systemBTertiary?: THREE.Color;
+}
+
+/** Apply a queued bundle of shader hooks via `onBeforeCompile`. Three.js
+ *  invokes `onBeforeCompile` once per material when the program first
+ *  compiles; subsequent calls require `material.needsUpdate = true`. */
+function applyShaderHooks(
+  material: THREE.MeshStandardMaterial | THREE.MeshPhysicalMaterial,
+  hooks: MaterialShaderHooks,
+): void {
+  if (
+    !hooks.ddnaRoughness &&
+    !hooks.pomHeightMap &&
+    !hooks.dirtOverlayMap &&
+    !hooks.systemBSecondary
+  ) {
+    return;
+  }
+  material.onBeforeCompile = (shader) => {
+    // DDNA: re-derive roughness from alpha channel.
+    if (hooks.ddnaRoughness) {
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <roughnessmap_fragment>",
+        [
+          "float roughnessFactor = roughness;",
+          "#ifdef USE_ROUGHNESSMAP",
+          "  vec4 texelRoughness = texture2D( roughnessMap, vRoughnessMapUv );",
+          "  roughnessFactor *= 1.0 - texelRoughness.a;",
+          "#endif",
+        ].join("\n"),
+      );
+    }
+
+    // POM: parallax occlusion ray-march replaces the standard map UV
+    // lookup with a height-displaced one. 16 sample steps is a
+    // reasonable cost/quality balance for typical hull-detail surfaces.
+    if (hooks.pomHeightMap) {
+      const heightScale = hooks.pomScale ?? 0.015;
+      shader.uniforms.pomHeightMap = { value: hooks.pomHeightMap };
+      shader.uniforms.pomHeightScale = { value: heightScale };
+
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <common>",
+        [
+          "#include <common>",
+          "uniform sampler2D pomHeightMap;",
+          "uniform float pomHeightScale;",
+        ].join("\n"),
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <map_fragment>",
+        [
+          "vec3 pomViewDir = normalize(vViewPosition);",
+          "vec2 pomUV = vMapUv;",
+          "{",
+          "  const int POM_STEPS = 16;",
+          "  float stepSize = 1.0 / float(POM_STEPS);",
+          "  float currentLayerH = 1.0;",
+          "  vec2 dtex = pomViewDir.xy * pomHeightScale / (abs(pomViewDir.z) + 0.001) / float(POM_STEPS);",
+          "  float texH = texture2D(pomHeightMap, pomUV).r;",
+          "  for (int i = 0; i < POM_STEPS; i++) {",
+          "    if (currentLayerH <= texH) break;",
+          "    pomUV -= dtex;",
+          "    texH = texture2D(pomHeightMap, pomUV).r;",
+          "    currentLayerH -= stepSize;",
+          "  }",
+          "}",
+          "#ifdef USE_MAP",
+          "  vec4 sampledDiffuseColor = texture2D(map, pomUV);",
+          "  #ifdef DECODE_VIDEO_TEXTURE",
+          "    sampledDiffuseColor = sRGBTransferEOTF(sampledDiffuseColor);",
+          "  #endif",
+          "  diffuseColor *= sampledDiffuseColor;",
+          "#endif",
+        ].join("\n"),
+      );
+    }
+
+    // Dirt / detail / breakup: a multiplied overlay on diffuseColor.
+    // CryEngine authors these as subtle surface variation that reads
+    // best when applied AFTER the base diffuse (and POM if present)
+    // have been sampled. SD does this inside his `physical_surface`
+    // template node graph; we inject an extra sample + multiply at the
+    // end of the diffuse fragment.
+    if (hooks.dirtOverlayMap) {
+      shader.uniforms.dirtOverlayMap = { value: hooks.dirtOverlayMap };
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <common>",
+        [
+          "#include <common>",
+          "uniform sampler2D dirtOverlayMap;",
+        ].join("\n"),
+      );
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <map_fragment>",
+        [
+          "#include <map_fragment>",
+          "#ifdef USE_MAP",
+          "  vec4 dirtSample = texture2D(dirtOverlayMap, vMapUv);",
+          // Multiplied overlay: 0 = full dirt darkening, 1 = clean.
+          // Limit darkening so even fully-dirty texels still read.
+          "  float dirtMix = mix(0.7, 1.0, dirtSample.r);",
+          "  diffuseColor.rgb *= dirtMix;",
+          "#endif",
+        ].join("\n"),
+      );
+    }
+
+    // Iridescent paint: Fresnel-weighted blend between secondary
+    // (entryB) and tertiary (entryC) palette colours. Mirrors the
+    // Fresnel-blend approach used by the Blender importer. The weight
+    // `pow(1 - NdotV, 5)` is a standard Schlick-style approximation.
+    //
+    // Caller pre-sets `material.color = white(0xffffff)` so the
+    // existing `<color_fragment>` and `<map_fragment>` paths leave
+    // diffuseColor at the texture's raw sample — we then multiply
+    // by the Fresnel-blended palette colour after those run.
+    if (hooks.systemBSecondary && hooks.systemBTertiary) {
+      shader.uniforms.systemBSecondary = {
+        value: new THREE.Vector3(
+          hooks.systemBSecondary.r,
+          hooks.systemBSecondary.g,
+          hooks.systemBSecondary.b,
+        ),
+      };
+      shader.uniforms.systemBTertiary = {
+        value: new THREE.Vector3(
+          hooks.systemBTertiary.r,
+          hooks.systemBTertiary.g,
+          hooks.systemBTertiary.b,
+        ),
+      };
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <common>",
+        [
+          "#include <common>",
+          "uniform vec3 systemBSecondary;",
+          "uniform vec3 systemBTertiary;",
+        ].join("\n"),
+      );
+      // Inject AFTER <map_fragment> so the diffuse texture has been
+      // sampled. Three.js sets `vNormal` and `vViewPosition` as
+      // varyings in the standard MeshStandardMaterial vertex shader,
+      // so we can compute the view-space Fresnel directly.
+      shader.fragmentShader = shader.fragmentShader.replace(
+        "#include <map_fragment>",
+        [
+          "#include <map_fragment>",
+          "{",
+          "  vec3 sysBN = normalize(vNormal);",
+          "  vec3 sysBV = normalize(vViewPosition);",
+          "  float sysBFresnel = pow(1.0 - clamp(dot(sysBN, sysBV), 0.0, 1.0), 5.0);",
+          "  vec3 sysBPalette = mix(systemBSecondary, systemBTertiary, sysBFresnel);",
+          "  diffuseColor.rgb *= sysBPalette;",
+          "}",
+        ].join("\n"),
+      );
+    }
+  };
+}
+
+/** Cumulative material-build metrics surfaced in the scene-viewer
+ *  status line. Reset per load via `resetMaterialMetrics`; read via
+ *  `getMaterialMetrics`. Counters increment as materials are built and
+ *  as their texture promises settle. */
+export interface MaterialBuildMetrics {
+  totalBuilt: number;
+  byFamily: Record<string, number>;
+  /** HardSurface submats whose `tint_palette` had entries but
+   *  `assigned_channel` was null — the loader fell back to `primary`. */
+  paletteHeuristicPrimaryFallback: number;
+  /** Submats where `resolvePaletteEntry` returned a usable entry. */
+  paletteTintApplied: number;
+  /** HardSurface submats with a `tint_palette` whose entry could not
+   *  be resolved (no entries OR routed-channel-not-found). */
+  paletteTintMissing: number;
+  /** Submats where `material.map` ended up populated after texture
+   *  promises settled. */
+  diffuseTextureSuccess: number;
+  /** HardSurface submats that authored at least one texture slot but
+   *  ended with `material.map` still null (load failure or all slots
+   *  routed to non-base roles). */
+  diffuseTextureMiss: number;
+  clearCoatFired: number;
+  systemAFired: number;
+  systemBFired: number;
+  ddnaRoughnessHooked: number;
+  dirtOverlayHooked: number;
+  pomHooked: number;
+}
+
+function makeEmptyMetrics(): MaterialBuildMetrics {
+  return {
+    totalBuilt: 0,
+    byFamily: {},
+    paletteHeuristicPrimaryFallback: 0,
+    paletteTintApplied: 0,
+    paletteTintMissing: 0,
+    diffuseTextureSuccess: 0,
+    diffuseTextureMiss: 0,
+    clearCoatFired: 0,
+    systemAFired: 0,
+    systemBFired: 0,
+    ddnaRoughnessHooked: 0,
+    dirtOverlayHooked: 0,
+    pomHooked: 0,
+  };
+}
+
+const metrics: MaterialBuildMetrics = makeEmptyMetrics();
+
+/** Wipe metrics at the start of a fresh scene load. */
+export function resetMaterialMetrics(): void {
+  const fresh = makeEmptyMetrics();
+  Object.assign(metrics, fresh);
+  metrics.byFamily = fresh.byFamily;
+}
+
+/** Snapshot of the current metrics. The returned object is a shallow
+ *  copy — `byFamily` is a fresh map so callers can mutate safely. */
+export function getMaterialMetrics(): MaterialBuildMetrics {
+  return { ...metrics, byFamily: { ...metrics.byFamily } };
+}
+
+/** Diagnostic counters tracking which material-build path each HardSurface
+ *  submaterial takes. Emits a single console.info summary line ~1s after
+ *  the last build, so the user can confirm S1 (ClearCoat) and S3 (System B
+ *  Fresnel) are firing without having to grep individual log lines. */
+const hsDiag = {
+  basic: 0,
+  clearcoat: 0,
+  systemA: 0,
+  systemB: 0,
+  flushTimer: null as ReturnType<typeof setTimeout> | null,
+};
+
+function recordHardSurfaceBuild(
+  useSystemB: boolean,
+  isSystemA: boolean,
+  wantsClearCoat: boolean,
+): void {
+  if (useSystemB) hsDiag.systemB += 1;
+  else if (isSystemA) hsDiag.systemA += 1;
+  else if (wantsClearCoat) hsDiag.clearcoat += 1;
+  else hsDiag.basic += 1;
+  if (hsDiag.flushTimer) clearTimeout(hsDiag.flushTimer);
+  hsDiag.flushTimer = setTimeout(() => {
+    const total =
+      hsDiag.basic + hsDiag.clearcoat + hsDiag.systemA + hsDiag.systemB;
+    console.info(
+      `[hardsurface] built ${total}: clearcoat=${hsDiag.clearcoat} ` +
+        `systemB=${hsDiag.systemB} systemA=${hsDiag.systemA} ` +
+        `basic=${hsDiag.basic}`,
+    );
+    hsDiag.basic = 0;
+    hsDiag.clearcoat = 0;
+    hsDiag.systemA = 0;
+    hsDiag.systemB = 0;
+    hsDiag.flushTimer = null;
+  }, 1000);
+}
+
+/** Detect whether a submaterial's source MTL is the `_i` iridescent
+ *  variant (e.g. shimmerscale paints, two-tone variants). When the
+ *  exporter emits `<stem>:<base>` blender_material_name strings, the
+ *  stem mirrors the source MTL filename minus `.mtl`, so a hull that
+ *  references `<paint>_i.mtl` shows up here as `<paint>_i:<submat>`.
+ *
+ *  The detection is intentionally narrow: only the trailing
+ *  underscore-i in the stem position triggers, so panels named with
+ *  embedded `_i` don't false-positive. */
+function isSystemBIridescent(submaterial: SubmaterialRecord): boolean {
+  const blenderName = submaterial.blender_material_name ?? "";
+  const colonIdx = blenderName.indexOf(":");
+  if (colonIdx > 0) {
+    const stem = blenderName.slice(0, colonIdx);
+    if (stem.toLowerCase().endsWith("_i")) return true;
+  }
+  return false;
+}
+
+/** Find a `TintPaletteEntry` by channel name (case-insensitive). */
+function findEntry(
+  entries: TintPaletteEntry[] | null | undefined,
+  channelName: string,
+): TintPaletteEntry | null {
+  if (!entries) return null;
+  const target = channelName.toLowerCase();
+  for (const entry of entries) {
+    if (entry.channel?.toLowerCase() === target) return entry;
+  }
+  return null;
+}
+
+/** Convert a `TintPaletteEntry`'s tint_color triplet to a Three.js
+ *  Color, or null if the entry is missing or malformed. The exporter
+ *  emits linear-space RGB, so no sRGB conversion is needed. */
+function rgbFromEntry(entry: TintPaletteEntry | null): THREE.Color | null {
+  if (!entry || !entry.tint_color) return null;
+  const [r, g, b] = entry.tint_color;
+  if (typeof r !== "number" || typeof g !== "number" || typeof b !== "number") {
+    return null;
+  }
+  return new THREE.Color(r, g, b);
+}
+
+/**
+ * Build a Three.js material for one submaterial record under a given
+ * render style. Returns the material plus a list of texture-load
+ * promises so the caller can wait for visual completion.
+ *
+ * Generic by design: no per-ship branches. Behaviour is keyed on
+ * `submaterial.shader_family` and the per-slot role / alpha_semantic /
+ * texture_transform fields, which the exporter populates for every
+ * entity. Adding a new ship requires no code changes here.
+ */
+export function buildMaterial(
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+  style: RenderStyle = "textured",
+): {
+  material: THREE.Material;
+  texturePromises: Promise<void>[];
+} {
+  const name =
+    submaterial.blender_material_name ??
+    submaterial.submaterial_name ??
+    "submaterial";
+  const family = submaterial.shader_family ?? "Unknown";
+
+  metrics.totalBuilt += 1;
+  metrics.byFamily[family] = (metrics.byFamily[family] ?? 0) + 1;
+
+  // Non-textured styles ignore sidecar textures entirely. Build them
+  // up-front and bail early. The palette tint is preserved for HardSurface
+  // submaterials so a Mustang in Metallic style still reads as the painted
+  // hull colour rather than reverting to the diagnostic grey.
+  if (style !== "textured") {
+    return {
+      material: buildStyledMaterial(name, family, style, submaterial),
+      texturePromises: [],
+    };
+  }
+
+  // Family-specific PBR construction.
+  //
+  // Decal classification is by feature flag, not just `shader_family`.
+  // CryEngine authors decals across multiple shader families: dedicated
+  // `MeshDecal` for stencil-driven projection, `Illum` with `%DECAL`
+  // and `%DECAL_OPACITY_MAP` flags for hull livery / "stickers", and
+  // `HardSurface` with `%DECAL` for layered paint stripes (Mustang Beta
+  // `decal_geometry`). All three need transparent + depth-write off +
+  // polygon offset to overlay correctly on the host hull. Routing them
+  // through `buildHardSurfaceMaterial` (the prior default) renders them
+  // as opaque metal painted *over* the hull, which is the "wrong
+  // sticker / wrong tile" bug the user reported on Mustang Beta —
+  // siblings sharing the same source texture mutated each others'
+  // sampler state, and the resulting opaque overlay fully occludes the
+  // hull beneath.
+  if (isDecalSubmaterial(submaterial)) {
+    return buildDecalMaterial(name, submaterial, loadTexture);
+  }
+  // Family-specific dispatch. Mirrors SD's `template_plan_for_submaterial`
+  // (upstream-sd/blender_addon/starbreaker_addon/templates.py:56-84):
+  // 11 CryEngine shader families collapse to 7 template branches. SD's
+  // 7 templates map to our 7 builder paths:
+  //
+  //   nodraw          -> buildNoDrawMaterial
+  //   layered_wear    -> buildLayerMaterial (Layer / LayerBlend_V2)
+  //   decal_stencil   -> buildDecalMaterial (MeshDecal + Illum-decal +
+  //                                           HardSurface-decal via flag)
+  //   parallax_pom    -> handled inside buildHardSurfaceMaterial via
+  //                       has_parallax_occlusion_mapping flag (POM is
+  //                       a HardSurface family with the %POM token)
+  //   screen_hud      -> buildScreenMaterial (DisplayScreen, Monitor,
+  //                                            UIPlane, UIMesh)
+  //   physical_glass  -> buildGlassMaterial (GlassPBR)
+  //   physical_surface-> buildHardSurfaceMaterial (HardSurface default)
+  //
+  // Plus three families SD groups under `biological` and one Hologram
+  // path that we split out:
+  //
+  //   biological      -> buildSkinMaterial (HumanSkin_V2, Eye, HairPBR,
+  //                                          Organic)
+  //   hologram        -> buildHologramMaterial (Hologram, HologramCIG,
+  //                                              Shield_Holo)
+  //
+  // Anything we don't recognise falls through to HardSurface, which is
+  // CryEngine's default material family and the safe fallback per SD.
+  switch (family) {
+    case "NoDraw":
+      return buildNoDrawMaterial(name);
+    case "GlassPBR":
+      return buildGlassMaterial(name, submaterial, loadTexture);
+    case "MeshDecal":
+      // Defensive: should be caught by `isDecalSubmaterial` above, but
+      // older sidecars without `decoded_feature_flags` still fall here.
+      return buildDecalMaterial(name, submaterial, loadTexture);
+    case "Layer":
+    case "LayerBlend_V2":
+      return buildLayerMaterial(name, submaterial, loadTexture);
+    case "Illum":
+      return buildIllumMaterial(name, submaterial, loadTexture);
+    case "DisplayScreen":
+    case "Monitor":
+    case "UIPlane":
+    case "UIMesh":
+      // Render-to-texture / UI screen families. Their authored slots
+      // are TexSlot6 (screen mask) and TexSlot9 ($RenderToTexture, a
+      // virtual path the engine substitutes at runtime — no on-disk
+      // PNG). Routing them through buildHardSurfaceMaterial leaves no
+      // diffuse and emits grey PBR. The emissive-panel stopgap is the
+      // closest stand-in without a real render target.
+      return buildScreenMaterial(name, family);
+    case "Hologram":
+    case "HologramCIG":
+    case "Shield_Holo":
+      return buildHologramMaterial(name, family);
+    case "HumanSkin_V2":
+    case "Eye":
+    case "HairPBR":
+    case "Organic":
+      return buildSkinMaterial(name, family, submaterial, loadTexture);
+    case "HardSurface":
+      return buildHardSurfaceMaterial(name, submaterial, loadTexture);
+    default: {
+      // Unrecognised shader family — route through HardSurface (the
+      // safe CryEngine default per SD) but re-tag as
+      // family_unknown_default so the picker / debug-fallback mode
+      // can surface it. The HardSurface builder already tagged
+      // originalColor with the palette tint; we overwrite the kind
+      // and re-apply debug colouring so the toggle picks up the new
+      // kind.
+      const built = buildHardSurfaceMaterial(name, submaterial, loadTexture);
+      const m = built.material;
+      m.userData.fallbackKind = FALLBACK_KINDS.FAMILY_UNKNOWN_DEFAULT;
+      applyDebugFallbackToMaterial(m);
+      return built;
+    }
+  }
+}
+
+/** Stopgap for shader families that author screen / HUD content via
+ *  render-to-texture rather than a diffuse PNG. Returns an unlit
+ *  emissive-coloured panel with light alpha so it reads as a glowing
+ *  display. No texture lookups, so safe to call when slots are empty. */
+function buildScreenMaterial(
+  name: string,
+  family: string,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const material = new THREE.MeshBasicMaterial({
+    name,
+    color: colourForFamily(family),
+    transparent: true,
+    opacity: 0.85,
+    depthWrite: false,
+  });
+  material.userData.fallbackKind = FALLBACK_KINDS.SCREEN_STUB;
+  tagOriginalColor(material);
+  applyDebugFallbackToMaterial(material);
+  return { material, texturePromises: [] };
+}
+
+/** Hologram / HologramCIG / Shield_Holo: animated translucent shader
+ *  with Fresnel-driven rim brightening and scanlines. The shader needs
+ *  per-frame `time` updates; we attach an updater so the scene-viewer's
+ *  animate loop can tick all hologram materials.
+ *
+ *  This is a simple unlit-emissive + angular-fresnel approximation;
+ *  the source format's hologram shader does more (scrolling noise,
+ *  edge iridescence, fresnel-modulated transparency), but this reads
+ *  as "hologram" in practice and is much closer than a flat fill. */
+const HOLOGRAM_VERTEX_SHADER = /* glsl */ `
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+  void main() {
+    #ifdef USE_INSTANCING
+      vec4 mvPos = modelViewMatrix * instanceMatrix * vec4(position, 1.0);
+      vNormal = normalize(normalMatrix * mat3(instanceMatrix) * normal);
+    #else
+      vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
+      vNormal = normalize(normalMatrix * normal);
+    #endif
+    vViewDir = normalize(-mvPos.xyz);
+    gl_Position = projectionMatrix * mvPos;
+  }
+`;
+
+const HOLOGRAM_FRAGMENT_SHADER = /* glsl */ `
+  uniform float time;
+  uniform vec3 baseColor;
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+  void main() {
+    float fresnel = pow(1.0 - abs(dot(vNormal, vViewDir)), 2.5);
+    float scanline = 0.85 + 0.15 * sin(gl_FragCoord.y * 2.0);
+    float shimmer = 0.95 + 0.05 * sin(time * 3.0 + gl_FragCoord.x * 0.1);
+    vec3 color = baseColor * (0.15 + fresnel * 0.6) * scanline * shimmer;
+    float alpha = (0.08 + fresnel * 0.5) * scanline;
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+/** Registry of live hologram materials so the scene-viewer animate loop
+ *  can update their `time` uniform each frame. The scene viewer pulls
+ *  this list once per frame and writes elapsed time into each. Cleared
+ *  when the scene unloads (per package generation). */
+export const hologramMaterials: THREE.ShaderMaterial[] = [];
+
+function buildHologramMaterial(
+  name: string,
+  family: string,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const tint = colourForFamily(family);
+  // Tint base toward cyan to match CryEngine's hologram default; some
+  // ships override via emissive textures but the family default is
+  // a saturated cyan-blue.
+  const blended = new THREE.Color();
+  const hsl = { h: 0, s: 0, l: 0 };
+  tint.getHSL(hsl);
+  blended.setHSL(0.52 + (hsl.h - 0.52) * 0.15, 0.7, 0.55);
+  const baseColorVec = new THREE.Vector3(blended.r, blended.g, blended.b);
+  const material = new THREE.ShaderMaterial({
+    name,
+    uniforms: {
+      time: { value: 0.0 },
+      baseColor: { value: baseColorVec },
+    },
+    vertexShader: HOLOGRAM_VERTEX_SHADER,
+    fragmentShader: HOLOGRAM_FRAGMENT_SHADER,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+  });
+  material.userData.fallbackKind = FALLBACK_KINDS.HOLOGRAM_STUB;
+  tagOriginalColor(material);
+  applyDebugFallbackToMaterial(material);
+  hologramMaterials.push(material);
+  return { material, texturePromises: [] };
+}
+
+/** Layer / LayerBlend_V2: same backbone as HardSurface but the
+ *  `layer_manifest` may publish multiple wear/damage layers. SD's
+ *  `layered_wear` template blends Primary + Wear via a per-pixel mask;
+ *  we currently pick the first layer whose `palette_channel` matches
+ *  the submaterial's `material_channel` (already happens in
+ *  `synthesisedLayerSlots`). The visible diffuse + normal end up in
+ *  texture_slots and route through the standard HardSurface path —
+ *  this builder exists so future layer-blend work has a hook, and so
+ *  Layer materials don't fall through the dispatch's `default` arm
+ *  alongside truly unknown families. */
+function buildLayerMaterial(
+  name: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  return buildHardSurfaceMaterial(name, submaterial, loadTexture);
+}
+
+/** Illum: emissive-heavy material. CryEngine uses Illum for
+ *  self-illuminated panels (control consoles, holographic ad boards
+ *  that aren't full Hologram shaders, glowing accent panels). Most
+ *  Illum submats carry an emissive texture; we route through the
+ *  HardSurface backbone (which already wires emissiveMap from any
+ *  emissive-roled slot) and bias emissive intensity up. */
+function buildIllumMaterial(
+  name: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const built = buildHardSurfaceMaterial(name, submaterial, loadTexture);
+  if (built.material instanceof THREE.MeshStandardMaterial) {
+    // Illum panels are self-lit. Boost the emissive intensity so the
+    // panel doesn't depend on scene lighting to be visible.
+    built.material.emissiveIntensity = 1.5;
+  }
+  return built;
+}
+
+/** HumanSkin_V2 / Eye / HairPBR / Organic: character-shader family.
+ *  SD's `biological` template implements proper subsurface for skin,
+ *  anisotropic specular for eyes, and fibre highlights for hair. We
+ *  ship a tuned MeshPhysicalMaterial baseline that reads passably for
+ *  characters: low metalness, medium roughness, slight clearcoat for
+ *  eye / wet-surface materials. Hair gets higher anisotropy via the
+ *  built-in `anisotropy` knob in MeshPhysicalMaterial r155+. */
+function buildSkinMaterial(
+  name: string,
+  family: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const isHair = family === "HairPBR";
+  const isEye = family === "Eye";
+  const material = new THREE.MeshPhysicalMaterial({
+    name,
+    color: new THREE.Color(0xc9a48c),
+    metalness: 0.0,
+    roughness: isHair ? 0.5 : isEye ? 0.1 : 0.6,
+    // Eyes get a clearcoat layer to simulate the cornea wet-surface
+    // specular over the iris/sclera diffuse.
+    clearcoat: isEye ? 1.0 : 0.0,
+    clearcoatRoughness: isEye ? 0.05 : 0.0,
+    // Hair gets anisotropy to streak highlights along the strand
+    // direction (best with proper tangent UVs; fallback otherwise).
+    anisotropy: isHair ? 0.7 : 0.0,
+  });
+  material.userData.fallbackKind = FALLBACK_KINDS.SKIN_DEFAULT;
+  tagOriginalColor(material);
+  applyDebugFallbackToMaterial(material);
+  const texturePromises: Promise<void>[] = [];
+  for (const slot of mergedSlots(submaterial)) {
+    if (!slot.export_path) continue;
+    const role = (slot.role ?? "").toLowerCase();
+    const slotName = (slot.slot ?? "").toUpperCase();
+    const promise = loadTexture(slot.export_path).then((sourceTex) => {
+      if (!sourceTex) return;
+      const tex = cloneTextureForSubmaterial(sourceTex);
+      applyTextureTransform(tex, slot.texture_transform);
+      if (isBaseColorRole(role) || slotName === "TEXSLOT1") {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.map = tex;
+        material.needsUpdate = true;
+      } else if (isNormalRole(role)) {
+        material.normalMap = tex;
+        material.needsUpdate = true;
+      } else if (isEmissiveRole(role)) {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.emissiveMap = tex;
+        material.emissive = new THREE.Color(0xffffff);
+        material.emissiveIntensity = 0.8;
+        material.needsUpdate = true;
+      }
+    });
+    texturePromises.push(promise);
+  }
+  return { material, texturePromises };
+}
+
+/** NoDraw: collision proxies and other geometry that should never
+ *  render. SD's `nodraw` template uses CLIP blend with full transparency.
+ *  In Three.js we set the mesh fully invisible via material.visible
+ *  semantics — but we still want to return a Material so the binding
+ *  pipeline has something to attach. A zero-alpha transparent material
+ *  with no depth write achieves the same effect.  */
+function buildNoDrawMaterial(
+  name: string,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const material = new THREE.MeshBasicMaterial({
+    name,
+    color: 0x000000,
+    transparent: true,
+    opacity: 0.0,
+    depthWrite: false,
+    // Never colorWrite either — completely invisible but still in the
+    // scene graph so traversal doesn't break.
+    colorWrite: false,
+  });
+  return { material, texturePromises: [] };
+}
+
+/** Classify a submaterial as decal-like across all shader families. The
+ *  CryEngine source of truth is the `%DECAL` / `%DECAL_OPACITY_MAP` /
+ *  `%STENCIL_MAP` tokens in StringGenMask, which the Rust exporter
+ *  decodes into `decoded_feature_flags`. We also accept `MeshDecal`
+ *  shader_family for older exports that predate the flag decoder.
+ *
+ *  Generic by category — keys off the feature flags, not the
+ *  submaterial name or ship name. New decal shader variants surface
+ *  automatically as soon as the exporter parses the right token. */
+export function isDecalSubmaterial(submaterial: SubmaterialRecord): boolean {
+  const family = submaterial.shader_family ?? "";
+  if (family === "MeshDecal") return true;
+  const flags = submaterial.decoded_feature_flags;
+  if (!flags) return false;
+  if (flags.has_decal) return true;
+  if (flags.has_stencil_map) return true;
+  return false;
+}
+
+/** Build one of the diagnostic / artistic styles. None of these consult
+ *  textures so they render uniformly across all entities. Tinting is
+ *  derived from the family rather than hardcoded per-asset so the modes
+ *  remain visually informative (glass cf. hull cf. decal). HardSurface
+ *  submaterials with a resolved palette tint use the palette colour
+ *  instead of the family default — the Metallic/Opaque styles then read
+ *  as the painted hull colour, which is more useful than uniform grey. */
+function buildStyledMaterial(
+  name: string,
+  family: string,
+  style: Exclude<RenderStyle, "textured">,
+  submaterial: SubmaterialRecord,
+): THREE.Material {
+  const paletteTint = resolvePaletteTint(submaterial);
+  const baseColour =
+    family === "HardSurface" && paletteTint
+      ? paletteTint
+      : colourForFamily(family);
+  switch (style) {
+    case "metallic":
+      return new THREE.MeshStandardMaterial({
+        name,
+        color: baseColour,
+        metalness: 0.85,
+        roughness: 0.25,
+      });
+    case "opaque":
+      return new THREE.MeshStandardMaterial({
+        name,
+        color: baseColour,
+        metalness: 0.05,
+        roughness: 0.85,
+      });
+    case "glass":
+      return new THREE.MeshStandardMaterial({
+        name,
+        color: baseColour,
+        metalness: 0.6,
+        roughness: 0.2,
+        transparent: true,
+        opacity: 0.35,
+        depthWrite: false,
+      });
+    case "holographic":
+    default:
+      return new THREE.MeshBasicMaterial({
+        name,
+        color: baseColour,
+        transparent: true,
+        opacity: 0.45,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+      });
+  }
+}
+
+/** Family-keyed tint used by the diagnostic styles. Generic colour wheel
+ *  by structural category: hulls grey, glass cyan, decals magenta,
+ *  emissives amber. */
+function colourForFamily(family: string): THREE.Color {
+  switch (family) {
+    case "GlassPBR":
+      return new THREE.Color(0x6ca8c8);
+    case "MeshDecal":
+      return new THREE.Color(0xc864c8);
+    case "Hologram":
+    case "HologramCIG":
+    case "Shield_Holo":
+      return new THREE.Color(0x66ccff);
+    case "DisplayScreen":
+    case "Monitor":
+    case "UIPlane":
+    case "UIMesh":
+      return new THREE.Color(0xffcc66);
+    default:
+      return new THREE.Color(0xc8c8c8);
+  }
+}
+
+/** Detect whether a palette channel encodes iridescent / angle-shift paint.
+ *
+ *  Ported from upstream-sd's `_palette_channel_has_iridescence`
+ *  (blender_addon/starbreaker_addon/runtime/palette_utils.py). The signal
+ *  is purely the palette's per-channel data — no boolean flag exists in
+ *  CIG's authored data, the engine deduces iridescence from how the
+ *  finish_specular relates to the base tint_color:
+ *
+ *    1. The channel's spec_color must be visibly chromatic
+ *       (max-min ≥ 0.10) — a flat grey spec is just standard
+ *       reflectance, not shimmer.
+ *    2. The spec_color must be far enough from the base tint_color
+ *       (Euclidean distance ≥ 0.12) that the angular endpoints
+ *       produce a visible shift.
+ *
+ *  For Aurora's shimmerscale paint, this fires on the tertiary channel
+ *  (colorful spec like teal/purple, distant from the dark base color).
+ *  The default RSI/Aurora_Mk2_White_Gray_Red palette and standard
+ *  paints fail one or both tests and stay non-iridescent. */
+function paletteChannelHasIridescence(
+  entries: TintPaletteEntry[] | null | undefined,
+  channelName: string | null | undefined,
+): boolean {
+  if (!entries || !channelName) return false;
+  const channel = channelName.toLowerCase();
+  if (channel !== "primary" && channel !== "secondary" && channel !== "tertiary") {
+    return false;
+  }
+  const entry = entries.find((e) => e.channel?.toLowerCase() === channel);
+  if (!entry || !entry.spec_color) return false;
+  const [fr, fg, fb] = entry.spec_color;
+  const [gr, gg, gb] = entry.tint_color;
+  const specChroma = Math.max(fr, fg, fb) - Math.min(fr, fg, fb);
+  if (specChroma < 0.1) return false;
+  const colorDistance = Math.sqrt(
+    (fr - gr) ** 2 + (fg - gg) ** 2 + (fb - gb) ** 2,
+  );
+  return colorDistance >= 0.12;
+}
+
+/** Build a HardSurface PBR material: BaseColor → map, NormalGloss → both
+ *  normalMap and (alpha-derived) roughnessMap, Emissive → emissiveMap.
+ *
+ *  When the sidecar carries a `tint_palette` with a resolved
+ *  `assigned_channel`, the channel's `tint_color` is set on
+ *  `material.color` and the standard `final_albedo = tint × diffuse`
+ *  composition falls out of MeshStandardMaterial's per-fragment colour
+ *  × map multiplication automatically — no custom shader required.
+ *
+ *  When the routed palette channel encodes iridescence (per
+ *  `paletteChannelHasIridescence`), this builds a `MeshPhysicalMaterial`
+ *  with iridescence + sheen rather than a `MeshStandardMaterial`, so
+ *  angle-shift paints (e.g. iridescent `_i.mtl` variants) get the
+ *  tertiary palette spec_color blended toward at grazing angles.
+ *  Three.js's built-in `iridescence` is thin-film, which combined with
+ *  `sheen` driven by the spec_color gives a reasonable approximation
+ *  of the in-engine look without a custom shader.
+ *
+ *  Layered HardSurface submaterials publish their visible diffuse/normal
+ *  pair via `layer_manifest` rather than `texture_slots`, because the
+ *  authored Layer chain (Primary, Wear, etc.) is preserved upstream for
+ *  future blending work. We synthesise TexSlot entries from the layer
+ *  whose `palette_channel` matches the submaterial's
+ *  `palette_routing.material_channel`, so the unified slot pipeline below
+ *  picks them up the same way it handles directly-authored textures. */
+function buildHardSurfaceMaterial(
+  name: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const paletteTint = resolvePaletteTint(submaterial);
+  const channelName = submaterial.palette_routing?.material_channel?.name ?? null;
+  const paletteEntry = resolvePaletteEntry(submaterial);
+  const paletteEntries = submaterial.tint_palette?.entries ?? [];
+
+  // System B iridescence (synthesis_priority_actions.md S3): the actual
+  // CryEngine shimmerscale mechanism. Source MTL ending in `_i.mtl`
+  // routes through a Fresnel blend between secondary (entryB) and
+  // tertiary (entryC) palette colours — NOT thin-film. The Fresnel
+  // injection lives in `applyShaderHooks`; here we just gate the
+  // material construction.
+  const isSystemB = isSystemBIridescent(submaterial);
+  const sysBSecondary = isSystemB
+    ? rgbFromEntry(findEntry(paletteEntries, "secondary"))
+    : null;
+  const sysBTertiary = isSystemB
+    ? rgbFromEntry(findEntry(paletteEntries, "tertiary"))
+    : null;
+  const useSystemB = isSystemB && sysBSecondary !== null && sysBTertiary !== null;
+
+  // System A (thin-film) — kept narrow, only fires when System B is
+  // not active and the explicit %IRIDESCENCE flag or SD's chromatic-
+  // spec heuristic both point at it.
+  const isSystemA =
+    !useSystemB &&
+    (submaterial.decoded_feature_flags?.has_iridescence === true ||
+      paletteChannelHasIridescence(paletteEntries, channelName));
+
+  // ClearCoat (synthesis_priority_actions.md S1): bit 1 of the engine's
+  // GBuffer ShadingModelId. "Used on majority of ship exterior paint."
+  // The exact SShaderGen permutation bit is an open RE question, so we
+  // apply the heuristic: any HardSurface that resolves a palette tint
+  // gets a clear coat — that includes both the routed-channel case and
+  // the heuristic primary-fallback in resolvePaletteEntry, which covers
+  // the chassis paint panels Aurora's main hull (Panel_LF_Paint_*,
+  // Tile_*, Trim_*) leaves with assigned_channel = null. Bare-metal /
+  // no-palette submaterials skip ClearCoat. System B materials skip it
+  // because the Fresnel-blend already provides the angular highlight;
+  // double-stacking ClearCoat over System B would mute the colour shift.
+  const wantsClearCoat = !useSystemB && paletteEntry !== null;
+
+  // Diagnostic breadcrumb: count which material-build path each submaterial
+  // takes during a load so the user can verify in the browser console that
+  // the S1+S3 (ClearCoat / System B) paths are firing. Throttled to one
+  // summary line per second of build activity to avoid log spam on big ships
+  // (Aurora has 1488 exterior bindings; Polaris has ~14k).
+  recordHardSurfaceBuild(useSystemB, isSystemA, wantsClearCoat);
+
+  // Persistent metrics surfaced in the UI. Same signal as the throttled
+  // diag log but accumulates across the load and is reset per scene.
+  if (useSystemB) metrics.systemBFired += 1;
+  if (isSystemA) metrics.systemAFired += 1;
+  if (wantsClearCoat) metrics.clearCoatFired += 1;
+  if (paletteEntry) metrics.paletteTintApplied += 1;
+  else if (submaterial.tint_palette) metrics.paletteTintMissing += 1;
+
+  // Classify which path this submaterial took so debug-fallback mode
+  // can recolour it. The heuristic case is detectable from the palette
+  // shape: tint_palette present, assigned_channel null, but
+  // resolvePaletteEntry returned a non-null entry (= it ran the
+  // primary fallback).
+  const tintPalette = submaterial.tint_palette;
+  const heuristicFired =
+    paletteEntry != null &&
+    tintPalette != null &&
+    tintPalette.assigned_channel == null;
+  const fallbackKind: FallbackKind = heuristicFired
+    ? FALLBACK_KINDS.HARDSURFACE_PALETTE_HEURISTIC
+    : paletteEntry != null
+      ? FALLBACK_KINDS.HARDSURFACE_PALETTE_RESOLVED
+      : FALLBACK_KINDS.HARDSURFACE_NO_PALETTE;
+
+  // System B sets the diffuse to white so the standard <map_fragment>
+  // path doesn't pre-tint; the per-pixel Fresnel mix in the hook does
+  // all the colouring. The non-tinted HardSurface fallback is also
+  // white (NOT grey 0xC8C8C8 as it used to be) — CryEngine's behaviour
+  // when a HardSurface submaterial has no palette routing is `color =
+  // (1,1,1) * diffuse`, i.e. let the diffuse texture sample render at
+  // its authored brightness. Multiplying by 0xC8C8C8 darkens the base
+  // texture by ~22% and produced the washed-out "white-greybox" look
+  // on the 125 of 196 HardSurface submats that have no `tint_palette`
+  // (per the picker dump on Panel_Main_LF_Paint_7's neighbours). The
+  // diffuse PNGs already carry the painted colour information; we just
+  // need to not crush them.
+  //
+  // Debug-fallback overlay is applied at the end via
+  // applyDebugFallbackToMaterial — keep build-time colour normal so
+  // the original tint is what gets stashed in userData for restore.
+  const baseColor = useSystemB
+    ? new THREE.Color(0xffffff)
+    : (paletteTint ?? new THREE.Color(0xffffff));
+
+  const usePhysical = useSystemB || isSystemA || wantsClearCoat;
+  const material: THREE.MeshStandardMaterial | THREE.MeshPhysicalMaterial =
+    usePhysical
+      ? new THREE.MeshPhysicalMaterial({
+          name,
+          color: baseColor,
+          // Painted hull panels are slightly more reflective than bare
+          // matte plastic — the clear coat layer carries most of the
+          // specular response anyway, so the base BSDF can be tuned for
+          // colour richness rather than gloss.
+          metalness: useSystemB ? 0.4 : isSystemA ? 0.3 : 0.15,
+          roughness: useSystemB ? 0.45 : isSystemA ? 0.4 : 0.55,
+          // ClearCoat: a thin reflective layer on top of the base BSDF.
+          // Conservative defaults — proper ClearCoat shading model
+          // resolution from PublicParams is a follow-up.
+          clearcoat: wantsClearCoat ? 0.5 : 0.0,
+          clearcoatRoughness: wantsClearCoat ? 0.1 : 0.0,
+          // System A thin-film — narrow path now; System B is the
+          // shimmerscale port.
+          iridescence: isSystemA ? 1.0 : 0.0,
+          iridescenceIOR: isSystemA ? 1.3 : 1.5,
+          iridescenceThicknessRange: isSystemA ? [100, 800] : [100, 400],
+          sheen: isSystemA ? 0.7 : 0.0,
+          sheenColor:
+            isSystemA && paletteEntry?.spec_color
+              ? new THREE.Color(
+                  paletteEntry.spec_color[0],
+                  paletteEntry.spec_color[1],
+                  paletteEntry.spec_color[2],
+                )
+              : new THREE.Color(0xffffff),
+          sheenRoughness: isSystemA ? 0.3 : 0.5,
+        })
+      : new THREE.MeshStandardMaterial({
+          name,
+          color: baseColor,
+          // Bare-metal / non-paint default. Most CryEngine hull panels
+          // are dielectric (per Baconator: "no metal maps. Roughness
+          // maps are just Gloss Maps inverted"). Specifically authored
+          // metallic submats (parkerized_metal, bronze, bare_metal)
+          // carry their own per-channel data via tint_palette spec_color.
+          metalness: 0.1,
+          roughness: 0.7,
+        });
+  if (paletteEntry?.glossiness != null) {
+    // Glossiness is the inverse of roughness. When provided we honour
+    // it directly; the alpha-derived DDNA roughness path below still
+    // runs and modulates per-pixel.
+    material.roughness = THREE.MathUtils.clamp(1.0 - paletteEntry.glossiness, 0.0, 1.0);
+  }
+  material.userData.fallbackKind = fallbackKind;
+  tagOriginalColor(material);
+  // Default IBL intensity; tune per-scene via the Settings panel slider.
+  material.envMapIntensity = 1.0;
+  applyDebugFallbackToMaterial(material);
+  const texturePromises: Promise<void>[] = [];
+  const hooks: MaterialShaderHooks = {};
+  if (useSystemB && sysBSecondary && sysBTertiary) {
+    hooks.systemBSecondary = sysBSecondary;
+    hooks.systemBTertiary = sysBTertiary;
+  }
+  // POM is gated by the explicit `%PARALLAX_OCCLUSION_MAPPING` token in
+  // the StringGenMask. CryEngine uses POM for screws / bolts / vents /
+  // grates / recesses where the mesh would otherwise need real
+  // displacement geometry. Without the token, a height texture is just
+  // displacement data the shader doesn't consume.
+  const wantsPom =
+    submaterial.decoded_feature_flags?.has_parallax_occlusion_mapping === true;
+
+  for (const slot of mergedSlots(submaterial)) {
+    if (!slot.export_path) continue;
+    const role = (slot.role ?? "").toLowerCase();
+    const slotName = (slot.slot ?? "").toUpperCase();
+    const alphaSemantic = (slot.alpha_semantic ?? "").toLowerCase();
+    const promise = loadTexture(slot.export_path).then((sourceTex) => {
+      if (!sourceTex) return;
+      // Clone before mutating: the texture cache hands out the same
+      // instance to every consumer, so per-submaterial sampler state
+      // (repeat, offset, colorSpace, wrap mode) MUST be local. Without
+      // this, a sibling submaterial's TexMod tile/offset bleeds into
+      // every other material that loaded the same source path.
+      const tex = cloneTextureForSubmaterial(sourceTex);
+      applyTextureTransform(tex, slot.texture_transform);
+      if (isBaseColorRole(role)) {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.map = tex;
+        material.needsUpdate = true;
+      } else if (isNormalRole(role)) {
+        material.normalMap = tex;
+        // CryEngine `_ddna` normals carry smoothness in the alpha
+        // channel. Re-use the same texture as roughnessMap and inject a
+        // shader that reads from .a instead of the default .g.
+        if (alphaSemantic === "smoothness") {
+          material.roughnessMap = tex;
+          hooks.ddnaRoughness = true;
+        }
+        material.needsUpdate = true;
+      } else if (isSpecularRole(role)) {
+        // Spec maps drive metalness on the standard PBR path.
+        material.metalnessMap = tex;
+        material.needsUpdate = true;
+      } else if (isEmissiveRole(role)) {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.emissiveMap = tex;
+        material.emissive = new THREE.Color(0xffffff);
+        material.emissiveIntensity = 1.0;
+        material.needsUpdate = true;
+      } else if (isHeightRole(role, slotName) && wantsPom) {
+        // Capture the height texture for POM injection. Sampler state
+        // (wrap, anisotropy) is inherited from the source; POM samples
+        // the .r channel only, so colorSpace doesn't need conversion.
+        hooks.pomHeightMap = tex;
+        // Default scale tuned for typical CryEngine surface detail:
+        // small enough that flat panels stay flat, large enough that
+        // screws/bolts read as inset. SD's `pom_library.blend` uses
+        // height_scale * 0.015 as its default, matched here.
+        hooks.pomScale = 0.015;
+      } else if (isDirtOverlayRole(role, slotName)) {
+        hooks.dirtOverlayMap = tex;
+      } else if (slotName === "TEXSLOT1" && !material.map) {
+        // Generic fallback: TexSlot1 is the base diffuse slot in the
+        // CryEngine HardSurface template even when the role enum could
+        // not classify it. Only used if no explicit BaseColor landed.
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.map = tex;
+        material.needsUpdate = true;
+      }
+    });
+    texturePromises.push(promise);
+  }
+
+  const hadTextureSlots = texturePromises.length > 0;
+
+  // LayerBlend no-palette fallback: when a LayerBlend submaterial has no
+  // tint_palette and no synthesised slots, bind the first layer_manifest
+  // diffuse so the surface at least carries its authored base color.
+  // Full multi-layer LayerBlend with edge-wear masks is a follow-up.
+  if (fallbackKind === FALLBACK_KINDS.HARDSURFACE_NO_PALETTE) {
+    const layers = submaterial.layer_manifest ?? [];
+    const layerWithDiff = layers.find((l) => l.diffuse_export_path);
+    if (layerWithDiff?.diffuse_export_path) {
+      const layerDiffPromise = loadTexture(layerWithDiff.diffuse_export_path).then(
+        (sourceTex) => {
+          if (!sourceTex || material.map) return; // already bound by slot path -- don't clobber
+          const tex = cloneTextureForSubmaterial(sourceTex);
+          tex.colorSpace = THREE.SRGBColorSpace;
+          material.map = tex;
+          material.needsUpdate = true;
+        },
+      );
+      texturePromises.push(layerDiffPromise);
+      if (layerWithDiff.normal_export_path) {
+        const layerNormPromise = loadTexture(layerWithDiff.normal_export_path).then(
+          (sourceTex) => {
+            if (!sourceTex || material.normalMap) return;
+            const tex = cloneTextureForSubmaterial(sourceTex);
+            const alphaSem = (layerWithDiff as LayerManifestEntry & { alpha_semantic?: string })
+              .alpha_semantic;
+            if (alphaSem === "smoothness" || layerWithDiff.normal_export_path?.includes("_ddna")) {
+              material.roughnessMap = tex;
+              hooks.ddnaRoughness = true;
+            }
+            material.normalMap = tex;
+            material.needsUpdate = true;
+          },
+        );
+        texturePromises.push(layerNormPromise);
+      }
+    }
+  }
+
+  // Defer the shader patch until after all texture promises settle so we
+  // only compile once. needsUpdate inside the patch triggers the
+  // recompile when the next frame renders.
+  Promise.allSettled(texturePromises).then(() => {
+    applyShaderHooks(material, hooks);
+    material.needsUpdate = true;
+    if (hadTextureSlots) {
+      if (material.map) metrics.diffuseTextureSuccess += 1;
+      else metrics.diffuseTextureMiss += 1;
+    }
+    if (hooks.ddnaRoughness) metrics.ddnaRoughnessHooked += 1;
+    if (hooks.dirtOverlayMap) metrics.dirtOverlayHooked += 1;
+    if (hooks.pomHeightMap) metrics.pomHooked += 1;
+  });
+
+  return { material, texturePromises };
+}
+
+/** Build a GlassPBR material using Three.js's built-in physical
+ *  transmission rather than a custom ShaderMaterial. */
+function buildGlassMaterial(
+  name: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const material = new THREE.MeshPhysicalMaterial({
+    name,
+    color: 0xffffff,
+    metalness: 0.0,
+    roughness: 0.05,
+    transmission: 1.0,
+    thickness: 0.05,
+    ior: 1.5,
+    transparent: true,
+    depthWrite: false,
+  });
+  const texturePromises: Promise<void>[] = [];
+
+  for (const slot of mergedSlots(submaterial)) {
+    if (!slot.export_path) continue;
+    const role = (slot.role ?? "").toLowerCase();
+    const promise = loadTexture(slot.export_path).then((sourceTex) => {
+      if (!sourceTex) return;
+      const tex = cloneTextureForSubmaterial(sourceTex);
+      applyTextureTransform(tex, slot.texture_transform);
+      if (isBaseColorRole(role)) {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.map = tex;
+        material.needsUpdate = true;
+      } else if (isNormalRole(role)) {
+        material.normalMap = tex;
+        // Light surface bumps without the full PBR roughness coupling —
+        // glass tends to read better with a clean, low-roughness surface.
+        material.needsUpdate = true;
+      }
+    });
+    texturePromises.push(promise);
+  }
+
+  return { material, texturePromises };
+}
+
+/** Build a decal material across all decal-bearing shader families. The
+ *  classifier (`isDecalSubmaterial`) routes Illum-with-DECAL,
+ *  HardSurface-with-DECAL, MeshDecal, and STENCIL_MAP submaterials all
+ *  through here.
+ *
+ *  Three CryEngine decal authoring patterns share this material shape:
+ *    - **Atlas livery decals** (Illum + `%DECAL%DECAL_OPACITY_MAP`): a
+ *      shared diffuse atlas with per-submaterial UV offset/tile to pick
+ *      a tile. The diffuse alpha gates the decal. Texture clone is
+ *      MANDATORY — adjacent submaterials select different atlas tiles.
+ *    - **Line decals** (Illum or HardSurface + `%DECAL`): tiled stripes
+ *      along the hull with the diffuse alpha + opacity falloff. Same
+ *      polygon-offset / depth-write-off treatment.
+ *    - **Stencil decals** (`MeshDecal` + `%STENCIL_MAP`): TexSlot7
+ *      virtual `$TintPaletteDecal` resolves to a stencil atlas the game
+ *      composites with palette colours at runtime. Without the palette
+ *      we render the alpha mask alone (or skip if no slot loaded).
+ *
+ *  All three need `transparent + depthWrite=false + polygonOffset` so
+ *  they overlay on the host hull without Z-fighting and without
+ *  occluding the underlying paint. The hull-paint route does NOT —
+ *  routing decal submaterials through it is what produced the wrong
+ *  stickers / wrong tiles bug. */
+function buildDecalMaterial(
+  name: string,
+  submaterial: SubmaterialRecord,
+  loadTexture: (exportPath: string) => Promise<THREE.Texture | null>,
+): { material: THREE.Material; texturePromises: Promise<void>[] } {
+  const material = new THREE.MeshStandardMaterial({
+    name,
+    color: 0xffffff,
+    metalness: 0.0,
+    roughness: 0.8,
+    transparent: true,
+    // Use alphaTest so fully-transparent texels (between atlas tiles
+    // and outside the stencil shape) don't write to depth. Decal atlas
+    // tiles otherwise paint the gap region as a uniform black square.
+    alphaTest: 0.02,
+    depthWrite: false,
+    polygonOffset: true,
+    polygonOffsetFactor: -1,
+    polygonOffsetUnits: -1,
+    // Per SD's Aurora work (2026-04-23T03:09): "POMs & Decals no longer
+    // reflect within 50mm of any surface". Decals are painted-on
+    // surfaces, not separate reflective geometry — they should inherit
+    // the host hull's reflection rather than producing their own.
+    // Zeroing envMapIntensity stops the IBL from layering a second
+    // specular response over the decal alpha.
+    envMapIntensity: 0,
+  });
+  const texturePromises: Promise<void>[] = [];
+
+  for (const slot of mergedSlots(submaterial)) {
+    if (!slot.export_path) continue;
+    const role = (slot.role ?? "").toLowerCase();
+    const slotName = (slot.slot ?? "").toUpperCase();
+    const alphaSemantic = (slot.alpha_semantic ?? "").toLowerCase();
+    const promise = loadTexture(slot.export_path).then((sourceTex) => {
+      if (!sourceTex) return;
+      // Decal submaterials are the canonical case for per-material
+      // texture clones: atlas decals share the same diffuse PNG across
+      // sibling submaterials with different per-tile UV offsets, so
+      // ANY mutation on the cached source texture corrupts every other
+      // tile selection. See `cloneTextureForSubmaterial` for context.
+      const tex = cloneTextureForSubmaterial(sourceTex);
+      applyTextureTransform(tex, slot.texture_transform);
+      if (isBaseColorRole(role) || slotName === "TEXSLOT1") {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        material.map = tex;
+        // Decal diffuse alpha gates the visible region. Without
+        // explicitly assigning alphaMap, MeshStandardMaterial reads
+        // alpha from `map` only when `transparent=true`, which is
+        // already the case here.
+        material.needsUpdate = true;
+      } else if (isNormalRole(role)) {
+        material.normalMap = tex;
+        // Decal DDNA carries smoothness in alpha just like the hull
+        // PBR path; reuse the same shader patch.
+        if (alphaSemantic === "smoothness") {
+          material.roughnessMap = tex;
+        }
+        material.needsUpdate = true;
+      } else if (isStencilRole(role, slot.slot ?? "")) {
+        // The stencil mask modulates alpha. Three.js doesn't have a
+        // dedicated alpha-mask slot on MeshStandardMaterial, so use
+        // alphaMap which multiplies the final alpha by the texture's
+        // luminance.
+        material.alphaMap = tex;
+        material.needsUpdate = true;
+      }
+      // Specular / spec_support, height, dust, breakup roles have no
+      // decal-relevant MeshStandardMaterial slot. Silently skipped.
+    });
+    texturePromises.push(promise);
+  }
+
+  return { material, texturePromises };
+}
+
+function mergedSlots(submaterial: SubmaterialRecord): TextureSlotRecord[] {
+  const slots = submaterial.texture_slots ?? [];
+  const direct = submaterial.direct_textures ?? [];
+  const synthesised = synthesisedLayerSlots(submaterial);
+  // `direct_textures` is the legacy / fallback per-role record set; for
+  // most decal and HardSurface submaterials it duplicates entries
+  // already present in `texture_slots` with the proper TexSlotN id and
+  // texture_transform. Keep slots authoritative — only carry direct
+  // entries whose `export_path` was not already covered by a slot.
+  // Without this, decal materials run their texture-load + map-assign
+  // pipeline twice for the diffuse, with the second run overwriting
+  // any sampler state set by the first.
+  const seenPaths = new Set<string>();
+  for (const slot of slots) {
+    if (slot.export_path) seenPaths.add(slot.export_path);
+  }
+  const uniqueDirect = direct.filter(
+    (d) => !d.export_path || !seenPaths.has(d.export_path),
+  );
+  return [...slots, ...uniqueDirect, ...synthesised];
+}
+
+/** For layered HardSurface submaterials the visible diffuse and DDNA
+ *  normal live on a layer entry whose `palette_channel` matches the
+ *  submaterial's `material_channel`, not on the top-level
+ *  `texture_slots`. Synthesise TexSlot1/TexSlot2-shaped records from that
+ *  layer so the unified slot pipeline can wire them into the
+ *  MeshStandardMaterial without family-specific branching. Only used when
+ *  no slots are directly authored — keeps the cheap path fast for
+ *  non-layered HardSurface and Illum materials. */
+function synthesisedLayerSlots(submaterial: SubmaterialRecord): TextureSlotRecord[] {
+  const slots = submaterial.texture_slots ?? [];
+  const direct = submaterial.direct_textures ?? [];
+  if (slots.length > 0 || direct.length > 0) return [];
+  const layers = submaterial.layer_manifest ?? [];
+  if (layers.length === 0) return [];
+  const matIdx = submaterial.palette_routing?.material_channel?.index;
+  // Prefer the layer whose palette_channel matches the submaterial's own
+  // material_channel; fall back to the first layer with any diffuse path
+  // so unrouted materials still get a visible base map.
+  const layer =
+    layers.find((l) => l.palette_channel?.index === matIdx && l.diffuse_export_path) ??
+    layers.find((l) => l.diffuse_export_path) ??
+    layers[0];
+  if (!layer) return [];
+  const synth: TextureSlotRecord[] = [];
+  if (layer.diffuse_export_path) {
+    synth.push({
+      role: "base_color",
+      slot: "TexSlot1",
+      export_path: layer.diffuse_export_path,
+    });
+  }
+  if (layer.normal_export_path) {
+    synth.push({
+      role: "normal_gloss",
+      slot: "TexSlot2",
+      export_path: layer.normal_export_path,
+      alpha_semantic: "smoothness",
+    });
+  }
+  return synth;
+}
+
+/** Resolve the palette entry (if any) referenced by a submaterial's
+ *  `tint_palette.assigned_channel`. Returns null when no palette is
+ *  present or when no entry matches.
+ *
+ *  Heuristic fallback: when entries exist but `assigned_channel` is
+ *  null (the Rust-side routing didn't resolve a channel), HardSurface
+ *  submaterials default to the `primary` entry. This is the chassis-
+ *  paint case from the aurora-chassis-diagnostic — Aurora's main hull
+ *  has 18-of-47 HardSurface submats with `tint_palette` populated but
+ *  no routed channel, leaving them grey instead of livery-tinted.
+ *  `primary` is the safe default because the per-channel paint
+ *  vehicles all author primary as the dominant base coat. */
+function resolvePaletteEntry(
+  submaterial: SubmaterialRecord,
+): TintPaletteEntry | null {
+  const palette = submaterial.tint_palette;
+  if (!palette) return null;
+  const entries = palette.entries ?? [];
+  let channelName = palette.assigned_channel;
+  if (channelName == null) {
+    if (entries.length === 0) return null;
+    const family = submaterial.shader_family ?? submaterial.shader ?? "";
+    const isHardSurfaceFamily =
+      family === "HardSurface" || family === "Layer" || family === "LayerBlend_V2";
+    if (!isHardSurfaceFamily) return null;
+    // Channel naming in the sidecar is the engine-internal letter form
+    // (entryA = primary, entryB = secondary, entryC = tertiary, entryD =
+    // glass). Per the picker dump on Aurora's Panel_Main_LF_Paint_7,
+    // the routed-case `assigned_channel` is "entryA", so the un-routed
+    // fallback must match that convention to land on the same slot.
+    // Fall back to the human-readable "primary" name if a future
+    // exporter switches conventions.
+    const primary =
+      entries.find((e) => e.channel?.toLowerCase() === "entrya") ??
+      entries.find((e) => e.channel?.toLowerCase() === "primary");
+    if (!primary) return null;
+    metrics.paletteHeuristicPrimaryFallback += 1;
+    return primary;
+  }
+  const entry = entries.find((e) => e.channel === channelName);
+  if (!entry) {
+    const label =
+      submaterial.blender_material_name ??
+      submaterial.submaterial_name ??
+      `idx:${submaterial.index ?? "?"}`;
+    console.debug(
+      `[decomposed-loader] tint_palette '${palette.palette_id}' on ` +
+        `submaterial '${label}' references missing channel ` +
+        `'${channelName}'.`,
+    );
+    return null;
+  }
+  return entry;
+}
+
+/** Convert a resolved palette entry's `tint_color` to a `THREE.Color`.
+ *  Tint values are linear-space floats (sRGB→linear conversion already
+ *  applied on the Rust side), and `THREE.Color` constructors treat their
+ *  numeric arguments as linear too — so the values feed straight through
+ *  with only a defensive clamp and a fall-back to white for short
+ *  tuples. */
+function resolvePaletteTint(submaterial: SubmaterialRecord): THREE.Color | null {
+  const entry = resolvePaletteEntry(submaterial);
+  if (!entry) return null;
+  const c = entry.tint_color ?? [];
+  const r = Math.max(0, typeof c[0] === "number" ? c[0] : 1);
+  const g = Math.max(0, typeof c[1] === "number" ? c[1] : 1);
+  const b = Math.max(0, typeof c[2] === "number" ? c[2] : 1);
+  return new THREE.Color(r, g, b);
+}
+
+/**
+ * Resolve a contract-relative path (`Data/...` or `Packages/...`) to an
+ * absolute path under the given export root. Forward-slash join — the
+ * Tauri command tolerates either separator.
+ */
+export function resolveContractPath(exportRoot: string, contractPath: string): string {
+  const trimmedRoot = exportRoot.replace(/[\\/]+$/, "");
+  const trimmedPath = contractPath.replace(/^[\\/]+/, "");
+  return `${trimmedRoot}/${trimmedPath}`;
+}

--- a/app/src/lib/decomposed-loader.ts
+++ b/app/src/lib/decomposed-loader.ts
@@ -338,7 +338,8 @@ export interface SubmaterialRecord {
   /** Per-submaterial palette tint baked by the exporter (HardSurface only).
    *  Null for non-tinted submaterials. When `assigned_channel` resolves to
    *  one of `entries`, the matching `tint_color` is multiplied with the
-   *  diffuse map (`final_albedo = tint_color × diffuse_sample`). */
+   *  diffuse map per the standard CryEngine HardSurface compositing rule
+   *  (`final_albedo = tint_color * diffuse_sample`). */
   tint_palette?: SubmaterialPalette | null;
   /** Palette-channel routing for layered HardSurface submaterials.
    *  `material_channel` is the channel this submaterial as a whole reads
@@ -1178,11 +1179,12 @@ interface MaterialShaderHooks {
   pomHeightMap?: THREE.Texture;
   pomScale?: number;
   dirtOverlayMap?: THREE.Texture;
-  /** Fresnel-blended secondary/tertiary palette colours used by the
-   *  iridescent paint variants. Activated when the submat's source MTL
-   *  filename ends in `_i` (gated upstream in
-   *  `buildHardSurfaceMaterial`). Mirrors the Fresnel-blend node group
-   *  used by the Blender importer. */
+  /** System B iridescence: selects between two palette colours
+   *  (`secondary` / `entryB` and `tertiary` / `entryC`) by Fresnel
+   *  weight `pow(1 - NdotV, 5)`. Activated when the submat's source
+   *  MTL filename ends in `_i` (gated upstream in
+   *  `buildHardSurfaceMaterial`). Approximates the engine's iridescent
+   *  paint shader for shimmerscale and similar two-tone variants. */
   systemBSecondary?: THREE.Color;
   systemBTertiary?: THREE.Color;
 }
@@ -1218,8 +1220,9 @@ function applyShaderHooks(
     }
 
     // POM: parallax occlusion ray-march replaces the standard map UV
-    // lookup with a height-displaced one. 16 sample steps is a
-    // reasonable cost/quality balance for typical hull-detail surfaces.
+    // lookup with a height-displaced one. Step count of 16 balances
+    // visual smoothness against the per-pixel sample cost; tune via
+    // heightScale.
     if (hooks.pomHeightMap) {
       const heightScale = hooks.pomScale ?? 0.015;
       shader.uniforms.pomHeightMap = { value: hooks.pomHeightMap };
@@ -1292,10 +1295,10 @@ function applyShaderHooks(
       );
     }
 
-    // Iridescent paint: Fresnel-weighted blend between secondary
-    // (entryB) and tertiary (entryC) palette colours. Mirrors the
-    // Fresnel-blend approach used by the Blender importer. The weight
-    // `pow(1 - NdotV, 5)` is a standard Schlick-style approximation.
+    // System B iridescence: Fresnel-weighted blend between secondary
+    // (entryB) and tertiary (entryC) palette colours;
+    // `pow(1 - NdotV, 5)` is a Schlick-style approximation of the
+    // engine's angular response.
     //
     // Caller pre-sets `material.color = white(0xffffff)` so the
     // existing `<color_fragment>` and `<map_fragment>` paths leave
@@ -1447,14 +1450,16 @@ function recordHardSurfaceBuild(
 }
 
 /** Detect whether a submaterial's source MTL is the `_i` iridescent
- *  variant (e.g. shimmerscale paints, two-tone variants). When the
- *  exporter emits `<stem>:<base>` blender_material_name strings, the
- *  stem mirrors the source MTL filename minus `.mtl`, so a hull that
- *  references `<paint>_i.mtl` shows up here as `<paint>_i:<submat>`.
+ *  variant (Aurora shimmerscale, 600i wavy, Starlancer two-tone).
+ *  When the exporter writes `<stem>:<base>` blender_material_name
+ *  strings, the stem mirrors the source MTL filename minus `.mtl`,
+ *  so a hull that references `<paint>_i.mtl` shows up here as
+ *  `<paint>_i:<submat>`.
  *
  *  The detection is intentionally narrow: only the trailing
  *  underscore-i in the stem position triggers, so panels named with
- *  embedded `_i` don't false-positive. */
+ *  embedded `_i` (e.g. some hypothetical `_iris_panel`) don't
+ *  false-positive. */
 function isSystemBIridescent(submaterial: SubmaterialRecord): boolean {
   const blenderName = submaterial.blender_material_name ?? "";
   const colonIdx = blenderName.indexOf(":");
@@ -1648,14 +1653,15 @@ function buildScreenMaterial(
 }
 
 /** Hologram / HologramCIG / Shield_Holo: animated translucent shader
- *  with Fresnel-driven rim brightening and scanlines. The shader needs
- *  per-frame `time` updates; we attach an updater so the scene-viewer's
- *  animate loop can tick all hologram materials.
+ *  with Fresnel-driven rim brightening and scanlines. The shader
+ *  needs per-frame `time` updates; we attach an updater so the
+ *  scene-viewer's animate loop can tick all hologram materials.
  *
- *  This is a simple unlit-emissive + angular-fresnel approximation;
- *  the source format's hologram shader does more (scrolling noise,
- *  edge iridescence, fresnel-modulated transparency), but this reads
- *  as "hologram" in practice and is much closer than a flat fill. */
+ *  Simple unlit-emissive plus angular-Fresnel approximation of the
+ *  engine's hologram shader. Does not yet implement scrolling noise,
+ *  edge iridescence, or fresnel-modulated transparency. Reads as
+ *  "hologram" in side-by-side comparisons with the in-game look. Far
+ *  closer than the prior `MeshBasicMaterial` flat fill. */
 const HOLOGRAM_VERTEX_SHADER = /* glsl */ `
   varying vec3 vNormal;
   varying vec3 vViewDir;
@@ -1989,18 +1995,19 @@ function paletteChannelHasIridescence(
  *
  *  When the sidecar carries a `tint_palette` with a resolved
  *  `assigned_channel`, the channel's `tint_color` is set on
- *  `material.color` and the standard `final_albedo = tint × diffuse`
- *  composition falls out of MeshStandardMaterial's per-fragment colour
- *  × map multiplication automatically — no custom shader required.
+ *  `material.color` and the standard CryEngine HardSurface compositing
+ *  rule (`final_albedo = tint_color * diffuse_sample`) falls out of
+ *  MeshStandardMaterial's per-fragment colour × map multiplication
+ *  automatically — no custom shader required.
  *
  *  When the routed palette channel encodes iridescence (per
  *  `paletteChannelHasIridescence`), this builds a `MeshPhysicalMaterial`
- *  with iridescence + sheen rather than a `MeshStandardMaterial`, so
- *  angle-shift paints (e.g. iridescent `_i.mtl` variants) get the
- *  tertiary palette spec_color blended toward at grazing angles.
- *  Three.js's built-in `iridescence` is thin-film, which combined with
- *  `sheen` driven by the spec_color gives a reasonable approximation
- *  of the in-engine look without a custom shader.
+ *  with iridescence + sheen rather than a `MeshStandardMaterial`.
+ *  Angle-shift paints (the `_i.mtl` variant) get the tertiary palette
+ *  spec_color blended toward at grazing angles. Three.js's built-in
+ *  `iridescence` is thin-film and not exactly what CryEngine does,
+ *  but combined with `sheen` driven by the spec_color it gives a
+ *  visible angular shift that approximates the engine.
  *
  *  Layered HardSurface submaterials publish their visible diffuse/normal
  *  pair via `layer_manifest` rather than `texture_slots`, because the
@@ -2019,12 +2026,10 @@ function buildHardSurfaceMaterial(
   const paletteEntry = resolvePaletteEntry(submaterial);
   const paletteEntries = submaterial.tint_palette?.entries ?? [];
 
-  // System B iridescence (synthesis_priority_actions.md S3): the actual
-  // CryEngine shimmerscale mechanism. Source MTL ending in `_i.mtl`
-  // routes through a Fresnel blend between secondary (entryB) and
-  // tertiary (entryC) palette colours — NOT thin-film. The Fresnel
-  // injection lives in `applyShaderHooks`; here we just gate the
-  // material construction.
+  // System B iridescence: source MTL ending in `_i.mtl` routes through
+  // a Fresnel blend between secondary (entryB) and tertiary (entryC)
+  // palette colours — NOT thin-film. The Fresnel injection lives in
+  // `applyShaderHooks`; here we just gate the material construction.
   const isSystemB = isSystemBIridescent(submaterial);
   const sysBSecondary = isSystemB
     ? rgbFromEntry(findEntry(paletteEntries, "secondary"))
@@ -2035,21 +2040,18 @@ function buildHardSurfaceMaterial(
   const useSystemB = isSystemB && sysBSecondary !== null && sysBTertiary !== null;
 
   // System A (thin-film) — kept narrow, only fires when System B is
-  // not active and the explicit %IRIDESCENCE flag or SD's chromatic-
-  // spec heuristic both point at it.
+  // not active and the explicit %IRIDESCENCE flag or the
+  // chromatic-spec heuristic both point at it.
   const isSystemA =
     !useSystemB &&
     (submaterial.decoded_feature_flags?.has_iridescence === true ||
       paletteChannelHasIridescence(paletteEntries, channelName));
 
-  // ClearCoat (synthesis_priority_actions.md S1): bit 1 of the engine's
-  // GBuffer ShadingModelId. "Used on majority of ship exterior paint."
-  // The exact SShaderGen permutation bit is an open RE question, so we
-  // apply the heuristic: any HardSurface that resolves a palette tint
-  // gets a clear coat — that includes both the routed-channel case and
-  // the heuristic primary-fallback in resolvePaletteEntry, which covers
-  // the chassis paint panels Aurora's main hull (Panel_LF_Paint_*,
-  // Tile_*, Trim_*) leaves with assigned_channel = null. Bare-metal /
+  // ClearCoat: used on the majority of ship exterior paint. Heuristic:
+  // any HardSurface that resolves a palette tint gets a clear coat —
+  // that includes both the routed-channel case and the heuristic
+  // primary-fallback in `resolvePaletteEntry`, which covers chassis
+  // paint panels left with `assigned_channel = null`. Bare-metal /
   // no-palette submaterials skip ClearCoat. System B materials skip it
   // because the Fresnel-blend already provides the angular highlight;
   // double-stacking ClearCoat over System B would mute the colour shift.
@@ -2119,8 +2121,11 @@ function buildHardSurfaceMaterial(
           metalness: useSystemB ? 0.4 : isSystemA ? 0.3 : 0.15,
           roughness: useSystemB ? 0.45 : isSystemA ? 0.4 : 0.55,
           // ClearCoat: a thin reflective layer on top of the base BSDF.
-          // Conservative defaults — proper ClearCoat shading model
-          // resolution from PublicParams is a follow-up.
+          // CryEngine's ClearCoatBlend shading model does roughly this
+          // with a fixed thin-coat IOR. Active on most painted hulls;
+          // off for System B (the Fresnel mix is the angular response)
+          // and bare metals. The 0.5 default is conservative; a richer
+          // ClearCoat port would read PublicParams.ClearCoatBlend.
           clearcoat: wantsClearCoat ? 0.5 : 0.0,
           clearcoatRoughness: wantsClearCoat ? 0.1 : 0.0,
           // System A thin-film — narrow path now; System B is the
@@ -2151,14 +2156,16 @@ function buildHardSurfaceMaterial(
           roughness: 0.7,
         });
   if (paletteEntry?.glossiness != null) {
-    // Glossiness is the inverse of roughness. When provided we honour
-    // it directly; the alpha-derived DDNA roughness path below still
-    // runs and modulates per-pixel.
+    // Glossiness is the inverse of roughness. When provided we honour it
+    // directly; the alpha-derived DDNA roughness path below still runs
+    // and modulates per-pixel.
     material.roughness = THREE.MathUtils.clamp(1.0 - paletteEntry.glossiness, 0.0, 1.0);
   }
   material.userData.fallbackKind = fallbackKind;
   tagOriginalColor(material);
-  // Default IBL intensity; tune per-scene via the Settings panel slider.
+  // Default IBL intensity. The constructor already sets sensible
+  // per-shader-family metalness; spec-routed metalness comes from
+  // texture binding below.
   material.envMapIntensity = 1.0;
   applyDebugFallbackToMaterial(material);
   const texturePromises: Promise<void>[] = [];
@@ -2204,7 +2211,10 @@ function buildHardSurfaceMaterial(
         }
         material.needsUpdate = true;
       } else if (isSpecularRole(role)) {
-        // Spec maps drive metalness on the standard PBR path.
+        // CryEngine spec_color textures are routed as metalnessMap on
+        // MeshStandardMaterial. The constructor's metalness baseline
+        // (0.1 for bare-metal, 0.3-0.4 for paint families) is treated
+        // as a multiplier the map can drive up to 1.0 per-pixel.
         material.metalnessMap = tex;
         material.needsUpdate = true;
       } else if (isEmissiveRole(role)) {
@@ -2239,10 +2249,10 @@ function buildHardSurfaceMaterial(
 
   const hadTextureSlots = texturePromises.length > 0;
 
-  // LayerBlend no-palette fallback: when a LayerBlend submaterial has no
-  // tint_palette and no synthesised slots, bind the first layer_manifest
-  // diffuse so the surface at least carries its authored base color.
-  // Full multi-layer LayerBlend with edge-wear masks is a follow-up.
+  // LayerBlend submaterials with no tint_palette have no synthesised
+  // slots; bind the first layer's diffuse so the surface at least
+  // carries its authored base colour. Full multi-layer LayerBlend with
+  // edge-wear masks and per-layer normal blending is future work.
   if (fallbackKind === FALLBACK_KINDS.HARDSURFACE_NO_PALETTE) {
     const layers = submaterial.layer_manifest ?? [];
     const layerWithDiff = layers.find((l) => l.diffuse_export_path);

--- a/app/src/lib/flight-camera.ts
+++ b/app/src/lib/flight-camera.ts
@@ -1,0 +1,831 @@
+// Quaternion-based 6DOF flight camera. No damping, no inertia, no smoothing:
+// when a key releases, motion stops on the next frame.
+//
+// Public surface:
+//   - `useFlightCamera`      - React hook that wires renderer/camera/scene refs
+//                              and returns a handle (or null until refs settle).
+//   - `FlightCamHandle`      - imperative handle: resetToScene / focusOnPoint /
+//                              dispose / getState / subscribe.
+//   - Pure helpers           - `getCameraDirections`, `rotateCameraLocal`,
+//                              `applyOrbitFromTarget`, `applyOrbitAroundTarget`,
+//                              `syncOrbitTargetToView`, `clampFov`,
+//                              `adjustMoveSpeed`, `advanceState`. These are the
+//                              testable math; they take and return plain values.
+//
+// Input mapping (idle WASDQE / IJKL / UO / arrows / [] / Numpad+/-):
+//   Translation: W/S forward/back, A/D strafe left/right, E/Q up/down. Each
+//   tick advances both `pos` and `orbitTarget` so the orbit pivot follows.
+//   Rotation:    I/K pitch up/down, J/L yaw left/right, U/O roll CCW/CW.
+//                Local-frame; multiplied onto the current quaternion in
+//                yaw -> pitch -> roll order. After rotation, orbitTarget is
+//                re-synced to `pos + fwd*orbitDist` so the pivot orb stays
+//                screen-centred along the new view direction.
+//   Orbit:       Arrow keys swing the camera around `orbitTarget` on a
+//                sphere of radius `orbitDist`. Up/Down pitch, Left/Right yaw.
+//                The orb stays put in world space; the camera repositions to
+//                `orbitTarget - newFwd * orbitDist`.
+//   Cart:        ] forward, [ backward along the local fwd axis. Actively
+//                shrinks (clamped at 1) / grows orbitDist so the orbit pivot
+//                still tracks the camera.
+//   FoV:         Numpad+/- step the perspective FoV by one degree per
+//                key DOWN event (not continuous). Clamped 10..120.
+//
+// Mouse on the renderer canvas:
+//   Left drag    pan; translates pos and orbitTarget by -right*dx + up*dy.
+//   Right drag   orbit; rotates the camera about orbitTarget with pitch=dy,
+//                yaw=-dx, then re-anchors pos at orbitTarget - fwd*orbitDist.
+//   Middle drag  look; same rotation, no orbit re-anchor; orbitTarget tracks
+//                pos + fwd*orbitDist.
+//   Wheel        adjusts the WASDQE move-speed multiplier only. Wheel never
+//                zooms or dollies the view.
+//
+// Click-vs-drag is gated by 5px / 350ms thresholds matching the existing
+// picker, so the picker keeps firing on relaxed left clicks.
+
+import { useEffect, useState } from "react";
+import type React from "react";
+import * as THREE from "three";
+
+// ---------- Public types ----------
+
+/** Three projection modes the active camera can be in:
+ *   - perspective: the scene's THREE.PerspectiveCamera (FoV-driven).
+ *   - orthographic: a parallel-projection camera whose frustum is sized
+ *     from the current orbitDist + viewport aspect.
+ *   - oblique:     orthographic frustum, then a fixed cabinet-style shear
+ *     (45 deg, half-depth) post-multiplied onto the projection matrix. */
+export type ProjectionMode = "perspective" | "orthographic" | "oblique";
+
+export const PROJECTION_MODES: readonly ProjectionMode[] = [
+  "perspective",
+  "orthographic",
+  "oblique",
+] as const;
+
+export interface FlightCamState {
+  pos: THREE.Vector3;
+  quat: THREE.Quaternion;
+  orbitDist: number;
+  /** Multiplier on the per-frame translation/rotation step. */
+  moveSpeed: number;
+  /** Perspective FoV in degrees, clamped 10..120. */
+  fov: number;
+  /** Active projection mode. Cycled via P, set via UI. Mode changes are
+   *  instant; no animation/damping. */
+  projectionMode: ProjectionMode;
+}
+
+export interface FlightCamHandle {
+  /** Frame the scene into view: position camera at the AABB centroid plus
+   *  diagonal/(2*tan(fov/2))*1.1, looking at the centroid. */
+  resetToScene(sceneRoot: THREE.Object3D): void;
+  /** Look at a specific point at the given distance (default 15). */
+  focusOnPoint(target: THREE.Vector3, distance?: number): void;
+  /** Detach all listeners and dispose the pivot orb. Called automatically
+   *  by the hook on unmount; safe to call manually too. */
+  dispose(): void;
+  /** Read the current state. The returned object is a snapshot - mutating
+   *  it has no effect on the camera. */
+  getState(): Readonly<FlightCamState>;
+  /** Subscribe to state changes. The listener fires at most once per
+   *  animation frame even when many keys / mouse events arrive in the
+   *  same tick. Returns an unsubscribe fn. */
+  subscribe(listener: (state: Readonly<FlightCamState>) => void): () => void;
+  /** Advance projection mode: perspective -> orthographic -> oblique ->
+   *  perspective. Bound to the P key and the UI cycle button. */
+  cycleProjectionMode(): void;
+  /** Set projection mode directly. Bound to the dropdown selector. */
+  setProjectionMode(mode: ProjectionMode): void;
+  /** Read the camera the renderer / picker should use this frame. Returns
+   *  the perspective camera in "perspective" mode and the internal
+   *  orthographic camera in "orthographic" or "oblique". The returned
+   *  reference is stable across frames; only its matrices update. */
+  getActiveCamera(): THREE.Camera;
+}
+
+// ---------- Public constants ----------
+
+export const SPEED_MIN = 0.05;
+export const SPEED_MAX = 50;
+export const SPEED_STEP = 1.15;
+export const FOV_MIN = 10;
+export const FOV_MAX = 120;
+
+/** Per-frame translation magnitude = PAN_BASE * moveSpeed. */
+const PAN_BASE = 0.5;
+/** Per-frame rotation magnitude (radians) = ROT_BASE * moveSpeed. */
+const ROT_BASE = 0.02;
+/** Mouse pan sensitivity (world units per pixel, scaled by FoV-independent factor). */
+const MOUSE_PAN_SENS = 0.15;
+/** Mouse orbit/look sensitivity (radians per pixel). */
+const MOUSE_ROT_SENS = 0.005;
+/** Click-vs-drag thresholds, mirrored from the existing picker. */
+const CLICK_PIX_THRESHOLD = 5;
+const CLICK_TIME_MS = 350;
+
+// ---------- Pure helpers (testable) ----------
+
+/** Local-frame direction vectors for the camera at the given quaternion.
+ *  Three.js convention: camera looks down -Z, right is +X, up is +Y. */
+export function getCameraDirections(quat: THREE.Quaternion): {
+  fwd: THREE.Vector3;
+  right: THREE.Vector3;
+  up: THREE.Vector3;
+} {
+  return {
+    fwd: new THREE.Vector3(0, 0, -1).applyQuaternion(quat),
+    right: new THREE.Vector3(1, 0, 0).applyQuaternion(quat),
+    up: new THREE.Vector3(0, 1, 0).applyQuaternion(quat),
+  };
+}
+
+/** Rotate a quaternion in its own local frame. Order is yaw -> pitch -> roll
+ *  (matching the order most users expect: heading, then attitude, then bank).
+ *  All deltas are radians; positive pitch tilts the camera down (rotates
+ *  about local +X), positive yaw turns left (about local +Y), positive roll
+ *  is CCW (about local +Z). */
+export function rotateCameraLocal(
+  quat: THREE.Quaternion,
+  pitchDelta: number,
+  yawDelta: number,
+  rollDelta: number,
+): THREE.Quaternion {
+  const out = quat.clone();
+  if (yawDelta !== 0) {
+    const q = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), yawDelta);
+    out.multiply(q);
+  }
+  if (pitchDelta !== 0) {
+    const q = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), pitchDelta);
+    out.multiply(q);
+  }
+  if (rollDelta !== 0) {
+    const q = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), rollDelta);
+    out.multiply(q);
+  }
+  out.normalize();
+  return out;
+}
+
+/** Place the camera at `orbitTarget - fwd * orbitDist` so it looks at the
+ *  pivot from `orbitDist` away. The state's quaternion is read but not
+ *  modified - call after any rotation update that should re-anchor. */
+export function applyOrbitFromTarget(
+  state: FlightCamState,
+  orbitTarget: THREE.Vector3,
+): { pos: THREE.Vector3 } {
+  const { fwd } = getCameraDirections(state.quat);
+  const pos = orbitTarget.clone().addScaledVector(fwd, -state.orbitDist);
+  return { pos };
+}
+
+/** Re-anchor the orbit target so it sits at `pos + fwd * orbitDist` for
+ *  the given pose. Call this any time the camera rotates (or moves
+ *  along a non-orbit-preserving path) to keep the pivot orb visually
+ *  centred on the screen along the new look direction. Returns a new
+ *  Vector3; does not mutate inputs. */
+export function syncOrbitTargetToView(
+  pos: THREE.Vector3,
+  quat: THREE.Quaternion,
+  orbitDist: number,
+): THREE.Vector3 {
+  const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(quat);
+  return pos.clone().addScaledVector(fwd, orbitDist);
+}
+
+/** Reposition the camera so it stays at distance `orbitDist` from a
+ *  fixed `orbitTarget`, looking along the state's current quaternion.
+ *  This is the math behind the arrow-key orbit: the caller rotates
+ *  `state.quat` first (changing fwd), then this helper drops `pos` at
+ *  `orbitTarget - newFwd * orbitDist`. The orbit target is left
+ *  untouched so the pivot orb stays put in world space.
+ *
+ *  Returns a fresh `{ pos, quat }`; does not mutate inputs. The quat is
+ *  passed through unchanged (cloned) for symmetry with other helpers. */
+export function applyOrbitAroundTarget(
+  state: FlightCamState,
+  orbitTarget: THREE.Vector3,
+): { pos: THREE.Vector3; quat: THREE.Quaternion } {
+  const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(state.quat);
+  const pos = orbitTarget.clone().addScaledVector(fwd, -state.orbitDist);
+  return { pos, quat: state.quat.clone() };
+}
+
+export function clampFov(value: number): number {
+  if (value < FOV_MIN) return FOV_MIN;
+  if (value > FOV_MAX) return FOV_MAX;
+  return value;
+}
+
+/** Geometric move-speed adjust. Negative deltaY (scroll up) speeds up by
+ *  SPEED_STEP; positive deltaY slows down by the same factor. Clamps to
+ *  SPEED_MIN..SPEED_MAX. deltaY === 0 returns `current` unchanged. */
+export function adjustMoveSpeed(current: number, wheelDeltaY: number): number {
+  if (wheelDeltaY === 0) return current;
+  if (wheelDeltaY < 0) return Math.min(SPEED_MAX, current * SPEED_STEP);
+  return Math.max(SPEED_MIN, current / SPEED_STEP);
+}
+
+/** Compute an orthographic frustum sized to match the apparent scale of
+ *  the perspective camera at `orbitDist` units away. The frustum height
+ *  is `orbitDist` world-units (so what you see in perspective at the
+ *  pivot stays roughly the same scale in ortho); width follows aspect.
+ *
+ *  Edge cases:
+ *  - `orbitDist <= 0` returns a degenerate (zero-size) frustum rather
+ *    than crashing. Three.js will produce a singular projection matrix
+ *    in that case; callers should clamp orbitDist if they need a finite
+ *    image, but a zero-size frustum is preferable to NaN.
+ *  - `viewportHeight <= 0` (window minimised, hidden tab) is treated as
+ *    aspect = 1 to keep the frustum finite; the renderer can resize once
+ *    the viewport reappears.
+ */
+export function computeOrthoFrustum(
+  orbitDist: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): { left: number; right: number; top: number; bottom: number } {
+  const aspect = viewportHeight > 0 ? viewportWidth / viewportHeight : 1;
+  const halfH = orbitDist * 0.5;
+  return {
+    top: halfH,
+    bottom: -halfH,
+    right: halfH * aspect,
+    left: -halfH * aspect,
+  };
+}
+
+/** Cabinet projection shear, post-multiplied onto an orthographic
+ *  projection matrix to produce a 45-deg, half-depth oblique view.
+ *
+ *  Returns a fresh Matrix4 every call. Three.js's `Matrix4.set` takes
+ *  args in row-major order even though the underlying storage is
+ *  column-major, so this layout reads naturally:
+ *
+ *      | 1 0 cos(a)*s 0 |
+ *      | 0 1 sin(a)*s 0 |
+ *      | 0 0    1     0 |
+ *      | 0 0    0     1 |
+ *
+ *  with a = pi/4 and s = 0.5.
+ */
+export function obliqueCabinetShear(): THREE.Matrix4 {
+  const angle = Math.PI / 4;
+  const scale = 0.5;
+  const m = new THREE.Matrix4();
+  m.set(
+    1, 0, scale * Math.cos(angle), 0,
+    0, 1, scale * Math.sin(angle), 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  );
+  return m;
+}
+
+/** Post-multiply the shear matrix onto the projection matrix in place,
+ *  matching Three.js convention where `m.multiply(other)` means
+ *  `this = this * other`. The mutation is intentional so callers can
+ *  apply this directly to `camera.projectionMatrix`; the same matrix
+ *  is also returned for chainability. */
+export function applyObliqueShear(
+  projectionMatrix: THREE.Matrix4,
+  shear: THREE.Matrix4,
+): THREE.Matrix4 {
+  return projectionMatrix.multiply(shear);
+}
+
+/** Step through the projection-mode cycle (perspective -> orthographic
+ *  -> oblique -> perspective). Pure helper so the cycle order is
+ *  testable independently of the hook. */
+export function nextProjectionMode(current: ProjectionMode): ProjectionMode {
+  const i = PROJECTION_MODES.indexOf(current);
+  return PROJECTION_MODES[(i + 1) % PROJECTION_MODES.length];
+}
+
+/** Per-frame step from a set of held key codes. Returns a NEW state and a
+ *  NEW orbitTarget; never mutates the inputs. Pure - no DOM, no THREE.Camera.
+ *  This is the load-bearing logic for the keyboard half of the controller. */
+export function advanceState(
+  state: FlightCamState,
+  orbitTarget: THREE.Vector3,
+  heldKeys: Set<string>,
+): { state: FlightCamState; orbitTarget: THREE.Vector3 } {
+  const pan = PAN_BASE * state.moveSpeed;
+  const rot = ROT_BASE * state.moveSpeed;
+
+  let pos = state.pos.clone();
+  let quat = state.quat.clone();
+  let orbitDist = state.orbitDist;
+  let target = orbitTarget.clone();
+  const dirs = getCameraDirections(quat);
+
+  // Translation: WASDQE - both pos and orbitTarget advance, so the pivot follows.
+  if (heldKeys.has("KeyW")) {
+    const d = dirs.fwd.clone().multiplyScalar(pan);
+    pos.add(d); target.add(d);
+  }
+  if (heldKeys.has("KeyS")) {
+    const d = dirs.fwd.clone().multiplyScalar(-pan);
+    pos.add(d); target.add(d);
+  }
+  if (heldKeys.has("KeyA")) {
+    const d = dirs.right.clone().multiplyScalar(-pan);
+    pos.add(d); target.add(d);
+  }
+  if (heldKeys.has("KeyD")) {
+    const d = dirs.right.clone().multiplyScalar(pan);
+    pos.add(d); target.add(d);
+  }
+  if (heldKeys.has("KeyE")) {
+    const d = dirs.up.clone().multiplyScalar(pan);
+    pos.add(d); target.add(d);
+  }
+  if (heldKeys.has("KeyQ")) {
+    const d = dirs.up.clone().multiplyScalar(-pan);
+    pos.add(d); target.add(d);
+  }
+
+  // Rotation: IJKL pitch/yaw, UO roll. Local-frame. After rotating, we
+  // re-anchor orbitTarget below so the pivot orb stays screen-centred
+  // along the new look direction.
+  let rotatedView = false;
+  let pitch = 0, yaw = 0, roll = 0;
+  if (heldKeys.has("KeyI")) { pitch -= rot; rotatedView = true; }
+  if (heldKeys.has("KeyK")) { pitch += rot; rotatedView = true; }
+  if (heldKeys.has("KeyJ")) { yaw   += rot; rotatedView = true; }
+  if (heldKeys.has("KeyL")) { yaw   -= rot; rotatedView = true; }
+  if (heldKeys.has("KeyU")) { roll  += rot; rotatedView = true; }
+  if (heldKeys.has("KeyO")) { roll  -= rot; rotatedView = true; }
+  if (rotatedView) {
+    quat = rotateCameraLocal(quat, pitch, yaw, roll);
+  }
+
+  // Cart: dolly along forward via orbitDist. ] in (clamped at 1), [ out.
+  // Pos moves along fwd while orbitDist shrinks/grows by the same amount,
+  // so the orb stays put in world space (we re-sync below to be safe).
+  let cartChanged = false;
+  if (heldKeys.has("BracketRight")) {
+    const fwdNow = new THREE.Vector3(0, 0, -1).applyQuaternion(quat);
+    pos.add(fwdNow.multiplyScalar(pan));
+    orbitDist = Math.max(1, orbitDist - pan);
+    cartChanged = true;
+  }
+  if (heldKeys.has("BracketLeft")) {
+    const fwdNow = new THREE.Vector3(0, 0, -1).applyQuaternion(quat);
+    pos.add(fwdNow.multiplyScalar(-pan));
+    orbitDist = orbitDist + pan;
+    cartChanged = true;
+  }
+
+  // Re-sync orbitTarget so it tracks the look direction after IJKL/UO
+  // rotation or the cart. WASDQE already moves both pos and target by
+  // the same delta, so syncing there is a no-op (target == pos + fwd*od
+  // already). We still call it unconditionally on view change to keep the
+  // invariant `target == pos + fwd*orbitDist` from drifting.
+  if (rotatedView || cartChanged) {
+    target = syncOrbitTargetToView(pos, quat, orbitDist);
+  }
+
+  // Arrow keys: orbit around the (world-fixed) target. The camera quat
+  // rotates first; then pos repositions to `target - newFwd*orbitDist`,
+  // so the orb stays put in world space and the camera swings around it.
+  // Signs: ArrowUp = pitch up (-rot), ArrowLeft = yaw left (+rot).
+  // NOTE: the orbit path bypasses the IJKL syncOrbitTargetToView
+  // call above by design - target must NOT be re-synced to fwd*orbitDist
+  // here, otherwise a held arrow key would precess the orb forward.
+  let arrowPitch = 0, arrowYaw = 0;
+  let orbited = false;
+  if (heldKeys.has("ArrowUp"))    { arrowPitch -= rot; orbited = true; }
+  if (heldKeys.has("ArrowDown"))  { arrowPitch += rot; orbited = true; }
+  if (heldKeys.has("ArrowLeft"))  { arrowYaw   += rot; orbited = true; }
+  if (heldKeys.has("ArrowRight")) { arrowYaw   -= rot; orbited = true; }
+  if (orbited) {
+    quat = rotateCameraLocal(quat, arrowPitch, arrowYaw, 0);
+    const o = applyOrbitAroundTarget(
+      {
+        pos,
+        quat,
+        orbitDist,
+        moveSpeed: state.moveSpeed,
+        fov: state.fov,
+        projectionMode: state.projectionMode,
+      },
+      target,
+    );
+    pos = o.pos;
+  }
+
+  return {
+    state: {
+      pos,
+      quat,
+      orbitDist,
+      moveSpeed: state.moveSpeed,
+      fov: state.fov,
+      projectionMode: state.projectionMode,
+    },
+    orbitTarget: target,
+  };
+}
+
+// ---------- Hook ----------
+
+interface HookArgs {
+  rendererRef: React.RefObject<THREE.WebGLRenderer | null>;
+  cameraRef: React.RefObject<THREE.PerspectiveCamera | null>;
+  sceneRef: React.RefObject<THREE.Scene | null>;
+}
+
+export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
+  const { rendererRef, cameraRef, sceneRef } = args;
+  const [handle, setHandle] = useState<FlightCamHandle | null>(null);
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    const camera = cameraRef.current;
+    const scene = sceneRef.current;
+    if (!renderer || !camera || !scene) {
+      // Refs are not populated yet on the first effect pass. Bump a tick
+      // counter so a follow-up render attaches us. We rely on the parent
+      // signalling readiness via a state update that re-renders this
+      // component; if the parent never does, the hook stays null.
+      return;
+    }
+
+    const dom = renderer.domElement;
+
+    // Initial state: identity quaternion at the camera's current position.
+    const state: FlightCamState = {
+      pos: camera.position.clone(),
+      quat: camera.quaternion.clone(),
+      orbitDist: 40,
+      moveSpeed: 1.0,
+      fov: clampFov(camera.fov),
+      projectionMode: "perspective",
+    };
+    const orbitTarget = new THREE.Vector3()
+      .copy(state.pos)
+      .addScaledVector(new THREE.Vector3(0, 0, -1).applyQuaternion(state.quat), state.orbitDist);
+    camera.fov = state.fov;
+    camera.updateProjectionMatrix();
+
+    // Internal orthographic camera. Pose is mirrored from the perspective
+    // camera every frame; frustum is recomputed from orbitDist + the
+    // renderer canvas aspect so the apparent scene scale stays close to
+    // the perspective view at the pivot. We share near/far with the
+    // perspective camera so culling is consistent across modes.
+    const ortho = new THREE.OrthographicCamera(-1, 1, 1, -1, camera.near, camera.far);
+    ortho.position.copy(camera.position);
+    ortho.quaternion.copy(camera.quaternion);
+    // Pre-built shear matrix; reused every oblique-mode update to avoid
+    // allocating a Matrix4 per frame.
+    const obliqueShear = obliqueCabinetShear();
+
+    /** Update the active camera's projection-side matrices for `state`. */
+    const applyProjection = (): void => {
+      const w = renderer.domElement.clientWidth || 1;
+      const h = renderer.domElement.clientHeight || 1;
+      if (state.projectionMode === "perspective") {
+        camera.aspect = w / h;
+        camera.fov = state.fov;
+        camera.updateProjectionMatrix();
+        return;
+      }
+      // Both ortho and oblique start from the same frustum.
+      const f = computeOrthoFrustum(state.orbitDist, w, h);
+      ortho.left = f.left;
+      ortho.right = f.right;
+      ortho.top = f.top;
+      ortho.bottom = f.bottom;
+      ortho.near = camera.near;
+      ortho.far = camera.far;
+      ortho.updateProjectionMatrix();
+      if (state.projectionMode === "oblique") {
+        applyObliqueShear(ortho.projectionMatrix, obliqueShear);
+        ortho.projectionMatrixInverse.copy(ortho.projectionMatrix).invert();
+      }
+    };
+    applyProjection();
+
+    // Pivot orb. Rendered on top, depth-test off, scaled with orbitDist.
+    const orbGeom = new THREE.SphereGeometry(1, 16, 12);
+    const orbMat = new THREE.MeshBasicMaterial({
+      color: 0xffaa00,
+      transparent: true,
+      opacity: 0.55,
+      depthTest: false,
+      depthWrite: false,
+    });
+    const orb = new THREE.Mesh(orbGeom, orbMat);
+    orb.name = "flight_cam_pivot";
+    orb.renderOrder = 1000;
+    scene.add(orb);
+
+    // Subscriptions: at most one fire per RAF tick.
+    const listeners = new Set<(s: Readonly<FlightCamState>) => void>();
+    let dirty = false;
+    const markDirty = () => { dirty = true; };
+
+    // ---- Keyboard ----
+    const heldKeys = new Set<string>();
+    const isTypingTarget = (): boolean => {
+      const ae = document.activeElement;
+      if (!ae) return false;
+      const tag = ae.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA";
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (isTypingTarget()) return;
+      heldKeys.add(e.code);
+      // Single-step FoV: process on key down, do not enter the per-frame loop.
+      if (e.code === "NumpadAdd") {
+        state.fov = clampFov(state.fov + 1);
+        camera.fov = state.fov;
+        camera.updateProjectionMatrix();
+        heldKeys.delete(e.code);
+        markDirty();
+      } else if (e.code === "NumpadSubtract") {
+        state.fov = clampFov(state.fov - 1);
+        camera.fov = state.fov;
+        camera.updateProjectionMatrix();
+        heldKeys.delete(e.code);
+        markDirty();
+      } else if (e.code === "KeyP") {
+        // Single-press cycle. We delete from heldKeys immediately so the
+        // per-frame translation loop never sees P (it's not a movement
+        // key) and a held P does not re-fire on every frame. Browsers
+        // still send key-repeat keydown events though, so a long press
+        // will cycle once per OS-repeat-tick rather than once per frame
+        // - not double-firing on a single press is what we test for.
+        // If `repeat` is true, suppress: only fresh presses cycle.
+        if (!e.repeat) {
+          state.projectionMode = nextProjectionMode(state.projectionMode);
+          applyProjection();
+          markDirty();
+        }
+        heldKeys.delete(e.code);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent): void => {
+      heldKeys.delete(e.code);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+
+    // ---- Mouse ----
+    type Btn = "left" | "right" | "mid";
+    const buttons: Record<Btn, boolean> = { left: false, right: false, mid: false };
+    let lastX = 0, lastY = 0;
+    let downX = 0, downY = 0, downT = 0;
+    let dragged = false;
+
+    const onPointerDown = (e: PointerEvent): void => {
+      if (e.button === 0) buttons.left = true;
+      else if (e.button === 1) { buttons.mid = true; e.preventDefault(); }
+      else if (e.button === 2) buttons.right = true;
+      lastX = e.clientX; lastY = e.clientY;
+      downX = e.clientX; downY = e.clientY;
+      downT = performance.now();
+      dragged = false;
+    };
+    // Up listens on window so a release outside the canvas still clears the button.
+    const onPointerUp = (e: PointerEvent): void => {
+      if (e.button === 0) buttons.left = false;
+      else if (e.button === 1) buttons.mid = false;
+      else if (e.button === 2) buttons.right = false;
+    };
+    const onPointerMove = (e: PointerEvent): void => {
+      if (!buttons.left && !buttons.right && !buttons.mid) return;
+      const dx = e.clientX - lastX;
+      const dy = e.clientY - lastY;
+      lastX = e.clientX;
+      lastY = e.clientY;
+
+      // Track click-vs-drag against the original down position. Once we
+      // cross the click thresholds we stop fighting the picker; the
+      // picker has its own thresholds and will simply not fire.
+      if (!dragged) {
+        const tdx = e.clientX - downX;
+        const tdy = e.clientY - downY;
+        const tdt = performance.now() - downT;
+        if (tdx * tdx + tdy * tdy > CLICK_PIX_THRESHOLD * CLICK_PIX_THRESHOLD || tdt > CLICK_TIME_MS) {
+          dragged = true;
+        }
+      }
+      // Suppress sub-threshold motion entirely so a clean click never nudges the camera.
+      if (!dragged) return;
+
+      if (buttons.left) {
+        const { right, up } = getCameraDirections(state.quat);
+        const dr = right.clone().multiplyScalar(-dx * MOUSE_PAN_SENS);
+        const du = up.clone().multiplyScalar(dy * MOUSE_PAN_SENS);
+        state.pos.add(dr).add(du);
+        orbitTarget.add(dr).add(du);
+        markDirty();
+      }
+      if (buttons.right) {
+        // Rotate then re-anchor pos at orbitTarget - fwd*orbitDist.
+        state.quat = rotateCameraLocal(state.quat, dy * MOUSE_ROT_SENS, -dx * MOUSE_ROT_SENS, 0);
+        const { fwd } = getCameraDirections(state.quat);
+        state.pos.copy(orbitTarget).addScaledVector(fwd, -state.orbitDist);
+        markDirty();
+      }
+      if (buttons.mid) {
+        // Look without re-anchor; keep orbitTarget locked at pos + fwd*orbitDist.
+        state.quat = rotateCameraLocal(state.quat, dy * MOUSE_ROT_SENS, -dx * MOUSE_ROT_SENS, 0);
+        const { fwd } = getCameraDirections(state.quat);
+        orbitTarget.copy(state.pos).addScaledVector(fwd, state.orbitDist);
+        markDirty();
+      }
+    };
+    const onContextMenu = (e: MouseEvent): void => { e.preventDefault(); };
+    const onWheel = (e: WheelEvent): void => {
+      state.moveSpeed = adjustMoveSpeed(state.moveSpeed, e.deltaY);
+      markDirty();
+    };
+
+    dom.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointerup", onPointerUp);
+    dom.addEventListener("pointermove", onPointerMove);
+    dom.addEventListener("contextmenu", onContextMenu);
+    dom.addEventListener("wheel", onWheel, { passive: true });
+
+    // ---- Per-frame loop ----
+    let rafId = 0;
+    let disposed = false;
+    const tick = (): void => {
+      if (disposed) return;
+      rafId = requestAnimationFrame(tick);
+
+      if (heldKeys.size > 0) {
+        const before = state.pos.clone();
+        const beforeQ = state.quat.clone();
+        const beforeOd = state.orbitDist;
+        const next = advanceState(state, orbitTarget, heldKeys);
+        state.pos.copy(next.state.pos);
+        state.quat.copy(next.state.quat);
+        state.orbitDist = next.state.orbitDist;
+        orbitTarget.copy(next.orbitTarget);
+        if (
+          !before.equals(state.pos) ||
+          !beforeQ.equals(state.quat) ||
+          beforeOd !== state.orbitDist
+        ) {
+          markDirty();
+        }
+      }
+
+      // Push the latest state to the camera every frame; cheap, and keeps
+      // us in sync if anything else nudged the THREE.Camera in between.
+      camera.position.copy(state.pos);
+      camera.quaternion.copy(state.quat);
+      // Mirror pose into the ortho camera so a switch to ortho/oblique
+      // is seamless. Cheap (vec3 + quat copy) and avoids a one-frame
+      // pop on cycle.
+      ortho.position.copy(state.pos);
+      ortho.quaternion.copy(state.quat);
+
+      // Refresh the active camera's projection. In perspective mode this
+      // is a no-op vs. what's already on the camera unless the canvas
+      // resized; in ortho/oblique it tracks orbitDist as the user
+      // dollies in/out via [/].
+      if (state.projectionMode !== "perspective") {
+        applyProjection();
+      }
+
+      // Scale the pivot orb with orbitDist; clamp the floor so it stays
+      // visible at point-blank dolly-in.
+      const r = Math.max(0.1, state.orbitDist * 0.01);
+      orb.position.copy(orbitTarget);
+      orb.scale.setScalar(r);
+
+      if (dirty && listeners.size > 0) {
+        const snapshot: Readonly<FlightCamState> = {
+          pos: state.pos.clone(),
+          quat: state.quat.clone(),
+          orbitDist: state.orbitDist,
+          moveSpeed: state.moveSpeed,
+          fov: state.fov,
+          projectionMode: state.projectionMode,
+        };
+        for (const l of listeners) l(snapshot);
+      }
+      dirty = false;
+    };
+    rafId = requestAnimationFrame(tick);
+
+    // ---- Handle ----
+    const h: FlightCamHandle = {
+      resetToScene(sceneRoot: THREE.Object3D): void {
+        sceneRoot.updateMatrixWorld(true);
+        const box = new THREE.Box3().setFromObject(sceneRoot);
+        let center: THREE.Vector3;
+        let dist: number;
+        if (box.isEmpty()) {
+          center = new THREE.Vector3(0, 0, 0);
+          dist = 80;
+        } else {
+          center = box.getCenter(new THREE.Vector3());
+          const size = box.getSize(new THREE.Vector3()).length();
+          if (!Number.isFinite(size) || size <= 0) {
+            dist = 80;
+          } else {
+            const fovRad = state.fov * Math.PI / 180;
+            dist = Math.max((size / (2 * Math.tan(fovRad / 2))) * 1.1, 10);
+          }
+        }
+        // Default vantage: above the centroid looking down -Z toward it,
+        // with world-up = +Y. lookAt produces a right-handed basis.
+        state.pos.set(center.x, center.y, center.z + dist);
+        const m = new THREE.Matrix4();
+        m.lookAt(state.pos, center, new THREE.Vector3(0, 1, 0));
+        state.quat.setFromRotationMatrix(m);
+        state.orbitDist = dist;
+        orbitTarget.copy(center);
+        // Also tighten near/far so the depth precision matches the ship size.
+        if (Number.isFinite(dist) && dist > 0) {
+          camera.near = Math.max(dist / 1000, 0.05);
+          camera.far = dist * 100;
+          camera.updateProjectionMatrix();
+        }
+        markDirty();
+      },
+      focusOnPoint(target: THREE.Vector3, distance?: number): void {
+        const dist = distance ?? 15;
+        const { fwd } = getCameraDirections(state.quat);
+        state.pos.copy(target).addScaledVector(fwd, -dist);
+        const m = new THREE.Matrix4();
+        m.lookAt(state.pos, target, new THREE.Vector3(0, 1, 0));
+        state.quat.setFromRotationMatrix(m);
+        state.orbitDist = dist;
+        orbitTarget.copy(target);
+        markDirty();
+      },
+      dispose(): void {
+        if (disposed) return;
+        disposed = true;
+        cancelAnimationFrame(rafId);
+        window.removeEventListener("keydown", onKeyDown);
+        window.removeEventListener("keyup", onKeyUp);
+        window.removeEventListener("pointerup", onPointerUp);
+        dom.removeEventListener("pointerdown", onPointerDown);
+        dom.removeEventListener("pointermove", onPointerMove);
+        dom.removeEventListener("contextmenu", onContextMenu);
+        dom.removeEventListener("wheel", onWheel);
+        scene.remove(orb);
+        orbGeom.dispose();
+        orbMat.dispose();
+        listeners.clear();
+      },
+      getState(): Readonly<FlightCamState> {
+        return {
+          pos: state.pos.clone(),
+          quat: state.quat.clone(),
+          orbitDist: state.orbitDist,
+          moveSpeed: state.moveSpeed,
+          fov: state.fov,
+          projectionMode: state.projectionMode,
+        };
+      },
+      subscribe(listener): () => void {
+        listeners.add(listener);
+        // Prime the listener so it can render an initial readout.
+        listener({
+          pos: state.pos.clone(),
+          quat: state.quat.clone(),
+          orbitDist: state.orbitDist,
+          moveSpeed: state.moveSpeed,
+          fov: state.fov,
+          projectionMode: state.projectionMode,
+        });
+        return () => listeners.delete(listener);
+      },
+      cycleProjectionMode(): void {
+        state.projectionMode = nextProjectionMode(state.projectionMode);
+        applyProjection();
+        markDirty();
+      },
+      setProjectionMode(mode: ProjectionMode): void {
+        if (state.projectionMode === mode) return;
+        state.projectionMode = mode;
+        applyProjection();
+        markDirty();
+      },
+      getActiveCamera(): THREE.Camera {
+        return state.projectionMode === "perspective" ? camera : ortho;
+      },
+    };
+    setHandle(h);
+
+    return () => {
+      h.dispose();
+      setHandle(null);
+    };
+    // Refs are populated by the parent's bootstrap effect, which runs
+    // before this one (effects fire top-down inside one component). After
+    // mount the refs do not change identity, so an empty dep array is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return handle;
+}

--- a/app/src/lib/flight-camera.ts
+++ b/app/src/lib/flight-camera.ts
@@ -62,6 +62,27 @@ export const PROJECTION_MODES: readonly ProjectionMode[] = [
   "oblique",
 ] as const;
 
+/** Named camera presets bound to the Numpad keys. The presets all aim
+ *  at the scene centroid; only the camera position differs. Distance is
+ *  computed from the scene AABB by `computeFramingDistance` so the model
+ *  fills ~`PRESET_FILL_FRACTION` of the viewport. */
+export type ViewPreset =
+  | "overhead"
+  | "perspective2"
+  | "side"
+  | "fore"
+  | "aft"
+  | "perspective";
+
+export const VIEW_PRESETS: readonly ViewPreset[] = [
+  "overhead",
+  "perspective2",
+  "side",
+  "fore",
+  "aft",
+  "perspective",
+] as const;
+
 export interface FlightCamState {
   pos: THREE.Vector3;
   quat: THREE.Quaternion;
@@ -96,6 +117,11 @@ export interface FlightCamHandle {
   cycleProjectionMode(): void;
   /** Set projection mode directly. Bound to the dropdown selector. */
   setProjectionMode(mode: ProjectionMode): void;
+  /** Snap to a named preset framing the given sceneRoot. Position is
+   *  computed from the scene AABB (centred on the centroid) at a
+   *  distance that fills `PRESET_FILL_FRACTION` of the viewport, looking
+   *  at the centroid. No damping; the swap is instant. */
+  setView(preset: ViewPreset, sceneRoot: THREE.Object3D): void;
   /** Read the camera the renderer / picker should use this frame. Returns
    *  the perspective camera in "perspective" mode and the internal
    *  orthographic camera in "orthographic" or "oblique". The returned
@@ -110,6 +136,13 @@ export const SPEED_MAX = 50;
 export const SPEED_STEP = 1.15;
 export const FOV_MIN = 10;
 export const FOV_MAX = 120;
+
+/** Fraction of the viewport's narrowest dimension the framed AABB should
+ *  cover. 0.8 = leave ~10% margin on every side of the entity. Shared by
+ *  `resetToScene` and `setView` so R and the Numpad keys agree on scale. */
+export const PRESET_FILL_FRACTION = 0.8;
+/** Fallback distance when the scene AABB is empty or degenerate. */
+export const FRAMING_FALLBACK_DISTANCE = 80;
 
 /** Per-frame translation magnitude = PAN_BASE * moveSpeed. */
 const PAN_BASE = 0.5;
@@ -300,6 +333,146 @@ export function applyObliqueShear(
 export function nextProjectionMode(current: ProjectionMode): ProjectionMode {
   const i = PROJECTION_MODES.indexOf(current);
   return PROJECTION_MODES[(i + 1) % PROJECTION_MODES.length];
+}
+
+/** Compute the camera distance that frames an AABB at the given
+ *  perspective FoV so the entity fills `fillFraction` of the viewport's
+ *  narrowest dimension.
+ *
+ *  The dominant axis is the largest of the three AABB extents; we fit
+ *  THAT extent into both the vertical and horizontal half-FoVs and take
+ *  the larger of the two distances so neither axis crops. The result is
+ *  divided by `fillFraction` to back the camera away an extra step,
+ *  leaving a margin (fillFraction = 0.8 => ~10% margin per side).
+ *
+ *  Edge cases:
+ *  - Degenerate AABB (extent_max <= 0) returns FRAMING_FALLBACK_DISTANCE
+ *    instead of dividing by zero.
+ *  - viewportAspect <= 0 is treated as 1 (square viewport) so we don't
+ *    produce a negative or NaN horizontal half-FoV.
+ *  - fillFraction <= 0 is treated as PRESET_FILL_FRACTION so a caller
+ *    that fat-fingers the argument still gets a finite distance.
+ */
+export function computeFramingDistance(
+  aabbMin: THREE.Vector3,
+  aabbMax: THREE.Vector3,
+  fovDegrees: number,
+  viewportAspect: number,
+  fillFraction: number,
+): number {
+  const dx = aabbMax.x - aabbMin.x;
+  const dy = aabbMax.y - aabbMin.y;
+  const dz = aabbMax.z - aabbMin.z;
+  const extent_max = Math.max(dx, dy, dz);
+  if (!Number.isFinite(extent_max) || extent_max <= 0) {
+    return FRAMING_FALLBACK_DISTANCE;
+  }
+  const aspect = viewportAspect > 0 && Number.isFinite(viewportAspect) ? viewportAspect : 1;
+  const fill = fillFraction > 0 ? fillFraction : PRESET_FILL_FRACTION;
+  const vfov = (fovDegrees * Math.PI) / 180;
+  const hfov = 2 * Math.atan(Math.tan(vfov / 2) * aspect);
+  const dV = (extent_max / 2) / Math.tan(vfov / 2);
+  const dH = (extent_max / 2) / Math.tan(hfov / 2);
+  return Math.max(dV, dH) / fill;
+}
+
+/** Map a keyboard event `code` to the matching `ViewPreset`. Returns
+ *  null for codes that are not bound to a preset. The mapping mirrors
+ *  the kaboos-loot Numpad layout: Numpad0 = overhead, Numpad1 =
+ *  perspective2, Numpad2 = side, Numpad3 = fore, Numpad4 = aft,
+ *  Numpad5 = perspective. Pure helper so the dispatch table is
+ *  testable without a DOM. */
+export function viewPresetForKeyCode(code: string): ViewPreset | null {
+  switch (code) {
+    case "Numpad0": return "overhead";
+    case "Numpad1": return "perspective2";
+    case "Numpad2": return "side";
+    case "Numpad3": return "fore";
+    case "Numpad4": return "aft";
+    case "Numpad5": return "perspective";
+    default: return null;
+  }
+}
+
+/** Top-level dispatch for the SceneViewer keyboard shortcuts that
+ *  affect the flight camera or the HUD. Pure (no DOM, no THREE), so
+ *  the routing table is unit-testable.
+ *
+ *  Behaviour:
+ *  - `R`           => calls `handle.resetToScene(sceneRoot)`. The
+ *                     repeat flag is ignored (held R refreshes).
+ *  - `H`           => calls `toggleHud()`. Suppressed on `repeat` so a
+ *                     held H does not strobe.
+ *  - `Numpad0..5`  => calls `handle.setView(preset, sceneRoot)`.
+ *                     Suppressed on `repeat`.
+ *  - anything else => returns `false` (caller decides).
+ *
+ *  Returns `true` if the event matched a binding (caller should call
+ *  preventDefault); `false` otherwise. */
+export function dispatchViewerHotkey(
+  e: { code: string; repeat: boolean },
+  handle: Pick<FlightCamHandle, "resetToScene" | "setView"> | null,
+  sceneRoot: THREE.Object3D | null,
+  toggleHud: () => void,
+): boolean {
+  if (e.code === "KeyR") {
+    if (handle && sceneRoot) handle.resetToScene(sceneRoot);
+    return true;
+  }
+  if (e.code === "KeyH") {
+    if (e.repeat) return true;
+    toggleHud();
+    return true;
+  }
+  const preset = viewPresetForKeyCode(e.code);
+  if (preset) {
+    if (e.repeat) return true;
+    if (handle && sceneRoot) handle.setView(preset, sceneRoot);
+    return true;
+  }
+  return false;
+}
+
+/** World-space camera offset (relative to the look target, in Y-up
+ *  Three.js basis) for each named preset. `dist` is the framing distance
+ *  computed by `computeFramingDistance`. The returned vector should be
+ *  added to the look target to get the camera's world position.
+ *
+ *  Conventions used here (matching kaboos-loot's setView, then mapped
+ *  from kaboos's Z-up basis to Three.js Y-up by swapping y<->z and
+ *  flipping signs where needed so visual semantics match):
+ *  - overhead: directly above the target, looking down. Camera at
+ *    (0, +dist, 0), since up = +Y.
+ *  - side:     to the +X side at the target's height.
+ *  - fore:     in front (kaboos uses cy - d for "fore"). In Y-up basis
+ *    we treat +Z toward the viewer as "fore", so camera at (0, 0, +dist).
+ *  - aft:      behind (-Z).
+ *  - perspective: 3/4 view above + side, looking at target. Kaboos
+ *    placed it at (cx + off, cy - off, cz + off); in Y-up that maps to
+ *    (+off, +off, +off) so the camera sits in the +X / +Y / +Z octant.
+ *  - perspective2: rotated 90 degrees from perspective; we negate X so
+ *    the camera ends up in the -X / +Y / +Z octant.
+ *
+ *  All of these aim at the (caller-provided) target, so the returned
+ *  offset only encodes direction + distance; the look quaternion is
+ *  derived from it via Matrix4.lookAt at call time.
+ */
+export function viewPresetOffset(preset: ViewPreset, dist: number): THREE.Vector3 {
+  const off = dist * 0.5;
+  switch (preset) {
+    case "overhead":
+      return new THREE.Vector3(0, dist, 0);
+    case "side":
+      return new THREE.Vector3(dist, 0, 0);
+    case "fore":
+      return new THREE.Vector3(0, 0, dist);
+    case "aft":
+      return new THREE.Vector3(0, 0, -dist);
+    case "perspective":
+      return new THREE.Vector3(off, off, off);
+    case "perspective2":
+      return new THREE.Vector3(-off, off, off);
+  }
 }
 
 /** Per-frame step from a set of held key codes. Returns a NEW state and a
@@ -719,29 +892,35 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
       resetToScene(sceneRoot: THREE.Object3D): void {
         sceneRoot.updateMatrixWorld(true);
         const box = new THREE.Box3().setFromObject(sceneRoot);
-        let center: THREE.Vector3;
+        // Orbit target is fixed at world origin (per the project's view
+        // convention for ship exports, which are emitted centred near
+        // origin). The framing distance is sized from the AABB so the
+        // entity fills PRESET_FILL_FRACTION of the viewport.
+        const target = new THREE.Vector3(0, 0, 0);
         let dist: number;
         if (box.isEmpty()) {
-          center = new THREE.Vector3(0, 0, 0);
-          dist = 80;
+          dist = FRAMING_FALLBACK_DISTANCE;
         } else {
-          center = box.getCenter(new THREE.Vector3());
-          const size = box.getSize(new THREE.Vector3()).length();
-          if (!Number.isFinite(size) || size <= 0) {
-            dist = 80;
-          } else {
-            const fovRad = state.fov * Math.PI / 180;
-            dist = Math.max((size / (2 * Math.tan(fovRad / 2))) * 1.1, 10);
-          }
+          const w = renderer.domElement.clientWidth || 1;
+          const h = renderer.domElement.clientHeight || 1;
+          dist = computeFramingDistance(
+            box.min,
+            box.max,
+            state.fov,
+            w / h,
+            PRESET_FILL_FRACTION,
+          );
         }
-        // Default vantage: above the centroid looking down -Z toward it,
-        // with world-up = +Y. lookAt produces a right-handed basis.
-        state.pos.set(center.x, center.y, center.z + dist);
+        // Default vantage: 3/4 view in the +X / +Y / +Z octant, looking
+        // back at the origin. Direction is normalised then scaled by
+        // dist so the camera's distance to target equals dist.
+        const dir = new THREE.Vector3(1, 0.6, 1).normalize();
+        state.pos.copy(target).addScaledVector(dir, dist);
         const m = new THREE.Matrix4();
-        m.lookAt(state.pos, center, new THREE.Vector3(0, 1, 0));
+        m.lookAt(state.pos, target, new THREE.Vector3(0, 1, 0));
         state.quat.setFromRotationMatrix(m);
-        state.orbitDist = dist;
-        orbitTarget.copy(center);
+        state.orbitDist = state.pos.distanceTo(target);
+        orbitTarget.copy(target);
         // Also tighten near/far so the depth precision matches the ship size.
         if (Number.isFinite(dist) && dist > 0) {
           camera.near = Math.max(dist / 1000, 0.05);
@@ -809,6 +988,47 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
         if (state.projectionMode === mode) return;
         state.projectionMode = mode;
         applyProjection();
+        markDirty();
+      },
+      setView(preset: ViewPreset, sceneRoot: THREE.Object3D): void {
+        sceneRoot.updateMatrixWorld(true);
+        const box = new THREE.Box3().setFromObject(sceneRoot);
+        const target = box.isEmpty()
+          ? new THREE.Vector3(0, 0, 0)
+          : box.getCenter(new THREE.Vector3());
+        let dist: number;
+        if (box.isEmpty()) {
+          dist = FRAMING_FALLBACK_DISTANCE;
+        } else {
+          const w = renderer.domElement.clientWidth || 1;
+          const h = renderer.domElement.clientHeight || 1;
+          dist = computeFramingDistance(
+            box.min,
+            box.max,
+            state.fov,
+            w / h,
+            PRESET_FILL_FRACTION,
+          );
+        }
+        const offset = viewPresetOffset(preset, dist);
+        state.pos.copy(target).add(offset);
+        // Three's lookAt picks an arbitrary basis when fwd is parallel to
+        // the world-up vector (overhead view). For the overhead preset we
+        // use +Z as up so the camera does not snap to a singular basis.
+        const worldUp =
+          preset === "overhead"
+            ? new THREE.Vector3(0, 0, -1)
+            : new THREE.Vector3(0, 1, 0);
+        const m = new THREE.Matrix4();
+        m.lookAt(state.pos, target, worldUp);
+        state.quat.setFromRotationMatrix(m);
+        state.orbitDist = state.pos.distanceTo(target);
+        orbitTarget.copy(target);
+        if (Number.isFinite(dist) && dist > 0) {
+          camera.near = Math.max(dist / 1000, 0.05);
+          camera.far = dist * 100;
+          camera.updateProjectionMatrix();
+        }
         markDirty();
       },
       getActiveCamera(): THREE.Camera {

--- a/app/src/lib/flight-camera.ts
+++ b/app/src/lib/flight-camera.ts
@@ -131,6 +131,15 @@ export interface FlightCamHandle {
    *  Settings panel toggle. The orb still updates its position every
    *  frame so toggling on does not require a frame for it to appear. */
   setPivotOrbVisible(visible: boolean): void;
+  /** Wheel-equivalent: nudge moveSpeed by one step. `direction = 1`
+   *  speeds up (matches scroll-up / wheel-deltaY < 0), `-1` slows
+   *  down. Used by the on-screen nav widget so mobile / remote
+   *  sessions can adjust speed without a physical wheel. */
+  nudgeMoveSpeed(direction: 1 | -1): void;
+  /** Single-step FoV adjust. `direction = 1` widens FoV, `-1`
+   *  narrows. Mirrors the NumpadAdd / NumpadSubtract bindings so the
+   *  on-screen nav widget can drive them too. */
+  nudgeFov(direction: 1 | -1): void;
 }
 
 // ---------- Public constants ----------
@@ -942,6 +951,18 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
           camera.far = dist * 100;
           camera.updateProjectionMatrix();
         }
+        // Scale the WASDQE move-speed proportional to scene size. Without
+        // this, big maps (Exec Hangar at km-scale) feel like W and S
+        // "don't work" -- a 0.5 unit/frame translation at the default
+        // moveSpeed=1.0 is imperceptible against a 5000 unit AABB. The
+        // chosen ratio (dist / 100) gives ~50 units/frame at SOC scale
+        // and ~0.4 units/frame for a small ship, both of which feel
+        // responsive without being uncontrollable. Wheel-up still scales
+        // it further, wheel-down still slows it down.
+        if (Number.isFinite(dist) && dist > 0) {
+          const auto = dist / 100;
+          state.moveSpeed = Math.min(SPEED_MAX, Math.max(SPEED_MIN, auto));
+        }
         markDirty();
       },
       focusOnPoint(target: THREE.Vector3, distance?: number): void {
@@ -1051,6 +1072,19 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
       },
       setPivotOrbVisible(visible: boolean): void {
         orb.visible = visible;
+      },
+      nudgeMoveSpeed(direction: 1 | -1): void {
+        // adjustMoveSpeed reads the sign of the deltaY: negative
+        // speeds up, positive slows down. Match that convention.
+        const deltaY = direction === 1 ? -100 : 100;
+        state.moveSpeed = adjustMoveSpeed(state.moveSpeed, deltaY);
+        markDirty();
+      },
+      nudgeFov(direction: 1 | -1): void {
+        state.fov = clampFov(state.fov + direction);
+        camera.fov = state.fov;
+        camera.updateProjectionMatrix();
+        markDirty();
       },
     };
     setHandle(h);

--- a/app/src/lib/flight-camera.ts
+++ b/app/src/lib/flight-camera.ts
@@ -127,12 +127,21 @@ export interface FlightCamHandle {
    *  orthographic camera in "orthographic" or "oblique". The returned
    *  reference is stable across frames; only its matrices update. */
   getActiveCamera(): THREE.Camera;
+  /** Show or hide the pivot orb. Off by default; users opt in via the
+   *  Settings panel toggle. The orb still updates its position every
+   *  frame so toggling on does not require a frame for it to appear. */
+  setPivotOrbVisible(visible: boolean): void;
 }
 
 // ---------- Public constants ----------
 
 export const SPEED_MIN = 0.05;
-export const SPEED_MAX = 50;
+// Map scenes (Exec Hangar, asteroid bases) span tens of thousands of units;
+// the previous 50 cap maxed out around ~1500 units/sec which is too slow to
+// traverse them. 500 gives ~15k units/sec at 60fps -- enough to cross a
+// multi-km scene in a few seconds while still letting smaller ships use the
+// low end of the curve. Wheel-up still clamps at this value.
+export const SPEED_MAX = 500;
 export const SPEED_STEP = 1.15;
 export const FOV_MIN = 10;
 export const FOV_MAX = 120;
@@ -395,14 +404,16 @@ export function viewPresetForKeyCode(code: string): ViewPreset | null {
 }
 
 /** Top-level dispatch for the SceneViewer keyboard shortcuts that
- *  affect the flight camera or the HUD. Pure (no DOM, no THREE), so
- *  the routing table is unit-testable.
+ *  affect the flight camera or the toolbar settings. Pure (no DOM, no
+ *  THREE), so the routing table is unit-testable.
  *
  *  Behaviour:
  *  - `R`           => calls `handle.resetToScene(sceneRoot)`. The
  *                     repeat flag is ignored (held R refreshes).
- *  - `H`           => calls `toggleHud()`. Suppressed on `repeat` so a
- *                     held H does not strobe.
+ *  - `H`           => calls `togglePivotOrb()`. Suppressed on `repeat`
+ *                     so a held H does not strobe. Was previously
+ *                     bound to "toggle HUD"; the HUD now has its own
+ *                     in-panel hide button instead.
  *  - `Numpad0..5`  => calls `handle.setView(preset, sceneRoot)`.
  *                     Suppressed on `repeat`.
  *  - anything else => returns `false` (caller decides).
@@ -413,7 +424,7 @@ export function dispatchViewerHotkey(
   e: { code: string; repeat: boolean },
   handle: Pick<FlightCamHandle, "resetToScene" | "setView"> | null,
   sceneRoot: THREE.Object3D | null,
-  toggleHud: () => void,
+  togglePivotOrb: () => void,
 ): boolean {
   if (e.code === "KeyR") {
     if (handle && sceneRoot) handle.resetToScene(sceneRoot);
@@ -421,7 +432,7 @@ export function dispatchViewerHotkey(
   }
   if (e.code === "KeyH") {
     if (e.repeat) return true;
-    toggleHud();
+    togglePivotOrb();
     return true;
   }
   const preset = viewPresetForKeyCode(e.code);
@@ -692,6 +703,10 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
     const orb = new THREE.Mesh(orbGeom, orbMat);
     orb.name = "flight_cam_pivot";
     orb.renderOrder = 1000;
+    // Default OFF. The orb is a debug-style affordance most users do
+    // not want visible all the time; opt in via Settings -> "Show
+    // pivot orb".
+    orb.visible = false;
     scene.add(orb);
 
     // Subscriptions: at most one fire per RAF tick.
@@ -1033,6 +1048,9 @@ export function useFlightCamera(args: HookArgs): FlightCamHandle | null {
       },
       getActiveCamera(): THREE.Camera {
         return state.projectionMode === "perspective" ? camera : ortho;
+      },
+      setPivotOrbVisible(visible: boolean): void {
+        orb.visible = visible;
       },
     };
     setHandle(h);

--- a/app/src/lib/perf.ts
+++ b/app/src/lib/perf.ts
@@ -1,0 +1,44 @@
+/**
+ * Load-phase performance instrumentation.
+ *
+ * Installs a PerformanceObserver that logs long tasks (>50ms) and slow
+ * events (>200ms) to the console so they are captured by the existing
+ * tauri-plugin-log / attachConsole pipeline and written to app.log.
+ *
+ * All output is prefixed with `[perf]` for easy grepping.
+ *
+ * Call `installPerfObserver()` once from main.tsx after `attachConsole()`.
+ * Safe to call in any environment; unknown entryTypes are silently skipped.
+ */
+export function installPerfObserver(): void {
+  // Chromium inside WebView2 supports "longtask"; Safari and older builds
+  // may not. Wrap in try/catch so a missing entryType does not crash the app.
+  try {
+    const longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const dur = entry.duration.toFixed(0);
+        // Only log tasks that are long enough to be a real bottleneck.
+        if (entry.duration >= 50) {
+          console.warn(`[perf] longtask ${dur}ms name=${entry.name}`);
+        }
+      }
+    });
+    longTaskObserver.observe({ entryTypes: ["longtask"] });
+  } catch {
+    // entryType not supported in this WebView build -- skip silently.
+  }
+
+  try {
+    const eventObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.duration >= 200) {
+          const dur = entry.duration.toFixed(0);
+          console.warn(`[perf] slow-event ${dur}ms name=${entry.name}`);
+        }
+      }
+    });
+    eventObserver.observe({ entryTypes: ["event"] });
+  } catch {
+    // entryType not supported in this WebView build -- skip silently.
+  }
+}

--- a/app/src/lib/progress-reporter.ts
+++ b/app/src/lib/progress-reporter.ts
@@ -1,0 +1,136 @@
+// State container for the unified `<ProgressOverlay>`. The parent route
+// owns a single reporter per long-running operation and passes the
+// update API down to the viewer components that contribute to it (the
+// SocSceneViewer instruments fetch + decode; the parent handles backend
+// events). When all phases complete -- or the operation is cancelled --
+// the reporter is reset and the overlay disappears.
+//
+// Phases are declared up front by the caller (`begin(phases)`) so the
+// overlay's checkpoint list is stable from first paint and the user
+// sees the work plan, not a list that grows mid-load.
+
+import { useCallback, useMemo, useState } from "react";
+import type { ProgressPhase } from "../components/progress-overlay";
+
+/**
+ * The reporter's mutating API. The four callbacks below are stable
+ * across renders (each `useCallback` has empty deps), so consumers
+ * MUST depend on these individually -- not on the whole reporter
+ * object -- when wiring them into `useCallback` / `useEffect` deps.
+ *
+ * Why: the reporter object identity changes whenever the underlying
+ * phases state updates (it has to, for React to re-render the
+ * overlay). If a consumer puts the whole reporter in its deps, every
+ * progress tick re-creates downstream callbacks; if those callbacks
+ * are passed as props to children, the children's effects re-fire on
+ * every progress tick. For a SOC load with ~1500 textures emitting
+ * ticks at ~6/sec, this triggers thousands of effect re-runs and
+ * saturates the Tauri IPC channel.
+ *
+ * The render-related fields (`phases`, `active`) DO change with
+ * state and are intended for use in JSX only.
+ */
+export interface ProgressReporter {
+  /** Snapshot of phases for rendering. Changes every progress tick. */
+  phases: ProgressPhase[];
+  /** True if any phase is `pending` or `active`. Render-only. */
+  active: boolean;
+  /** Replace the phase list and mark the reporter active. The first
+   *  phase is auto-marked `active`; the rest start `pending`.
+   *  STABLE reference. */
+  begin: (phases: Omit<ProgressPhase, "status">[]) => void;
+  /** Update one phase by id. Patch is shallow-merged. Status
+   *  transitions are explicit. STABLE reference. */
+  update: (id: string, patch: Partial<Omit<ProgressPhase, "id">>) => void;
+  /** Mark a phase complete and optionally activate the next pending
+   *  phase. STABLE reference. */
+  advance: (completedId: string) => void;
+  /** Reset to no phases. STABLE reference. */
+  reset: () => void;
+}
+
+export function useProgressReporter(): ProgressReporter {
+  const [phases, setPhases] = useState<ProgressPhase[]>([]);
+
+  const begin = useCallback(
+    (declared: Omit<ProgressPhase, "status">[]) => {
+      const next: ProgressPhase[] = declared.map((p, i) => ({
+        ...p,
+        status: i === 0 ? "active" : "pending",
+      }));
+      setPhases(next);
+    },
+    [],
+  );
+
+  const update = useCallback(
+    (id: string, patch: Partial<Omit<ProgressPhase, "id">>) => {
+      setPhases((prev) => {
+        let changed = false;
+        const next = prev.map((phase) => {
+          if (phase.id !== id) return phase;
+          const merged = { ...phase, ...patch };
+          // Skip the state update if nothing actually changed -- a
+          // common case during XHR `progress` events that fire many
+          // times per second with the same fraction (rounded). Keeps
+          // React from re-rendering the overlay unnecessarily.
+          if (
+            merged.fraction === phase.fraction &&
+            merged.detail === phase.detail &&
+            merged.status === phase.status &&
+            merged.label === phase.label &&
+            merged.weight === phase.weight
+          ) {
+            return phase;
+          }
+          changed = true;
+          return merged;
+        });
+        return changed ? next : prev;
+      });
+    },
+    [],
+  );
+
+  const advance = useCallback((completedId: string) => {
+    setPhases((prev) => {
+      let foundCompleted = false;
+      let activatedNext = false;
+      const next = prev.map((phase) => {
+        if (phase.id === completedId && phase.status !== "complete") {
+          foundCompleted = true;
+          return { ...phase, status: "complete" as const, fraction: 1 };
+        }
+        if (
+          foundCompleted &&
+          !activatedNext &&
+          phase.status === "pending"
+        ) {
+          activatedNext = true;
+          return { ...phase, status: "active" as const };
+        }
+        return phase;
+      });
+      return foundCompleted ? next : prev;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setPhases([]);
+  }, []);
+
+  const active =
+    phases.length > 0 && phases.some((p) => p.status !== "complete");
+
+  // Memoise the returned object so its identity only changes when
+  // `phases` (and therefore `active`) changes. `begin` / `update` /
+  // `advance` / `reset` are stable across renders, so adding them to
+  // the dep array is a no-op past the first render. This is defensive
+  // -- consumers are expected to depend on individual stable callbacks
+  // rather than the whole object -- but the memo avoids cascades when
+  // a consumer accidentally captures the whole `progress` value.
+  return useMemo(
+    () => ({ phases, active, begin, update, advance, reset }),
+    [phases, active, begin, update, advance, reset],
+  );
+}

--- a/app/src/lib/render-styles.ts
+++ b/app/src/lib/render-styles.ts
@@ -1,0 +1,238 @@
+// Viewer-agnostic render-style application.
+//
+// The Ships viewer has a sidecar-driven material pipeline (one
+// `SubmaterialRecord` per slot, dispatched by shader family). When the
+// user picks a non-textured style for a ship, the loader rebuilds each
+// material by calling family-specific builders that know about the
+// underlying CryEngine semantics — see `decomposed-loader.ts`.
+//
+// The SOC scene viewer (Maps tab) has none of that metadata: it loads a
+// single `.glb` whose materials are plain `MeshStandardMaterial`
+// instances that GLTFLoader synthesises from `baseColorFactor` +
+// userData. So a different application path is needed there: walk every
+// mesh, swap the current material for its stylised variant, remember
+// the original so a switch back to "textured" restores fidelity.
+//
+// `applyRenderStyleToScene` here is that walk. It re-uses the underlying
+// `makeMobiGlasMaterial` from `decomposed-loader.ts` so the visible
+// shader is identical to the Ships path; only the dispatch surface
+// differs. It also keeps a per-source-material cache so 1,500 brushes
+// sharing one source material allocate one stylised material, not 1,500
+// of them.
+
+import * as THREE from "three";
+import {
+  makeMobiGlasMaterial,
+  type RenderStyle,
+} from "./decomposed-loader";
+
+// Re-export so consumers depend on this module rather than reaching into
+// the Ships-specific `decomposed-loader.ts`.
+export {
+  RENDER_STYLES,
+  blendTowardCyan,
+  clearMobiGlasMaterials,
+  updateMobiGlasTime,
+  type RenderStyle,
+} from "./decomposed-loader";
+
+/** Marker on `mesh.userData` that holds the pre-style material so we can
+ *  restore fidelity when the user switches back to "textured". The
+ *  prefix keeps it clearly internal. */
+const ORIGINAL_MATERIAL_KEY = "__renderStyleOriginalMaterial";
+
+/** Marker on `mesh.userData` recording which non-textured style is
+ *  currently applied. Lets the next apply pass skip work for meshes
+ *  whose style has not changed and reverse cleanup correctly. */
+const CURRENT_STYLE_KEY = "__renderStyleApplied";
+
+interface CachedStyled {
+  material: THREE.Material;
+  unregister?: () => void;
+}
+
+/** Walk every mesh under `root` and apply `style`. Materials swapped in
+ *  for non-textured styles are cached by source-material UUID, so any
+ *  meshes that already shared one source material continue to share one
+ *  stylised material. Switching back to "textured" restores the
+ *  originals saved on `mesh.userData`. Safe to call repeatedly with the
+ *  same style (becomes a near-noop after the first pass).
+ *
+ *  This helper does not touch lighting, shadows, environment, or scene
+ *  tone-mapping — only material instances. The MobiGlas time uniform
+ *  must still be advanced per frame via `updateMobiGlasTime` in the
+ *  viewer's animate loop. */
+export function applyRenderStyleToScene(
+  root: THREE.Object3D,
+  style: RenderStyle,
+): void {
+  // Cache stylised materials by source-material UUID so identical source
+  // materials share one styled instance. Holds for one apply call; a
+  // future call rebuilds (cheap, since dedupe still folds).
+  const styledCache = new Map<string, CachedStyled>();
+
+  root.traverse((obj) => {
+    if (!(obj instanceof THREE.Mesh)) return;
+
+    const mesh = obj as THREE.Mesh;
+    const currentArr: THREE.Material[] = Array.isArray(mesh.material)
+      ? mesh.material
+      : [mesh.material];
+
+    if (style === "textured") {
+      // Restore originals if any were saved. Dispose the per-mesh
+      // stylised wrappers we'd swapped in (the underlying
+      // `makeMobiGlasMaterial.unregister()` lifecycle is owned by the
+      // caller via `clearMobiGlasMaterials` at scene rebuild time, so
+      // we don't unregister per-material here — disposing the GPU
+      // resources is enough). This keeps the path for live-style-swap
+      // safe to call without leaking VRAM.
+      const original = mesh.userData[ORIGINAL_MATERIAL_KEY];
+      if (original !== undefined) {
+        // Dispose the styled material(s) currently on the mesh before
+        // restoring the original. Don't dispose the original — it lives
+        // on through the GLB loader's own lifecycle.
+        for (const m of currentArr) {
+          // Be defensive: don't dispose the original even if userData
+          // somehow points at it.
+          if (m !== original && !sameMaterial(m, original)) {
+            m.dispose();
+          }
+        }
+        mesh.material = original;
+        delete mesh.userData[ORIGINAL_MATERIAL_KEY];
+        delete mesh.userData[CURRENT_STYLE_KEY];
+      }
+      return;
+    }
+
+    // Non-textured style: stash the current material as the original
+    // (only on first apply for this mesh) and swap in the stylised
+    // variant. Re-applying the same style is a no-op past the first
+    // pass.
+    const previousStyle = mesh.userData[CURRENT_STYLE_KEY] as
+      | RenderStyle
+      | undefined;
+    if (previousStyle === style) return;
+
+    if (mesh.userData[ORIGINAL_MATERIAL_KEY] === undefined) {
+      mesh.userData[ORIGINAL_MATERIAL_KEY] = mesh.material;
+    }
+
+    // Build the stylised material(s) per source. For multi-material
+    // meshes we apply per-slot so each slot's source colour drives its
+    // stylised variant.
+    const sources: THREE.Material[] = Array.isArray(
+      mesh.userData[ORIGINAL_MATERIAL_KEY],
+    )
+      ? (mesh.userData[ORIGINAL_MATERIAL_KEY] as THREE.Material[])
+      : [mesh.userData[ORIGINAL_MATERIAL_KEY] as THREE.Material];
+
+    const replacements: THREE.Material[] = sources.map((src) =>
+      stylisedFor(src, style, styledCache),
+    );
+
+    mesh.material = Array.isArray(mesh.userData[ORIGINAL_MATERIAL_KEY])
+      ? replacements
+      : replacements[0];
+    mesh.userData[CURRENT_STYLE_KEY] = style;
+  });
+}
+
+/** Build (or fetch from cache) the stylised material that corresponds
+ *  to `source` + `style`. Cache key is the source material's UUID, so
+ *  shared sources collapse to shared replacements. */
+function stylisedFor(
+  source: THREE.Material,
+  style: Exclude<RenderStyle, "textured">,
+  cache: Map<string, CachedStyled>,
+): THREE.Material {
+  const key = `${source.uuid}|${style}`;
+  const hit = cache.get(key);
+  if (hit) return hit.material;
+
+  const built = buildStyleVariant(source, style);
+  cache.set(key, built);
+  return built.material;
+}
+
+/** Construct a stylised variant of `source` for the given non-textured
+ *  style. Mirrors the per-arm shapes in `decomposed-loader.ts`'s
+ *  `buildStyledMaterial`, but reads inputs from a generic
+ *  `THREE.Material` instead of a Ships-specific `SubmaterialRecord`. */
+function buildStyleVariant(
+  source: THREE.Material,
+  style: Exclude<RenderStyle, "textured">,
+): CachedStyled {
+  const baseColor = readBaseColor(source);
+  const name = source.name || "styled";
+
+  switch (style) {
+    case "metallic":
+      return {
+        material: new THREE.MeshStandardMaterial({
+          name,
+          color: baseColor,
+          metalness: 0.85,
+          roughness: 0.25,
+        }),
+      };
+    case "opaque":
+      return {
+        material: new THREE.MeshStandardMaterial({
+          name,
+          color: baseColor,
+          metalness: 0.05,
+          roughness: 0.85,
+        }),
+      };
+    case "glass":
+      return {
+        material: new THREE.MeshStandardMaterial({
+          name,
+          color: baseColor,
+          metalness: 0.6,
+          roughness: 0.2,
+          transparent: true,
+          opacity: 0.35,
+          depthWrite: false,
+        }),
+      };
+    case "mobiglas": {
+      const result = makeMobiGlasMaterial(baseColor.getHex());
+      result.material.name = name;
+      return { material: result.material, unregister: result.unregister };
+    }
+    case "holographic":
+    default:
+      return {
+        material: new THREE.MeshBasicMaterial({
+          name,
+          color: baseColor,
+          transparent: true,
+          opacity: 0.45,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+        }),
+      };
+  }
+}
+
+/** Pull a base RGB tint out of `source`. MeshStandardMaterial /
+ *  MeshPhysicalMaterial / MeshBasicMaterial / MeshLambertMaterial all
+ *  expose `.color`; everything else falls back to a neutral grey so the
+ *  stylised pass still produces a renderable material. */
+function readBaseColor(source: THREE.Material): THREE.Color {
+  const colored = source as unknown as { color?: THREE.Color };
+  if (colored.color instanceof THREE.Color) {
+    return colored.color.clone();
+  }
+  return new THREE.Color(0xc8c8c8);
+}
+
+/** Loose equality for materials — suffices for the safety check in the
+ *  textured-restore path where we want to avoid disposing the very
+ *  material we're restoring. */
+function sameMaterial(a: THREE.Material, b: THREE.Material): boolean {
+  return a === b || a.uuid === b.uuid;
+}

--- a/app/src/lib/screenshot.ts
+++ b/app/src/lib/screenshot.ts
@@ -1,0 +1,226 @@
+// High-resolution screenshot capture for the scene viewer.
+//
+// The base WebGLRenderer is sized to the viewport; this module spins up a
+// throwaway renderer at the target megapixel count, renders one frame,
+// dumps it as a PNG, then disposes its GPU resources. Reusing the base
+// renderer is avoided so the visible viewport never changes size during
+// capture (changing the canvas size would re-flow Three.js's depth /
+// stencil buffers and could leave artifacts on the next render).
+
+import * as THREE from "three";
+import {
+  applyObliqueShear,
+  obliqueCabinetShear,
+  type ProjectionMode,
+} from "./flight-camera";
+
+/** Compute a (width, height) pair whose aspect matches the viewport and
+ *  whose pixel count is approximately `targetMegapixels` million. The
+ *  derivation is height-first so the integer rounding never produces a
+ *  zero dimension. Pure helper for tests. */
+export function computeScreenshotDimensions(
+  viewportAspect: number,
+  targetMegapixels: number,
+): { width: number; height: number } {
+  const aspect = viewportAspect > 0 ? viewportAspect : 1;
+  const totalPixels = targetMegapixels * 1_000_000;
+  const height = Math.round(Math.sqrt(totalPixels / aspect));
+  const width = Math.round(height * aspect);
+  return { width, height };
+}
+
+/** Build a deterministic filename for a screenshot. The slug defaults to
+ *  "viewer" when the package name is missing or empty so the output is
+ *  always usable. The timestamp is local-time so the filename matches the
+ *  user's wall clock. */
+export function formatScreenshotFilename(
+  packageSlug: string | null | undefined,
+  date: Date,
+): string {
+  const slug =
+    packageSlug && packageSlug.length > 0 ? packageSlug : "viewer";
+  const pad = (n: number): string => n.toString().padStart(2, "0");
+  const yyyy = date.getFullYear();
+  const mm = pad(date.getMonth() + 1);
+  const dd = pad(date.getDate());
+  const hh = pad(date.getHours());
+  const mi = pad(date.getMinutes());
+  const ss = pad(date.getSeconds());
+  return `screenshot_${slug}_${yyyy}${mm}${dd}_${hh}${mi}${ss}.png`;
+}
+
+export interface ScreenshotOpts {
+  scene: THREE.Scene;
+  camera: THREE.Camera;
+  baseRenderer: THREE.WebGLRenderer;
+  filename: string;
+  /** Target megapixel count; defaults to 50. The actual width/height are
+   *  derived to match the viewport aspect, so the final pixel count is
+   *  within rounding distance of the target. */
+  targetMegapixels?: number;
+  /** Optional projection mode hint. When the active camera is an
+   *  OrthographicCamera, the cloned screenshot camera's frustum is
+   *  recomputed for the high-res aspect. When the mode is "oblique",
+   *  the cabinet shear is reapplied so the screenshot matches what
+   *  the viewport renders. */
+  projectionMode?: ProjectionMode;
+  /** Progress hook: phases run in order render -> encode -> download ->
+   *  done. Failure throws and never emits "done". */
+  onProgress?: (
+    phase: "render" | "encode" | "download" | "done",
+    info?: string,
+  ) => void;
+}
+
+/** Capture a high-resolution screenshot of the current scene through the
+ *  current camera. Returns the actual dimensions and the PNG byte size.
+ *  Errors propagate; the caller is responsible for surfacing them. */
+export async function captureScreenshot(
+  opts: ScreenshotOpts,
+): Promise<{ width: number; height: number; bytes: number }> {
+  const targetMP = opts.targetMegapixels ?? 50;
+  // Read the live viewport aspect so the screenshot framing matches what
+  // the user sees on-screen at capture time. `getBoundingClientRect()`
+  // is post-CSS-scaling; using `clientWidth` would be device pixels and
+  // could subtly differ on high-DPI setups.
+  const rect = opts.baseRenderer.domElement.getBoundingClientRect();
+  const viewportAspect =
+    rect.height > 0 && rect.width > 0 ? rect.width / rect.height : 1;
+  const { width, height } = computeScreenshotDimensions(viewportAspect, targetMP);
+  const aspect = width / height;
+
+  // Throwaway renderer; preserveDrawingBuffer is required so toBlob can
+  // read back the freshly rendered framebuffer.
+  const tmpRenderer = new THREE.WebGLRenderer({
+    antialias: true,
+    preserveDrawingBuffer: true,
+  });
+  tmpRenderer.setPixelRatio(1);
+  tmpRenderer.setSize(width, height, false);
+
+  // Mirror colour-management settings from the base renderer so the
+  // screenshot matches the on-screen render. Without this the captured
+  // PNG could come out gamma-shifted relative to the viewport.
+  tmpRenderer.outputColorSpace = opts.baseRenderer.outputColorSpace;
+  tmpRenderer.toneMapping = opts.baseRenderer.toneMapping;
+  tmpRenderer.toneMappingExposure = opts.baseRenderer.toneMappingExposure;
+
+  let ssCam: THREE.Camera;
+  if (opts.camera instanceof THREE.PerspectiveCamera) {
+    const cloned = opts.camera.clone() as THREE.PerspectiveCamera;
+    cloned.aspect = aspect;
+    cloned.updateProjectionMatrix();
+    ssCam = cloned;
+  } else if (opts.camera instanceof THREE.OrthographicCamera) {
+    const cloned = opts.camera.clone() as THREE.OrthographicCamera;
+    // Recompute frustum bounds for the new aspect, anchoring on the
+    // current vertical extent (top/bottom unchanged). This is the
+    // inverse of `computeOrthoFrustum`'s aspect-derived horizontal sizing
+    // and keeps the framing consistent with what the viewport shows.
+    const halfH = (cloned.top - cloned.bottom) * 0.5;
+    cloned.top = halfH;
+    cloned.bottom = -halfH;
+    cloned.right = halfH * aspect;
+    cloned.left = -halfH * aspect;
+    cloned.updateProjectionMatrix();
+    if (opts.projectionMode === "oblique") {
+      applyObliqueShear(cloned.projectionMatrix, obliqueCabinetShear());
+      cloned.projectionMatrixInverse.copy(cloned.projectionMatrix).invert();
+    }
+    ssCam = cloned;
+  } else {
+    // Generic Camera fallback: clone, do not touch the projection matrix.
+    ssCam = opts.camera.clone();
+  }
+
+  try {
+    opts.onProgress?.("render", `${width}x${height}`);
+    tmpRenderer.render(opts.scene, ssCam);
+
+    opts.onProgress?.("encode");
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      tmpRenderer.domElement.toBlob((b) => {
+        if (b) resolve(b);
+        else reject(new Error("toBlob returned null"));
+      }, "image/png");
+    });
+
+    opts.onProgress?.("download", `${blob.size} bytes`);
+    await saveBlob(blob, opts.filename);
+
+    opts.onProgress?.("done");
+    return { width, height, bytes: blob.size };
+  } catch (err) {
+    console.error("[screenshot] capture failed:", err);
+    throw err;
+  } finally {
+    // Cleanup runs even on error so the temporary GL context is released.
+    tmpRenderer.dispose();
+    tmpRenderer.forceContextLoss();
+  }
+}
+
+/** Persist the PNG bytes. Tries the Tauri save dialog first; falls back to
+ *  a browser anchor download when Tauri APIs are not available. The
+ *  anchor path covers vitest / browser-only runs and the case where
+ *  `plugin-fs` is not bundled.
+ *
+ *  `plugin-fs` is not in this app's package.json today, so the dialog
+ *  branch is dormant in the current build; if/when plugin-fs ships, the
+ *  branch lights up automatically without code changes. The dynamic
+ *  string-keyed import keeps TypeScript from demanding type definitions
+ *  for a missing dependency. */
+async function saveBlob(blob: Blob, filename: string): Promise<void> {
+  const tauriDialog = await tryImport<{
+    save: (opts: {
+      defaultPath?: string;
+      filters?: { name: string; extensions: string[] }[];
+    }) => Promise<string | null>;
+  }>("@tauri-apps/plugin-dialog");
+  const tauriFs = await tryImport<{
+    writeFile: (path: string, data: Uint8Array) => Promise<void>;
+  }>("@tauri-apps/plugin-fs");
+
+  if (tauriDialog && tauriFs) {
+    const path = await tauriDialog.save({
+      defaultPath: filename,
+      filters: [{ name: "PNG", extensions: ["png"] }],
+    });
+    if (!path) {
+      // User cancelled; treat as a no-op without throwing.
+      return;
+    }
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    await tauriFs.writeFile(path, bytes);
+    return;
+  }
+
+  // Anchor download fallback. URL.createObjectURL + an off-DOM <a>
+  // element is the standard browser pattern; works inside Tauri's
+  // webview too because Tauri exposes a real DOM.
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/** Dynamic-import wrapper that hides missing modules behind a null
+ *  return. The string-keyed indirection keeps TypeScript from issuing
+ *  TS2307 for plugins that are not installed in every build. */
+async function tryImport<T>(moduleName: string): Promise<T | null> {
+  try {
+    // Vite resolves the literal at runtime; TS sees only `string` so it
+    // does not type-check the missing module.
+    const dynamicImport = (s: string): Promise<unknown> =>
+      import(/* @vite-ignore */ s);
+    const mod = (await dynamicImport(moduleName)) as T;
+    return mod;
+  } catch {
+    return null;
+  }
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,11 +1,37 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { attachConsole } from "@tauri-apps/plugin-log";
+import {
+  debug as logDebug,
+  error as logError,
+  info as logInfo,
+  trace as logTrace,
+  warn as logWarn,
+} from "@tauri-apps/plugin-log";
 import App from "./App";
 import "./globals.css";
 
-// Route Rust log::info!/warn!/error! to browser devtools console.
-attachConsole();
+// Forward browser console.* into the Rust log (and on to app.log + stdout).
+// We deliberately do NOT call attachConsole(): it would route Rust logs back
+// into console, which forwardConsole would re-capture, creating an infinite
+// loop. View Rust logs via the terminal (`tauri dev` stdout) or the log
+// file at %LOCALAPPDATA%\app.starbreaker\logs\StarBreaker.log.
+// Mirror to the original console so DevTools keeps working unchanged.
+type LogFn = (msg: string) => Promise<void>;
+function forwardConsole(fnName: "log" | "debug" | "info" | "warn" | "error", logger: LogFn) {
+  const original = console[fnName].bind(console);
+  console[fnName] = (...args: unknown[]) => {
+    original(...args);
+    const msg = args
+      .map((a) => (typeof a === "string" ? a : (() => { try { return JSON.stringify(a); } catch { return String(a); } })()))
+      .join(" ");
+    void logger(msg).catch(() => {});
+  };
+}
+forwardConsole("log", logTrace);
+forwardConsole("debug", logDebug);
+forwardConsole("info", logInfo);
+forwardConsole("warn", logWarn);
+forwardConsole("error", logError);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/app/src/stores/app-store.ts
+++ b/app/src/stores/app-store.ts
@@ -3,7 +3,7 @@ import { persist } from "zustand/middleware";
 import type { DiscoverResult } from "../lib/commands";
 import { tauriStorage } from "../lib/tauri-storage";
 
-export type AppMode = "p4k" | "datacore" | "export" | "audio";
+export type AppMode = "p4k" | "datacore" | "export" | "audio" | "scene";
 
 interface AppState {
   mode: AppMode;

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -41,18 +41,25 @@ import {
   DECOMPOSED_CONTRACT_VERSION,
   DEFAULT_SCENE_EXPORT_OPTS,
   getSceneCachePath,
+  listAllSocpaks,
   listDecomposedPackages,
   listSceneEntities,
+  loadSceneToGltf,
   onSceneExportDone,
   onSceneExportProgress,
+  onSceneLoadProgress,
   pruneStaleCache,
   startSceneExport,
   type CacheStats,
   type DecomposedPackageInfo,
+  type LoadSceneResponse,
   type SceneEntityDto,
   type SceneExportOpts,
+  type SocpakDirEntry,
 } from "../lib/commands";
+import { SocpakTree } from "../components/socpak-tree";
 import { SceneViewer, DEFAULT_DIAGNOSTIC_SETTINGS } from "../components/scene-viewer";
+import { SocSceneViewer } from "../components/soc-scene-viewer";
 import { ProjectionModePicker } from "../components/projection-mode-picker";
 import type { FlightCamHandle } from "../lib/flight-camera";
 import {
@@ -102,6 +109,59 @@ interface BusyState {
   entityName: string;
   fraction: number;
   stage: string;
+}
+
+/**
+ * Root prefix for the Maps tab tree. Socpaks live almost exclusively
+ * under `Data\ObjectContainers\` -- starting elsewhere would surface
+ * directories the composer cannot load. Backslash-terminated to
+ * match the format the lazy listing returns.
+ */
+const MAPS_ROOT_PREFIX = "Data\\ObjectContainers\\";
+
+/**
+ * Hardcoded fallback used only when the lazy root listing errors
+ * (P4k not loaded, command rejected, IPC failure). Keeps the Maps
+ * tab clickable instead of leaving the user staring at a permanent
+ * error state. The Executive Hangar path is the reference scene we
+ * know loads end-to-end.
+ */
+const MAP_FALLBACK_PATH =
+  "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_final_set\\ab_pyro_final_set_dungeon_executive-001.socpak";
+
+interface SocBusyState {
+  socpakPath: string;
+  fraction: number;
+  stage: string;
+  message: string;
+}
+
+/**
+ * Translate a SOC scene-load progress event into a [0,1] fraction
+ * for the loading bar. Phase weights are tuned to the observed
+ * Exec Hangar timings on a cold cache (~12s total): compose ~5%,
+ * resolve ~85%, emit ~8%, cache_write ~2%. Within each phase the
+ * fraction is `current/total` linearly, so the resolve phase shows
+ * fine-grained progress as meshes resolve.
+ */
+function computeSocFraction(
+  phase: string,
+  current: number,
+  total: number,
+): number {
+  const within = total > 0 ? Math.min(1, Math.max(0, current / total)) : 0;
+  switch (phase) {
+    case "compose":
+      return 0.0 + within * 0.05;
+    case "resolve":
+      return 0.05 + within * 0.85;
+    case "emit":
+      return 0.9 + within * 0.08;
+    case "cache_write":
+      return 0.98 + within * 0.02;
+    default:
+      return within;
+  }
 }
 
 /**
@@ -510,6 +570,35 @@ export function SceneView() {
   const [flightCamHandle, setFlightCamHandle] =
     useState<FlightCamHandle | null>(null);
 
+  // SOC scene state (Maps tab). The Maps tab loads a top-level
+  // socpak through `loadSceneToGltf`, which composes many zones,
+  // resolves meshes/materials, and writes a single GLB to the scene
+  // cache. The `socResponse` carries the cache path + AABB the
+  // SocSceneViewer needs to render and frame. SocBusyState tracks
+  // progress events while the load is in flight.
+  const [socResponse, setSocResponse] = useState<LoadSceneResponse | null>(null);
+  const [socActivePath, setSocActivePath] = useState<string | null>(null);
+  const [socBusy, setSocBusy] = useState<SocBusyState | null>(null);
+  const [socError, setSocError] = useState<string | null>(null);
+  // Flight-camera handle published by the SocSceneViewer. Hosted in
+  // the Maps tab toolbar via `<ProjectionModePicker>`.
+  const [socFlightCamHandle, setSocFlightCamHandle] =
+    useState<FlightCamHandle | null>(null);
+
+  // Maps tab now uses the lazy `SocpakTree` component, which manages
+  // its own per-branch state. We only track tab-level mount lifecycle
+  // here.
+  const [mapsMounted, setMapsMounted] = useState(false);
+  // Global socpak path index. Populated lazily on the first Maps tab
+  // activation via `listAllSocpaks` and held for the rest of the
+  // session. The lazy tree's branch-by-branch filter cannot find a
+  // path the user has not yet expanded; this index drives the "search
+  // everywhere" mode in `SocpakTree` so a typed query matches across
+  // the entire archive. Null while loading; the tree falls back to
+  // local-branch filtering until the index lands.
+  const [socpakIndex, setSocpakIndex] = useState<string[] | null>(null);
+  const [socpakIndexError, setSocpakIndexError] = useState<string | null>(null);
+
   // User-tunable viewer settings (collapsible panel in the bottom-right
   // of the viewer pane). New settings extend `ViewerSettings`; the panel
   // renders rows from the state shape so adding one is local.
@@ -661,6 +750,75 @@ export function SceneView() {
     };
   }, [refreshEntities, refreshCacheStats]);
 
+  // Mount the SocpakTree only after the Maps tab is first opened. The
+  // tree fires its own root listing on mount, so we want that single
+  // backend call to fire once -- on entry to the tab -- not repeatedly
+  // as React re-renders the parent. Once mounted, switching away and
+  // back keeps the tree (and its loaded-branch cache) intact.
+  useEffect(() => {
+    if (activeCategory === "Maps" && !mapsMounted) {
+      setMapsMounted(true);
+    }
+  }, [activeCategory, mapsMounted]);
+
+  // Kick off the global socpak path index in parallel with the lazy
+  // tree's first paint. `listAllSocpaks` is cached on disk by p4k
+  // identity so the second-launch path is a JSON read; the cold path
+  // is a few hundred ms of linear scan. We deliberately do NOT block
+  // the tree on this -- the user can browse / click leaves while the
+  // index loads. Once it lands, the tree's search input switches to
+  // global mode automatically.
+  useEffect(() => {
+    if (activeCategory !== "Maps") return;
+    if (socpakIndex !== null) return;
+    if (socpakIndexError !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const paths = await listAllSocpaks();
+        if (cancelled) return;
+        setSocpakIndex(paths);
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setSocpakIndexError(msg);
+        // Do not surface as a blocking error -- the lazy tree still
+        // works without the index. Log so a missing index is visible
+        // in the dev tools.
+        console.warn("list_all_socpaks_cmd failed:", msg);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCategory, socpakIndex, socpakIndexError]);
+
+  // Subscribe to SOC scene-load progress events. Translates the
+  // backend's `(phase, current, total, message)` into a single
+  // fraction for the loading bar. Phase weights are deliberately
+  // skewed: resolve dominates wall-clock (~80% of a cold load on
+  // Exec Hangar), so it gets the bulk of the bar.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    onSceneLoadProgress((p) => {
+      if (cancelled) return;
+      const fraction = computeSocFraction(p.phase, p.current, p.total);
+      const stage = p.phase.charAt(0).toUpperCase() + p.phase.slice(1);
+      setSocBusy((prev) => {
+        if (!prev) return prev;
+        return { ...prev, fraction, stage, message: p.message };
+      });
+    }).then((u) => {
+      if (cancelled) u();
+      else unlisten = u;
+    });
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
   // Tear down the pending two-click confirmation timer when the view
   // unmounts so the timeout doesn't fire against a stale setState.
   useEffect(() => {
@@ -790,6 +948,64 @@ export function SceneView() {
     }
     setBusy(null);
     generationRef.current++;
+  }, []);
+
+  const launchMap = useCallback(async (socpakPath: string) => {
+    setSocError(null);
+    setActionError(null);
+    setSocActivePath(socpakPath);
+    setSocResponse(null);
+    setSocBusy({
+      socpakPath,
+      fraction: 0,
+      stage: "Starting",
+      message: "Reading socpak...",
+    });
+    try {
+      const response = await loadSceneToGltf(socpakPath);
+      // If the user navigated away mid-load, drop the result.
+      setSocActivePath((current) => {
+        if (current !== socpakPath) return current;
+        setSocResponse(response);
+        setSocBusy(null);
+        console.log(
+          `[soc-load] cache_hit=${response.cache_hit} ` +
+            `meshes=${response.mesh_count} placements=${response.placement_count} ` +
+            `lights=${response.light_count} materials=${response.materials_resolved}/` +
+            `${response.materials_resolved + response.materials_default} ` +
+            `glb_bytes=${response.glb_bytes} ` +
+            `dropped=${response.dropped_placements} failed_meshes=${response.failed_mesh_paths}`,
+        );
+        return current;
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setSocError(msg);
+      setSocBusy(null);
+    }
+  }, []);
+
+  /** Bridge `SocpakTree`'s leaf-click event to the existing load flow. */
+  const handleTreeLeafClick = useCallback(
+    (entry: SocpakDirEntry) => {
+      void launchMap(entry.path);
+    },
+    [launchMap],
+  );
+
+  /** Click handler for the fallback Executive Hangar entry. */
+  const handleFallbackClick = useCallback(() => {
+    void launchMap(MAP_FALLBACK_PATH);
+  }, [launchMap]);
+
+  const handleSocCancel = useCallback(() => {
+    // No backend cancel hook for `load_scene_to_gltf` yet -- the load
+    // runs as a single `spawn_blocking` task that owns its work
+    // through completion. Clearing local state stops the UI from
+    // reacting to in-flight events; the backend keeps building so
+    // the user does not have to repeat the wait on the next click.
+    setSocActivePath(null);
+    setSocBusy(null);
   }, []);
 
   // Escape hatch: pick an external decomposed root.
@@ -954,93 +1170,57 @@ export function SceneView() {
             </button>
           </div>
 
-          {/* Entity list (or Maps placeholder) */}
+          {/* Entity list (or Maps tree). The Maps tab uses a separate
+              flex column so SocpakTree can own its own scroll region;
+              the entity list keeps the legacy single-scroll layout. */}
+          {activeCategory === "Maps" ? (
+            <div className="flex-1 flex flex-col min-h-0">
+              <div className="px-3 py-2 border-b border-border/60 shrink-0">
+                <p className="text-[11px] text-text-dim leading-relaxed">
+                  Browse the p4k object-container tree. Click a folder to
+                  expand it; click a `.socpak` to load the scene. Cold
+                  loads take ~10 seconds; cached loads are instant.
+                </p>
+              </div>
+              {mapsMounted && (
+                <SocpakTree
+                  rootPrefix={MAPS_ROOT_PREFIX}
+                  onLeafClick={handleTreeLeafClick}
+                  activePath={socActivePath}
+                  globalIndex={socpakIndex}
+                />
+              )}
+              {/* Always-visible escape hatch to the reference Exec Hangar
+                  scene, in case the tree errors or the user wants the
+                  one-click path that worked in the prior catalog UI. */}
+              <div className="px-3 py-2 border-t border-border/60 shrink-0">
+                <button
+                  onClick={handleFallbackClick}
+                  className="w-full text-left text-[10px] text-text-faint hover:text-text-sub transition-colors"
+                  title={MAP_FALLBACK_PATH}
+                >
+                  Open Executive Hangar (reference scene)
+                </button>
+              </div>
+            </div>
+          ) : (
           <div className="flex-1 overflow-y-auto">
-            {activeCategory === "Maps" && (
-              <>
-                <div className="px-3 py-2 border-b border-border/60">
-                  <p className="text-[11px] text-text-dim leading-relaxed">
-                    Multi-zone scene rendering. Loadable once the SOC-chunk
-                    scene parser lands. Each archetype below maps to a class
-                    of socpak content the engine renders today.
-                  </p>
-                </div>
-                {[
-                  {
-                    name: "Ship interiors",
-                    desc: "Full inhabitable interiors (Polaris, Carrack, 890 Jump). 5-zone modular composition.",
-                  },
-                  {
-                    name: "Hangars",
-                    desc: "Single-pad, XL, and executive hangars across Stanton + Pyro. Per-faction dressing.",
-                  },
-                  {
-                    name: "Prison facilities",
-                    desc: "Klescher hub + cave routes. Multi-room interconnected layout.",
-                  },
-                  {
-                    name: "Mining caves",
-                    desc: "Rock-cracker caverns and FPS-spec caves. Procedural stone with detail decals.",
-                  },
-                  {
-                    name: "Surface outposts",
-                    desc: "Planetside bunkers, drug labs, derelict shacks. Small modular footprint.",
-                  },
-                  {
-                    name: "Modular habitations",
-                    desc: "EZ Hab assemblies, Triggerfish, Good Doctor. Multi-level recursive containers.",
-                  },
-                  {
-                    name: "Derelict stations",
-                    desc: "Wreck interiors with damage states. Larger zone counts.",
-                  },
-                ].map((archetype) => (
-                  <div
-                    key={archetype.name}
-                    className="group flex items-start gap-2 px-3 py-2 text-xs cursor-not-allowed
-                               text-text-faint border-l-2 border-l-transparent
-                               opacity-60"
-                    title={`${archetype.name} -- not yet loadable`}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="truncate text-text-dim">
-                        {archetype.name}
-                      </div>
-                      <div className="text-[10px] text-text-faint leading-snug mt-0.5">
-                        {archetype.desc}
-                      </div>
-                    </div>
-                    <span className="text-[9px] uppercase tracking-wide text-text-faint shrink-0 mt-0.5">
-                      future
-                    </span>
-                  </div>
-                ))}
-                <div className="px-3 py-3 border-t border-border/60 mt-1">
-                  <p className="text-[10px] text-text-faint leading-relaxed">
-                    Future feature: SOC chunk parsing
-                    (brushes / entities / visareas), zone transform
-                    composition, and InstancedMesh batching for multi-zone
-                    scene loading.
-                  </p>
-                </div>
-              </>
-            )}
-            {activeCategory !== "Maps" && entitiesLoading && (
+            {entitiesLoading && (
               <div className="px-4 py-6 text-xs text-text-dim">
                 Scanning DataCore...
               </div>
             )}
-            {activeCategory !== "Maps" && entitiesError && (
+            {entitiesError && (
               <div className="px-4 py-3 text-xs text-danger break-words">
                 {entitiesError}
               </div>
             )}
-            {activeCategory !== "Maps" && !entitiesLoading && !entitiesError && filtered.length === 0 && (
+            {!entitiesLoading && !entitiesError && filtered.length === 0 && (
               <div className="px-4 py-6 text-xs text-text-dim">
                 No matches.
               </div>
             )}
-            {activeCategory !== "Maps" && filtered.map((entity) => {
+            {filtered.map((entity) => {
               const isActive = activeEntityName === entity.entity_name;
               const isBusy =
                 busy !== null && busy.entityName === entity.entity_name;
@@ -1095,17 +1275,97 @@ export function SceneView() {
               );
             })}
           </div>
+          )}
         </div>
 
         {/* ── Right pane: viewer / progress ── */}
         <div className="flex-1 relative overflow-hidden min-w-0">
-          {actionError && !busy && (
+          {/* SOC scene-package mode: dedicated viewer for the Maps tab.
+              Renders a self-contained GLB emitted by `loadSceneToGltf`
+              instead of a decomposed-export package. */}
+          {activeCategory === "Maps" && (
+            <>
+              {socError && !socBusy && (
+                <div className="absolute top-3 right-3 z-10 max-w-md bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
+                  {socError}
+                </div>
+              )}
+              {socBusy && (
+                <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
+                  <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
+                    <h3 className="text-sm font-semibold text-text">
+                      Loading scene
+                    </h3>
+                    <div className="flex flex-col gap-1.5">
+                      <div className="w-full bg-surface rounded-full h-2 overflow-hidden">
+                        <div
+                          className="bg-accent h-full rounded-full transition-all duration-300"
+                          style={{ width: `${Math.min(socBusy.fraction, 1) * 100}%` }}
+                        />
+                      </div>
+                      <div className="flex items-center justify-between text-[11px] text-text-dim">
+                        <span className="truncate">
+                          {socBusy.message || socBusy.stage || "Working..."}
+                        </span>
+                        <span className="tabular-nums">
+                          {Math.round(socBusy.fraction * 100)}%
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      onClick={handleSocCancel}
+                      className="w-full py-2 rounded-md text-xs font-medium bg-danger/15 text-danger hover:bg-danger/25 transition-colors cursor-pointer"
+                      title="Stop tracking the load. The backend keeps building so the next click reuses cached output."
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+              {!socResponse && !socBusy && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="max-w-md text-center px-6">
+                    <Box
+                      size={48}
+                      strokeWidth={1.5}
+                      className="mx-auto text-text-dim mb-3 opacity-40"
+                    />
+                    <h3 className="text-base font-medium text-text mb-2">
+                      Pick a scene
+                    </h3>
+                    <p className="text-sm text-text-sub">
+                      Choose a map from the list. Cold loads take a few
+                      seconds; cached loads are instant.
+                    </p>
+                  </div>
+                </div>
+              )}
+              {socResponse && (
+                <>
+                  {/* Top-right toolbar: projection-mode picker hosted by
+                      the parent so it lives in the same flex row as the
+                      ship viewer's controls. */}
+                  <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+                    <ProjectionModePicker handle={socFlightCamHandle} embedded />
+                  </div>
+                  <SocSceneViewer
+                    response={socResponse}
+                    onStatus={setStatus}
+                    onFlightCamReady={setSocFlightCamHandle}
+                  />
+                </>
+              )}
+            </>
+          )}
+
+          {/* Decomposed-export mode: existing scene-viewer pipeline. */}
+          {activeCategory !== "Maps" && actionError && !busy && (
             <div className="absolute top-3 right-3 z-10 max-w-md bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
               {actionError}
             </div>
           )}
 
-          {busy && (
+          {activeCategory !== "Maps" && busy && (
             <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
               <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
                 <h3 className="text-sm font-semibold text-text">
@@ -1137,7 +1397,7 @@ export function SceneView() {
             </div>
           )}
 
-          {!active && !busy && (
+          {activeCategory !== "Maps" && !active && !busy && (
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="max-w-md text-center px-6">
                 <Box
@@ -1156,7 +1416,7 @@ export function SceneView() {
             </div>
           )}
 
-          {active && (
+          {activeCategory !== "Maps" && active && (
             <>
               {/* Top-right control strip: Livery + Style + Settings.
                   Settings is inline here so it sits immediately right of

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -1,0 +1,1219 @@
+// Self-service Scene Viewer.
+//
+// The user picks a ship/vehicle from a searchable list. If a cached
+// export exists for the current options, it loads instantly. Otherwise
+// the in-process exporter runs, emits progress, and the resulting
+// package is mounted in the viewer.
+//
+// Rendering itself is unchanged — `SceneViewer` consumes a
+// `DecomposedPackageInfo` (package_dir + export_root + package_name).
+// We synthesize one from the cache hit / export-done payload.
+//
+// The "Open Decomposed Package..." button is kept as an escape hatch
+// for power users with externally-produced packages.
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  Box,
+  ChevronDown,
+  ChevronUp,
+  FolderOpen,
+  RotateCw,
+  CheckCircle2,
+  Search,
+  Settings,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  browseDecomposedRoot,
+  cacheStats,
+  cancelSceneExport,
+  clearAllSceneCache,
+  clearSceneCache,
+  DECOMPOSED_CONTRACT_VERSION,
+  DEFAULT_SCENE_EXPORT_OPTS,
+  getSceneCachePath,
+  listDecomposedPackages,
+  listSceneEntities,
+  onSceneExportDone,
+  onSceneExportProgress,
+  pruneStaleCache,
+  startSceneExport,
+  type CacheStats,
+  type DecomposedPackageInfo,
+  type SceneEntityDto,
+  type SceneExportOpts,
+} from "../lib/commands";
+import { SceneViewer, DEFAULT_DIAGNOSTIC_SETTINGS } from "../components/scene-viewer";
+import {
+  RENDER_STYLES,
+  type PaintVariant,
+  type RenderStyle,
+} from "../lib/decomposed-loader";
+import type { DiagnosticSettings } from "../components/scene-viewer";
+
+/**
+ * Format a byte count as a short human string. Falls back to bytes for
+ * sub-KB values; uses decimal (1000-based) units to match what most file
+ * managers display alongside disk free space.
+ */
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let idx = 0;
+  while (value >= 1000 && idx < units.length - 1) {
+    value /= 1000;
+    idx += 1;
+  }
+  const digits = idx === 0 || value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(digits)} ${units[idx]}`;
+}
+
+/** Synthesize a DecomposedPackageInfo from a package_dir path. */
+function packageInfoFromDir(packageDir: string): DecomposedPackageInfo {
+  // Pull out the trailing folder name as the package name and walk back
+  // up two levels (`Packages/<name>` → root) for the export root. The
+  // SceneViewer component already tolerates either separator.
+  const norm = packageDir.replace(/\\/g, "/");
+  const segments = norm.split("/").filter((s) => s.length > 0);
+  const packageName = segments[segments.length - 1] ?? packageDir;
+  // Drop the last two segments: `<package_name>` and `Packages`.
+  const exportRoot = segments.slice(0, -2).join("/");
+  return {
+    package_dir: norm,
+    export_root: exportRoot.length > 0 ? exportRoot : norm,
+    package_name: packageName,
+    has_scene_manifest: true,
+  };
+}
+
+interface BusyState {
+  entityName: string;
+  fraction: number;
+  stage: string;
+}
+
+/**
+ * User-tunable viewer settings. This is intentionally a flat object so
+ * adding new fields is one line per setting; the `SettingsPanel` below
+ * renders rows declaratively from the state shape so growing the surface
+ * is a localised edit, not a structural one.
+ *
+ * Future fields land here (e.g. `showGrid`, `showAxes`, `bgColor`,
+ * `exposure`, etc.). When a field is added, plumb it through the
+ * `SceneViewer` Props and add a matching row in `SettingsPanel`.
+ */
+interface ViewerSettings {
+  showGroundPlane: boolean;
+  showGrid: boolean;
+  groundPlaneColor: [number, number, number];
+  diagnostics: DiagnosticSettings;
+}
+
+const DEFAULT_VIEWER_SETTINGS: ViewerSettings = {
+  showGroundPlane: true,
+  showGrid: true,
+  groundPlaneColor: [128, 128, 128],
+  diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS },
+};
+
+/**
+ * Floating, collapsible settings overlay anchored to the top-right of
+ * the viewer pane, immediately right of the Style/Livery controls.
+ * Starts collapsed (button only). Clicking the button toggles the
+ * body open/closed. The body grows downward from the button.
+ */
+function SettingsPanel({
+  settings,
+  onChange,
+}: {
+  settings: ViewerSettings;
+  onChange: (patch: Partial<ViewerSettings>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Guard: merge defaults so that missing fields (e.g. after a store
+  // hydration against an older settings shape) never produce undefined
+  // values reaching .toFixed() in the slider rows -- which is the root
+  // cause of the expand-crash reported after the slider additions.
+  const diag: DiagnosticSettings = { ...DEFAULT_DIAGNOSTIC_SETTINGS, ...settings.diagnostics };
+  const groundColor: [number, number, number] = settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
+
+  const patchDiag = useCallback(
+    (patch: Partial<DiagnosticSettings>) => {
+      onChange({ diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS, ...settings.diagnostics, ...patch } });
+    },
+    [onChange, settings.diagnostics],
+  );
+
+  const patchGroundColor = useCallback(
+    (channel: 0 | 1 | 2, val: number) => {
+      const base = settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
+      const next: [number, number, number] = [...base] as [number, number, number];
+      next[channel] = val;
+      onChange({ groundPlaneColor: next });
+    },
+    [onChange, settings.groundPlaneColor],
+  );
+
+  const resetAll = useCallback(() => {
+    onChange({ diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS } });
+  }, [onChange]);
+
+  return (
+    <div className="relative z-10">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub hover:text-text hover:bg-bg-alt shadow transition-colors cursor-pointer select-none"
+        title={open ? "Collapse settings" : "Expand settings"}
+        aria-label={open ? "Collapse settings panel" : "Expand settings panel"}
+      >
+        <Settings size={14} strokeWidth={1.75} />
+        <span>Settings</span>
+        {open ? (
+          <ChevronDown size={12} strokeWidth={1.75} />
+        ) : (
+          <ChevronUp size={12} strokeWidth={1.75} />
+        )}
+      </button>
+      {open && (
+        <div
+          className="absolute top-full right-0 mt-1.5 w-[280px] max-h-[70vh] overflow-y-auto bg-bg-alt/95 border border-border rounded-md shadow-lg p-3 flex flex-col gap-3 backdrop-blur-sm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <SettingsSection title="Display">
+            <SettingsToggleRow
+              label="Show ground plane"
+              checked={settings.showGroundPlane ?? DEFAULT_VIEWER_SETTINGS.showGroundPlane}
+              onChange={(v) => onChange({ showGroundPlane: v })}
+            />
+            <SettingsToggleRow
+              label="Show grid"
+              checked={settings.showGrid ?? DEFAULT_VIEWER_SETTINGS.showGrid}
+              onChange={(v) => onChange({ showGrid: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Ground Plane Color">
+            <SettingsSliderRow
+              label="R"
+              value={groundColor[0]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(0, v)}
+            />
+            <SettingsSliderRow
+              label="G"
+              value={groundColor[1]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(1, v)}
+            />
+            <SettingsSliderRow
+              label="B"
+              value={groundColor[2]}
+              min={0}
+              max={255}
+              step={1}
+              displayDecimals={0}
+              onChange={(v) => patchGroundColor(2, v)}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Render Tuning">
+            <SettingsSliderRow
+              label="envMapIntensity"
+              value={diag.envMapIntensity}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ envMapIntensity: v })}
+            />
+            <SettingsSliderRow
+              label="Tone map exposure"
+              value={diag.toneMappingExposure}
+              min={0}
+              max={3}
+              step={0.05}
+              onChange={(v) => patchDiag({ toneMappingExposure: v })}
+            />
+            <SettingsSliderRow
+              label="Metalness"
+              value={diag.metalness}
+              min={0}
+              max={1}
+              step={0.01}
+              onChange={(v) => patchDiag({ metalness: v })}
+            />
+            <SettingsCheckboxSliderRow
+              label="Roughness"
+              value={diag.roughness}
+              min={0}
+              max={1}
+              step={0.01}
+              enabled={diag.roughnessOverrideEnabled}
+              onEnabledChange={(v) => patchDiag({ roughnessOverrideEnabled: v })}
+              onChange={(v) => patchDiag({ roughness: v })}
+            />
+            <SettingsSliderRow
+              label="Clearcoat"
+              value={diag.clearcoat}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(v) => patchDiag({ clearcoat: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Scene Lights">
+            <SettingsSliderRow
+              label="Ambient intensity"
+              value={diag.ambientIntensity}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ ambientIntensity: v })}
+            />
+            <SettingsSliderRow
+              label="Directional intensity"
+              value={diag.directionalIntensity}
+              min={0}
+              max={5}
+              step={0.1}
+              onChange={(v) => patchDiag({ directionalIntensity: v })}
+            />
+            <SettingsSliderRow
+              label="Headlight intensity"
+              value={diag.headlightIntensity}
+              min={0}
+              max={5}
+              step={0.1}
+              onChange={(v) => patchDiag({ headlightIntensity: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Color Path">
+            <SettingsSliderRow
+              label="Color saturation"
+              value={diag.colorSaturation}
+              min={0}
+              max={2}
+              step={0.05}
+              onChange={(v) => patchDiag({ colorSaturation: v })}
+            />
+          </SettingsSection>
+
+          <button
+            onClick={resetAll}
+            className="mt-1 w-full py-1.5 rounded-md text-xs font-medium bg-surface hover:bg-surface-hi text-text-sub hover:text-text transition-colors cursor-pointer"
+            title="Reset all sliders to defaults"
+          >
+            Reset all
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A labeled group inside the settings panel. Sections give the panel
+ * structure as it grows -- display, lighting, gizmos, performance, etc.
+ * each get their own section. The label is small-caps to keep visual
+ * weight low; rows inside carry the legible labels.
+ */
+function SettingsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="text-[10px] uppercase tracking-wider text-text-faint font-medium">
+        {title}
+      </div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * A single boolean-toggle row. Future row variants (dropdown, slider,
+ * color) follow the same shape so sections compose declaratively. The
+ * whole row is the click target; the checkbox is decorative on the
+ * right so the layout reads like a settings list rather than a form.
+ */
+function SettingsToggleRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 px-1.5 py-1 rounded text-xs text-text-sub hover:bg-surface/40 cursor-pointer select-none">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-accent cursor-pointer"
+      />
+    </label>
+  );
+}
+
+/**
+ * A labeled slider row. Shows "label: X.XX" on the left and a range
+ * input filling the row. Live-applies on every `input` event.
+ * `displayDecimals` controls how many decimal places to show in the
+ * value badge (default 2); pass 0 for integer-valued sliders like RGB.
+ */
+function SettingsSliderRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  displayDecimals = 2,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  displayDecimals?: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 px-1.5 py-1">
+      <div className="flex items-center justify-between text-xs text-text-sub select-none">
+        <span>{label}</span>
+        <span className="tabular-nums text-text-faint">{value.toFixed(displayDecimals)}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-accent cursor-pointer"
+      />
+    </div>
+  );
+}
+
+/**
+ * A slider row that has a checkbox guard. The slider is disabled (and
+ * visually dimmed) when `enabled` is false, so the user must opt-in
+ * before the value takes effect. Used for the roughness override which
+ * defaults to unchecked ("don't override").
+ */
+function SettingsCheckboxSliderRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  enabled,
+  onEnabledChange,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  enabled: boolean;
+  onEnabledChange: (v: boolean) => void;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className={`flex flex-col gap-0.5 px-1.5 py-1 ${enabled ? "" : "opacity-60"}`}>
+      <div className="flex items-center justify-between text-xs text-text-sub select-none">
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => onEnabledChange(e.target.checked)}
+            className="accent-accent cursor-pointer"
+          />
+          <span>{label}</span>
+        </label>
+        <span className="tabular-nums text-text-faint">{value.toFixed(2)}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={!enabled}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-accent cursor-pointer disabled:cursor-not-allowed"
+      />
+    </div>
+  );
+}
+
+export function SceneView() {
+  // Source list: the union of "discovered DataCore entities" and any
+  // externally-mounted packages from the escape-hatch picker.
+  const [entities, setEntities] = useState<SceneEntityDto[]>([]);
+  const [entitiesLoading, setEntitiesLoading] = useState(false);
+  const [entitiesError, setEntitiesError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<string>("Ships");
+
+  const [active, setActive] = useState<DecomposedPackageInfo | null>(null);
+  const [activeEntityName, setActiveEntityName] = useState<string | null>(null);
+  const [busy, setBusy] = useState<BusyState | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>("");
+  // Presentation mode for materials. Switching is in-place; the scene
+  // is not re-loaded.
+  const [renderStyle, setRenderStyle] = useState<RenderStyle>("textured");
+  // Per-ship paint variants discovered from the loaded package's
+  // `paints.json`. The dropdown hides itself when this list is empty
+  // (entities with no DataCore paint variants, or older exports
+  // pre-paints.json). Keyed by `palette_id` to align with the
+  // exporter's stable identifier; null means "default (as-baked)".
+  const [paintVariants, setPaintVariants] = useState<PaintVariant[]>([]);
+  const [livery, setLivery] = useState<string | null>(null);
+
+  // User-tunable viewer settings (collapsible panel in the bottom-right
+  // of the viewer pane). New settings extend `ViewerSettings`; the panel
+  // renders rows from the state shape so adding one is local.
+  const [viewerSettings, setViewerSettings] = useState<ViewerSettings>(
+    DEFAULT_VIEWER_SETTINGS,
+  );
+  const updateSettings = useCallback((patch: Partial<ViewerSettings>) => {
+    setViewerSettings((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  // Fast Preview toggle. When enabled, the exporter skips interior
+  // socpak containers — full Polaris drops from minutes to seconds at
+  // the cost of an empty hull. The cache key already encodes
+  // `include_interior` (`_i0` vs `_i1`), so fast and full live in
+  // separate cache slots. Default OFF so first-time users get the full
+  // ship; flipping the toggle re-runs `listSceneEntities` so the
+  // "cached" badges reflect the chosen slot.
+  const [fastPreview, setFastPreview] = useState(false);
+
+  const opts: SceneExportOpts = useMemo(
+    () => ({
+      ...DEFAULT_SCENE_EXPORT_OPTS,
+      include_interior: !fastPreview,
+    }),
+    [fastPreview],
+  );
+
+  // Track in-flight export so progress events from older runs don't
+  // overwrite newer state.
+  const generationRef = useRef(0);
+
+  // Cache status surfaced in the toolbar. `null` while the first stats
+  // call is in flight or after a failure; the UI hides the chip in that
+  // case rather than showing "0 entries", which would be misleading.
+  const [cache, setCache] = useState<CacheStats | null>(null);
+  // Two-click confirmation state for "Clear all". When non-null, the
+  // button label switches to "Click again to confirm" until the timeout
+  // fires or the user clicks again. Less obtrusive than window.confirm
+  // and consistent with how the per-row re-export button behaves.
+  const [confirmClearAll, setConfirmClearAll] = useState(false);
+  const confirmClearTimer = useRef<number | null>(null);
+
+  const refreshCacheStats = useCallback(async () => {
+    try {
+      const stats = await cacheStats();
+      setCache(stats);
+    } catch (err) {
+      // Don't surface as a hard error — the cache chip is informational.
+      console.warn("cache_stats failed:", err);
+      setCache(null);
+    }
+  }, []);
+
+  const refreshEntities = useCallback(async () => {
+    setEntitiesLoading(true);
+    setEntitiesError(null);
+    try {
+      const list = await listSceneEntities(opts);
+      setEntities(list);
+    } catch (err) {
+      setEntitiesError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEntitiesLoading(false);
+    }
+  }, [opts]);
+
+  // On first mount only: prune cache slots stamped with prior contract
+  // versions, then read stats so the toolbar reflects what's left. The
+  // prune is opt-in housekeeping (safe to skip; orphaned slots just
+  // waste disk until the user clicks "Clear all"), but doing it once
+  // per launch keeps things tidy after a contract bump.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await pruneStaleCache(DECOMPOSED_CONTRACT_VERSION);
+      } catch (err) {
+        // Non-fatal: a locked file or absent cache root just means
+        // there was nothing to prune.
+        console.warn("prune_stale_cache failed:", err);
+      }
+      if (!cancelled) {
+        await refreshCacheStats();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fetch the entity list on mount.
+  useEffect(() => {
+    refreshEntities();
+  }, [refreshEntities]);
+
+  // Reset livery and paint-variant list whenever the active package
+  // changes. The SceneViewer publishes the new ship's paints via
+  // `onPaints` once its scene loads; the dropdown stays empty in the
+  // meantime so a stale variant from a previous ship can't be
+  // accidentally re-applied.
+  useEffect(() => {
+    setLivery(null);
+    setPaintVariants([]);
+  }, [active?.package_dir]);
+
+  // Subscribe to scene export events for the lifetime of the view.
+  useEffect(() => {
+    let cancelled = false;
+    const unlisteners: Array<() => void> = [];
+
+    onSceneExportProgress((p) => {
+      if (cancelled) return;
+      setBusy((prev) => {
+        if (!prev || prev.entityName !== p.entity_name) return prev;
+        return { ...prev, fraction: p.fraction, stage: p.stage };
+      });
+    }).then((unlisten) => {
+      if (cancelled) unlisten();
+      else unlisteners.push(unlisten);
+    });
+
+    onSceneExportDone((r) => {
+      if (cancelled) return;
+      setBusy((prev) => {
+        if (!prev || prev.entityName !== r.entity_name) return prev;
+        return null;
+      });
+      if (r.error) {
+        setActionError(`Export failed: ${r.error}`);
+        return;
+      }
+      if (r.package_dir) {
+        // Refresh the entity list so the cached badge updates, and
+        // bump the toolbar stats since a new slot just landed.
+        refreshEntities();
+        refreshCacheStats();
+        setActive(packageInfoFromDir(r.package_dir));
+        setActiveEntityName(r.entity_name);
+      }
+    }).then((unlisten) => {
+      if (cancelled) unlisten();
+      else unlisteners.push(unlisten);
+    });
+
+    return () => {
+      cancelled = true;
+      for (const fn of unlisteners) fn();
+    };
+  }, [refreshEntities, refreshCacheStats]);
+
+  // Tear down the pending two-click confirmation timer when the view
+  // unmounts so the timeout doesn't fire against a stale setState.
+  useEffect(() => {
+    return () => {
+      if (confirmClearTimer.current !== null) {
+        window.clearTimeout(confirmClearTimer.current);
+        confirmClearTimer.current = null;
+      }
+    };
+  }, []);
+
+  const handleClearAll = useCallback(async () => {
+    // First click arms the confirmation; second click within 2s does
+    // the wipe. The button label flips between the two states. We
+    // intentionally avoid `window.confirm` here — the chrome dialog is
+    // jarring for an action this narrow.
+    if (!confirmClearAll) {
+      setConfirmClearAll(true);
+      if (confirmClearTimer.current !== null) {
+        window.clearTimeout(confirmClearTimer.current);
+      }
+      confirmClearTimer.current = window.setTimeout(() => {
+        setConfirmClearAll(false);
+        confirmClearTimer.current = null;
+      }, 2000);
+      return;
+    }
+
+    if (confirmClearTimer.current !== null) {
+      window.clearTimeout(confirmClearTimer.current);
+      confirmClearTimer.current = null;
+    }
+    setConfirmClearAll(false);
+
+    try {
+      const result = await clearAllSceneCache();
+      // Drop any in-memory references to caches that no longer exist.
+      // The active scene viewer keeps its already-loaded geometry —
+      // clearing the cache only affects future loads — so we don't
+      // close it. The entity list re-runs so badges flip off.
+      await refreshEntities();
+      await refreshCacheStats();
+      setStatus(
+        `Cleared ${result.entries_removed} cache entr` +
+          (result.entries_removed === 1 ? "y" : "ies"),
+      );
+    } catch (err) {
+      setActionError(
+        `Clear cache failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }, [confirmClearAll, refreshEntities, refreshCacheStats]);
+
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of entities) set.add(e.category);
+    // Stable order: Ships first, then alphabetical.
+    return Array.from(set).sort((a, b) => {
+      if (a === b) return 0;
+      if (a === "Ships") return -1;
+      if (b === "Ships") return 1;
+      return a.localeCompare(b);
+    });
+  }, [entities]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return entities.filter((e) => {
+      if (e.category !== activeCategory) return false;
+      if (q.length === 0) return true;
+      return (
+        e.entity_name.toLowerCase().includes(q) ||
+        (e.display_name?.toLowerCase().includes(q) ?? false)
+      );
+    });
+  }, [entities, activeCategory, search]);
+
+  const launchEntity = useCallback(
+    async (entity: SceneEntityDto, forceReexport = false) => {
+      setActionError(null);
+      const gen = ++generationRef.current;
+
+      try {
+        if (forceReexport) {
+          await clearSceneCache(entity.entity_name, opts);
+          // Per-row re-export removed a slot; reflect that in the
+          // toolbar chip immediately. The new slot will be re-added by
+          // the export-done handler.
+          refreshCacheStats();
+        }
+
+        // Cache check first — instant load when present.
+        if (!forceReexport) {
+          const slot = await getSceneCachePath(entity.entity_name, opts);
+          if (slot.cached && slot.package_dir) {
+            if (gen !== generationRef.current) return;
+            setActive(packageInfoFromDir(slot.package_dir));
+            setActiveEntityName(entity.entity_name);
+            return;
+          }
+        }
+
+        // Cache miss → kick off the in-process export.
+        if (gen !== generationRef.current) return;
+        setActive(null);
+        setActiveEntityName(entity.entity_name);
+        setBusy({
+          entityName: entity.entity_name,
+          fraction: 0,
+          stage: "Starting export...",
+        });
+        await startSceneExport(entity.entity_name, opts);
+      } catch (err) {
+        if (gen !== generationRef.current) return;
+        setBusy(null);
+        setActionError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [opts, refreshCacheStats],
+  );
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await cancelSceneExport();
+    } catch (err) {
+      console.error("Cancel failed:", err);
+    }
+    setBusy(null);
+    generationRef.current++;
+  }, []);
+
+  // Escape hatch: pick an external decomposed root.
+  const handleOpenExternal = async () => {
+    setActionError(null);
+    try {
+      const dir = await browseDecomposedRoot();
+      if (!dir) return;
+      const found = await listDecomposedPackages(dir);
+      if (found.length === 0) {
+        setActionError(
+          "No decomposed packages found. Pick a folder containing 'Packages/' or a single package directory.",
+        );
+        return;
+      }
+      const pkg = found.find((p) => p.has_scene_manifest) ?? found[0];
+      setActive(pkg);
+      setActiveEntityName(null);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      {/* ── Toolbar ── */}
+      <div
+        className="flex items-center gap-3 px-4 border-b border-border shrink-0"
+        style={{ height: "var(--toolbar-height)" }}
+      >
+        <Box size={16} strokeWidth={1.75} className="text-text-sub shrink-0" />
+        <h2 className="text-sm font-medium text-text shrink-0">Scene Viewer</h2>
+        {status && (
+          <span className="text-xs text-text-dim font-mono truncate flex-1 min-w-0">
+            {status}
+          </span>
+        )}
+        <label
+          className={`
+            ${status ? "" : "ml-auto"} flex items-center gap-2 px-2.5 py-1.5 rounded-md
+            text-xs cursor-pointer transition-colors select-none
+            ${
+              fastPreview
+                ? "bg-primary/15 text-text"
+                : "bg-surface hover:bg-surface-hi text-text-sub hover:text-text"
+            }
+          `}
+          title="Skip interior socpak containers. Polaris drops from minutes to seconds. Cached separately from the full export."
+        >
+          <input
+            type="checkbox"
+            checked={fastPreview}
+            onChange={(e) => setFastPreview(e.target.checked)}
+            className="accent-accent cursor-pointer"
+          />
+          Fast preview (skip interiors)
+        </label>
+        {cache && (
+          <span
+            className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-surface text-text-sub text-xs select-none"
+            title={`Cache root: ${cache.cache_root}`}
+          >
+            <span className="text-text-faint">Cache</span>
+            <span className="tabular-nums">
+              {cache.entry_count} {cache.entry_count === 1 ? "entry" : "entries"}
+            </span>
+            <span className="text-text-faint">
+              ({formatBytes(cache.total_bytes)})
+            </span>
+          </span>
+        )}
+        <button
+          onClick={handleClearAll}
+          disabled={cache !== null && cache.entry_count === 0}
+          className={`
+            flex items-center gap-2 px-3 py-1.5 rounded-md text-xs transition-colors
+            disabled:opacity-40 disabled:cursor-not-allowed
+            ${
+              confirmClearAll
+                ? "bg-danger/15 text-danger hover:bg-danger/25"
+                : "bg-surface hover:bg-surface-hi text-text-sub hover:text-text"
+            }
+          `}
+          title={
+            confirmClearAll
+              ? "Click again within 2s to wipe every cached scene"
+              : "Wipe every cached scene under decomposed_cache/"
+          }
+        >
+          <Trash2 size={14} strokeWidth={1.75} />
+          {confirmClearAll ? "Click again to confirm" : "Clear all"}
+        </button>
+        <button
+          onClick={handleOpenExternal}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-surface hover:bg-surface-hi text-text-sub hover:text-text text-xs transition-colors"
+          title="Open an externally-produced decomposed package"
+        >
+          <FolderOpen size={14} strokeWidth={1.75} />
+          Open Package...
+        </button>
+      </div>
+
+      <div className="flex-1 flex overflow-hidden min-h-0">
+        {/* ── Left rail: scene picker ── */}
+        <div className="w-[300px] shrink-0 border-r border-border bg-bg-alt flex flex-col min-h-0">
+          {/* Search */}
+          <div className="p-3 border-b border-border flex items-center gap-2">
+            <Search size={14} className="text-text-faint shrink-0" />
+            <input
+              type="text"
+              placeholder="Search ships..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="flex-1 bg-transparent outline-none text-sm text-text placeholder:text-text-faint"
+            />
+            {search && (
+              <button
+                onClick={() => setSearch("")}
+                className="text-text-faint hover:text-text"
+                title="Clear"
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+
+          {/* Category tabs */}
+          <div className="flex gap-1 px-3 py-2 border-b border-border flex-wrap">
+            {categories.map((cat) => {
+              const count = entities.filter((e) => e.category === cat).length;
+              return (
+                <button
+                  key={cat}
+                  onClick={() => setActiveCategory(cat)}
+                  className={`
+                    px-2.5 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer
+                    ${
+                      cat === activeCategory
+                        ? "bg-primary/15 text-text"
+                        : "text-text-dim hover:bg-surface/60 hover:text-text"
+                    }
+                  `}
+                >
+                  {cat}
+                  <span className="ml-1.5 opacity-60">{count}</span>
+                </button>
+              );
+            })}
+            {/* Maps tab -- placeholder for future multi-zone scene rendering. */}
+            <button
+              onClick={() => setActiveCategory("Maps")}
+              className={`
+                px-2.5 py-1 rounded-md text-xs font-medium transition-colors cursor-pointer
+                ${
+                  activeCategory === "Maps"
+                    ? "bg-primary/15 text-text"
+                    : "text-text-dim hover:bg-surface/60 hover:text-text"
+                }
+              `}
+            >
+              Maps
+            </button>
+          </div>
+
+          {/* Entity list (or Maps placeholder) */}
+          <div className="flex-1 overflow-y-auto">
+            {activeCategory === "Maps" && (
+              <>
+                <div className="px-3 py-2 border-b border-border/60">
+                  <p className="text-[11px] text-text-dim leading-relaxed">
+                    Multi-zone scene rendering. Each archetype below maps to a
+                    class of socpak content; loading is a future feature once
+                    the multi-zone scene parser lands.
+                  </p>
+                </div>
+                {[
+                  {
+                    name: "Ship interiors",
+                    desc: "Full inhabitable interiors (Polaris, Carrack, 890 Jump). 5-zone modular composition.",
+                  },
+                  {
+                    name: "Hangars",
+                    desc: "Single-pad, XL, and executive hangars across Stanton + Pyro. Per-faction dressing.",
+                  },
+                  {
+                    name: "Prison facilities",
+                    desc: "Klescher hub + cave routes. Multi-room interconnected layout.",
+                  },
+                  {
+                    name: "Mining caves",
+                    desc: "Rock-cracker caverns and FPS-spec caves. Procedural stone with detail decals.",
+                  },
+                  {
+                    name: "Surface outposts",
+                    desc: "Planetside bunkers, drug labs, derelict shacks. Small modular footprint.",
+                  },
+                  {
+                    name: "Modular habitations",
+                    desc: "EZ Hab assemblies, Triggerfish, Good Doctor. Multi-level recursive containers.",
+                  },
+                  {
+                    name: "Derelict stations",
+                    desc: "Wreck interiors with damage states. Larger zone counts.",
+                  },
+                ].map((archetype) => (
+                  <div
+                    key={archetype.name}
+                    className="group flex items-start gap-2 px-3 py-2 text-xs cursor-not-allowed
+                               text-text-faint border-l-2 border-l-transparent
+                               opacity-60"
+                    title={`${archetype.name} -- not yet loadable`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate text-text-dim">
+                        {archetype.name}
+                      </div>
+                      <div className="text-[10px] text-text-faint leading-snug mt-0.5">
+                        {archetype.desc}
+                      </div>
+                    </div>
+                    <span className="text-[9px] uppercase tracking-wide text-text-faint shrink-0 mt-0.5">
+                      future
+                    </span>
+                  </div>
+                ))}
+                <div className="px-3 py-3 border-t border-border/60 mt-1">
+                  <p className="text-[10px] text-text-faint leading-relaxed">
+                    Future feature: SOC chunk parsing
+                    (brushes / entities / visareas), zone transform
+                    composition, and InstancedMesh batching for multi-zone
+                    scene loading.
+                  </p>
+                </div>
+              </>
+            )}
+            {activeCategory !== "Maps" && entitiesLoading && (
+              <div className="px-4 py-6 text-xs text-text-dim">
+                Scanning DataCore...
+              </div>
+            )}
+            {activeCategory !== "Maps" && entitiesError && (
+              <div className="px-4 py-3 text-xs text-danger break-words">
+                {entitiesError}
+              </div>
+            )}
+            {activeCategory !== "Maps" && !entitiesLoading && !entitiesError && filtered.length === 0 && (
+              <div className="px-4 py-6 text-xs text-text-dim">
+                No matches.
+              </div>
+            )}
+            {activeCategory !== "Maps" && filtered.map((entity) => {
+              const isActive = activeEntityName === entity.entity_name;
+              const isBusy =
+                busy !== null && busy.entityName === entity.entity_name;
+              return (
+                <div
+                  key={entity.entity_name}
+                  className={`
+                    group flex items-center gap-2 px-3 py-2 text-xs cursor-pointer
+                    transition-colors border-l-2
+                    ${
+                      isActive
+                        ? "bg-primary/10 text-text border-l-accent"
+                        : "text-text-sub hover:bg-surface/40 border-l-transparent"
+                    }
+                  `}
+                  onClick={() => {
+                    if (!isBusy) launchEntity(entity);
+                  }}
+                  title={entity.entity_name}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="truncate">
+                      {entity.display_name ?? entity.entity_name}
+                    </div>
+                    {entity.display_name && (
+                      <div className="truncate text-[10px] text-text-faint">
+                        {entity.entity_name}
+                      </div>
+                    )}
+                  </div>
+                  {entity.cached && (
+                    <CheckCircle2
+                      size={14}
+                      className="text-success shrink-0"
+                      strokeWidth={1.75}
+                      aria-label="Cached"
+                    />
+                  )}
+                  {entity.cached && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        launchEntity(entity, true);
+                      }}
+                      className="opacity-0 group-hover:opacity-100 text-text-faint hover:text-text transition-opacity shrink-0"
+                      title="Re-export (clear cache)"
+                    >
+                      <RotateCw size={12} strokeWidth={1.75} />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Right pane: viewer / progress ── */}
+        <div className="flex-1 relative overflow-hidden min-w-0">
+          {actionError && !busy && (
+            <div className="absolute top-3 right-3 z-10 max-w-md bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
+              {actionError}
+            </div>
+          )}
+
+          {busy && (
+            <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
+              <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
+                <h3 className="text-sm font-semibold text-text">
+                  Exporting {busy.entityName}
+                </h3>
+                <div className="flex flex-col gap-1.5">
+                  <div className="w-full bg-surface rounded-full h-2 overflow-hidden">
+                    <div
+                      className="bg-accent h-full rounded-full transition-all duration-300"
+                      style={{ width: `${Math.min(busy.fraction, 1) * 100}%` }}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between text-[11px] text-text-dim">
+                    <span className="truncate">
+                      {busy.stage || "Working..."}
+                    </span>
+                    <span className="tabular-nums">
+                      {Math.round(busy.fraction * 100)}%
+                    </span>
+                  </div>
+                </div>
+                <button
+                  onClick={handleCancel}
+                  className="w-full py-2 rounded-md text-xs font-medium bg-danger/15 text-danger hover:bg-danger/25 transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {!active && !busy && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="max-w-md text-center px-6">
+                <Box
+                  size={48}
+                  strokeWidth={1.5}
+                  className="mx-auto text-text-dim mb-3 opacity-40"
+                />
+                <h3 className="text-base font-medium text-text mb-2">
+                  Pick a scene
+                </h3>
+                <p className="text-sm text-text-sub">
+                  Choose a ship from the list. Cached scenes load
+                  instantly; new ones export in the background.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {active && (
+            <>
+              {/* Top-right control strip: Livery + Style + Settings.
+                  Settings is inline here so it sits immediately right of
+                  Style and the dropdown grows downward from the button. */}
+              <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+                {paintVariants.length > 0 && (
+                  <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
+                    <span className="text-text-faint">Livery</span>
+                    <select
+                      value={livery ?? ""}
+                      onChange={(e) =>
+                        setLivery(e.target.value === "" ? null : e.target.value)
+                      }
+                      className="bg-transparent outline-none text-text cursor-pointer"
+                    >
+                      <option value="" className="bg-bg-alt text-text">
+                        Default
+                      </option>
+                      {paintVariants.map((v) => (
+                        <option
+                          key={v.palette_id}
+                          value={v.palette_id}
+                          className="bg-bg-alt text-text"
+                        >
+                          {v.display_name ??
+                            v.subgeometry_tag ??
+                            v.palette_id}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
+                  <span className="text-text-faint">Style</span>
+                  <select
+                    value={renderStyle}
+                    onChange={(e) => setRenderStyle(e.target.value as RenderStyle)}
+                    className="bg-transparent outline-none text-text cursor-pointer"
+                  >
+                    {RENDER_STYLES.map((opt) => (
+                      <option key={opt.value} value={opt.value} className="bg-bg-alt text-text">
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <SettingsPanel
+                  settings={viewerSettings}
+                  onChange={updateSettings}
+                />
+              </div>
+              <SceneViewer
+                packageInfo={active}
+                renderStyle={renderStyle}
+                showGroundPlane={viewerSettings.showGroundPlane}
+                showGrid={viewerSettings.showGrid}
+                groundPlaneColor={viewerSettings.groundPlaneColor}
+                diagnostics={viewerSettings.diagnostics}
+                livery={livery}
+                onPaints={setPaintVariants}
+                onStatus={setStatus}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -53,6 +53,8 @@ import {
   type SceneExportOpts,
 } from "../lib/commands";
 import { SceneViewer, DEFAULT_DIAGNOSTIC_SETTINGS } from "../components/scene-viewer";
+import { ProjectionModePicker } from "../components/projection-mode-picker";
+import type { FlightCamHandle } from "../lib/flight-camera";
 import {
   RENDER_STYLES,
   type PaintVariant,
@@ -500,6 +502,13 @@ export function SceneView() {
   // exporter's stable identifier; null means "default (as-baked)".
   const [paintVariants, setPaintVariants] = useState<PaintVariant[]>([]);
   const [livery, setLivery] = useState<string | null>(null);
+
+  // Flight-camera handle the SceneViewer publishes upward so we can
+  // host the projection-mode picker in the top-right toolbar instead
+  // of having it free-float inside the canvas (where it collided with
+  // the Livery + Style + Settings strip).
+  const [flightCamHandle, setFlightCamHandle] =
+    useState<FlightCamHandle | null>(null);
 
   // User-tunable viewer settings (collapsible panel in the bottom-right
   // of the viewer pane). New settings extend `ViewerSettings`; the panel
@@ -1153,6 +1162,7 @@ export function SceneView() {
                   Settings is inline here so it sits immediately right of
                   Style and the dropdown grows downward from the button. */}
               <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+                <ProjectionModePicker handle={flightCamHandle} embedded />
                 {paintVariants.length > 0 && (
                   <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
                     <span className="text-text-faint">Livery</span>
@@ -1209,6 +1219,7 @@ export function SceneView() {
                 livery={livery}
                 onPaints={setPaintVariants}
                 onStatus={setStatus}
+                onFlightCamReady={setFlightCamHandle}
               />
             </>
           )}

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -951,9 +951,9 @@ export function SceneView() {
               <>
                 <div className="px-3 py-2 border-b border-border/60">
                   <p className="text-[11px] text-text-dim leading-relaxed">
-                    Multi-zone scene rendering. Each archetype below maps to a
-                    class of socpak content; loading is a future feature once
-                    the multi-zone scene parser lands.
+                    Multi-zone scene rendering. Loadable once the SOC-chunk
+                    scene parser lands. Each archetype below maps to a class
+                    of socpak content the engine renders today.
                   </p>
                 </div>
                 {[

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -182,8 +182,8 @@ interface ViewerSettings {
 }
 
 const DEFAULT_VIEWER_SETTINGS: ViewerSettings = {
-  showGroundPlane: true,
-  showGrid: true,
+  showGroundPlane: false,
+  showGrid: false,
   groundPlaneColor: [128, 128, 128],
   diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS },
 };

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -85,6 +85,16 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(digits)} ${units[idx]}`;
 }
 
+/** Derive a short slug from a socpak path for screenshot filenames.
+ *  Strips the directory prefix and the `.socpak` extension; falls back
+ *  to "soc_scene" when the input is null. */
+function socpakSlug(socpakPath: string | null): string {
+  if (!socpakPath) return "soc_scene";
+  const normalised = socpakPath.replace(/\\/g, "/");
+  const tail = normalised.split("/").pop() ?? socpakPath;
+  return tail.replace(/\.socpak$/i, "");
+}
+
 /** Synthesize a DecomposedPackageInfo from a package_dir path. */
 function packageInfoFromDir(packageDir: string): DecomposedPackageInfo {
   // Pull out the trailing folder name as the package name and walk back
@@ -263,13 +273,23 @@ export function SceneView() {
   // ship; flipping the toggle re-runs `listSceneEntities` so the
   // "cached" badges reflect the chosen slot.
   const [fastPreview, setFastPreview] = useState(false);
+  // Show WIP toggle. When enabled, listSceneEntities also returns
+  // CIG-internal / in-development entities (Mauler, Idris, Javelin,
+  // Starlifter A2, plus 400+ NPC variants and derelicts). The list
+  // grows from ~80 ships to ~500. WIP entries get an [WIP] badge in
+  // the row. Default OFF -- most users want the player-flyable
+  // roster only. Toggling re-runs listSceneEntities; does not
+  // affect the export cache key (these flags only filter the LIST,
+  // not the export bytes).
+  const [showWip, setShowWip] = useState(false);
 
   const opts: SceneExportOpts = useMemo(
     () => ({
       ...DEFAULT_SCENE_EXPORT_OPTS,
       include_interior: !fastPreview,
+      include_wip: showWip,
     }),
-    [fastPreview],
+    [fastPreview, showWip],
   );
 
   // Track in-flight export so progress events from older runs don't
@@ -799,6 +819,26 @@ export function SceneView() {
           />
           Fast preview (skip interiors)
         </label>
+        <label
+          className={`
+            flex items-center gap-2 px-2.5 py-1.5 rounded-md
+            text-xs cursor-pointer transition-colors select-none
+            ${
+              showWip
+                ? "bg-primary/15 text-text"
+                : "bg-surface hover:bg-surface-hi text-text-sub hover:text-text"
+            }
+          `}
+          title="Also list CIG-internal / in-development entities (Mauler, Idris-M, Javelin, Starlifter A2, plus NPC variants and derelicts). The list grows from ~80 to ~500 entries; WIP entries get a [WIP] badge."
+        >
+          <input
+            type="checkbox"
+            checked={showWip}
+            onChange={(e) => setShowWip(e.target.checked)}
+            className="accent-accent cursor-pointer"
+          />
+          Show WIP
+        </label>
         {cache && (
           <span
             className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-surface text-text-sub text-xs select-none"
@@ -980,8 +1020,18 @@ export function SceneView() {
                   title={entity.entity_name}
                 >
                   <div className="flex-1 min-w-0">
-                    <div className="truncate">
-                      {entity.display_name ?? entity.entity_name}
+                    <div className="truncate flex items-center gap-1.5">
+                      <span className="truncate">
+                        {entity.display_name ?? entity.entity_name}
+                      </span>
+                      {entity.is_wip && (
+                        <span
+                          className="shrink-0 text-[9px] font-mono uppercase tracking-wider px-1 py-0.5 rounded bg-warning/20 text-warning border border-warning/30"
+                          title="inclusionMode != ReadyToInclude in DataCore. WIP capital ship, NPC variant, derelict, or mission objective. Export may produce a partial mesh or placeholder textures."
+                        >
+                          WIP
+                        </span>
+                      )}
                     </div>
                     {entity.display_name && (
                       <div className="truncate text-[10px] text-text-faint">
@@ -1089,6 +1139,7 @@ export function SceneView() {
                     onPhaseProgress={updateSocPhase}
                     onLoadComplete={handleSocLoadComplete}
                     onTogglePivotOrb={togglePivotOrb}
+                    screenshotSlug={socpakSlug(socActivePath)}
                   />
                 </>
               )}

--- a/app/src/views/scene-view.tsx
+++ b/app/src/views/scene-view.tsx
@@ -18,17 +18,13 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactNode,
 } from "react";
 import {
   Box,
-  ChevronDown,
-  ChevronUp,
   FolderOpen,
   RotateCw,
   CheckCircle2,
   Search,
-  Settings,
   Trash2,
   X,
 } from "lucide-react";
@@ -58,16 +54,18 @@ import {
   type SocpakDirEntry,
 } from "../lib/commands";
 import { SocpakTree } from "../components/socpak-tree";
-import { SceneViewer, DEFAULT_DIAGNOSTIC_SETTINGS } from "../components/scene-viewer";
+import { SceneViewer } from "../components/scene-viewer";
 import { SocSceneViewer } from "../components/soc-scene-viewer";
-import { ProjectionModePicker } from "../components/projection-mode-picker";
-import type { FlightCamHandle } from "../lib/flight-camera";
+import { ProgressOverlay } from "../components/progress-overlay";
 import {
-  RENDER_STYLES,
-  type PaintVariant,
-  type RenderStyle,
-} from "../lib/decomposed-loader";
-import type { DiagnosticSettings } from "../components/scene-viewer";
+  DEFAULT_VIEWER_SETTINGS,
+  type ViewerSettings,
+} from "../components/settings-panel";
+import { ViewerToolbar } from "../components/viewer-toolbar";
+import type { FlightCamHandle } from "../lib/flight-camera";
+import { type PaintVariant } from "../lib/decomposed-loader";
+import { type RenderStyle } from "../lib/render-styles";
+import { useProgressReporter } from "../lib/progress-reporter";
 
 /**
  * Format a byte count as a short human string. Falls back to bytes for
@@ -105,12 +103,6 @@ function packageInfoFromDir(packageDir: string): DecomposedPackageInfo {
   };
 }
 
-interface BusyState {
-  entityName: string;
-  fraction: number;
-  stage: string;
-}
-
 /**
  * Root prefix for the Maps tab tree. Socpaks live almost exclusively
  * under `Data\ObjectContainers\` -- starting elsewhere would surface
@@ -129,22 +121,14 @@ const MAPS_ROOT_PREFIX = "Data\\ObjectContainers\\";
 const MAP_FALLBACK_PATH =
   "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_final_set\\ab_pyro_final_set_dungeon_executive-001.socpak";
 
-interface SocBusyState {
-  socpakPath: string;
-  fraction: number;
-  stage: string;
-  message: string;
-}
-
 /**
  * Translate a SOC scene-load progress event into a [0,1] fraction
- * for the loading bar. Phase weights are tuned to the observed
- * Exec Hangar timings on a cold cache (~12s total): compose ~5%,
- * resolve ~85%, emit ~8%, cache_write ~2%. Within each phase the
- * fraction is `current/total` linearly, so the resolve phase shows
- * fine-grained progress as meshes resolve.
+ * for the backend phase of the unified progress overlay. Phase weights
+ * inside the backend step are tuned to observed Exec Hangar timings on
+ * a cold cache: compose ~5%, resolve ~85%, emit ~8%, cache_write ~2%.
+ * Within each sub-phase the fraction is `current/total` linearly.
  */
-function computeSocFraction(
+function computeSocBackendFraction(
   phase: string,
   current: number,
   total: number,
@@ -164,379 +148,6 @@ function computeSocFraction(
   }
 }
 
-/**
- * User-tunable viewer settings. This is intentionally a flat object so
- * adding new fields is one line per setting; the `SettingsPanel` below
- * renders rows declaratively from the state shape so growing the surface
- * is a localised edit, not a structural one.
- *
- * Future fields land here (e.g. `showGrid`, `showAxes`, `bgColor`,
- * `exposure`, etc.). When a field is added, plumb it through the
- * `SceneViewer` Props and add a matching row in `SettingsPanel`.
- */
-interface ViewerSettings {
-  showGroundPlane: boolean;
-  showGrid: boolean;
-  groundPlaneColor: [number, number, number];
-  diagnostics: DiagnosticSettings;
-}
-
-const DEFAULT_VIEWER_SETTINGS: ViewerSettings = {
-  showGroundPlane: false,
-  showGrid: false,
-  groundPlaneColor: [128, 128, 128],
-  diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS },
-};
-
-/**
- * Floating, collapsible settings overlay anchored to the top-right of
- * the viewer pane, immediately right of the Style/Livery controls.
- * Starts collapsed (button only). Clicking the button toggles the
- * body open/closed. The body grows downward from the button.
- */
-function SettingsPanel({
-  settings,
-  onChange,
-}: {
-  settings: ViewerSettings;
-  onChange: (patch: Partial<ViewerSettings>) => void;
-}) {
-  const [open, setOpen] = useState(false);
-
-  // Guard: merge defaults so that missing fields (e.g. after a store
-  // hydration against an older settings shape) never produce undefined
-  // values reaching .toFixed() in the slider rows -- which is the root
-  // cause of the expand-crash reported after the slider additions.
-  const diag: DiagnosticSettings = { ...DEFAULT_DIAGNOSTIC_SETTINGS, ...settings.diagnostics };
-  const groundColor: [number, number, number] = settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
-
-  const patchDiag = useCallback(
-    (patch: Partial<DiagnosticSettings>) => {
-      onChange({ diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS, ...settings.diagnostics, ...patch } });
-    },
-    [onChange, settings.diagnostics],
-  );
-
-  const patchGroundColor = useCallback(
-    (channel: 0 | 1 | 2, val: number) => {
-      const base = settings.groundPlaneColor ?? DEFAULT_VIEWER_SETTINGS.groundPlaneColor;
-      const next: [number, number, number] = [...base] as [number, number, number];
-      next[channel] = val;
-      onChange({ groundPlaneColor: next });
-    },
-    [onChange, settings.groundPlaneColor],
-  );
-
-  const resetAll = useCallback(() => {
-    onChange({ diagnostics: { ...DEFAULT_DIAGNOSTIC_SETTINGS } });
-  }, [onChange]);
-
-  return (
-    <div className="relative z-10">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub hover:text-text hover:bg-bg-alt shadow transition-colors cursor-pointer select-none"
-        title={open ? "Collapse settings" : "Expand settings"}
-        aria-label={open ? "Collapse settings panel" : "Expand settings panel"}
-      >
-        <Settings size={14} strokeWidth={1.75} />
-        <span>Settings</span>
-        {open ? (
-          <ChevronDown size={12} strokeWidth={1.75} />
-        ) : (
-          <ChevronUp size={12} strokeWidth={1.75} />
-        )}
-      </button>
-      {open && (
-        <div
-          className="absolute top-full right-0 mt-1.5 w-[280px] max-h-[70vh] overflow-y-auto bg-bg-alt/95 border border-border rounded-md shadow-lg p-3 flex flex-col gap-3 backdrop-blur-sm"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <SettingsSection title="Display">
-            <SettingsToggleRow
-              label="Show ground plane"
-              checked={settings.showGroundPlane ?? DEFAULT_VIEWER_SETTINGS.showGroundPlane}
-              onChange={(v) => onChange({ showGroundPlane: v })}
-            />
-            <SettingsToggleRow
-              label="Show grid"
-              checked={settings.showGrid ?? DEFAULT_VIEWER_SETTINGS.showGrid}
-              onChange={(v) => onChange({ showGrid: v })}
-            />
-          </SettingsSection>
-
-          <SettingsSection title="Ground Plane Color">
-            <SettingsSliderRow
-              label="R"
-              value={groundColor[0]}
-              min={0}
-              max={255}
-              step={1}
-              displayDecimals={0}
-              onChange={(v) => patchGroundColor(0, v)}
-            />
-            <SettingsSliderRow
-              label="G"
-              value={groundColor[1]}
-              min={0}
-              max={255}
-              step={1}
-              displayDecimals={0}
-              onChange={(v) => patchGroundColor(1, v)}
-            />
-            <SettingsSliderRow
-              label="B"
-              value={groundColor[2]}
-              min={0}
-              max={255}
-              step={1}
-              displayDecimals={0}
-              onChange={(v) => patchGroundColor(2, v)}
-            />
-          </SettingsSection>
-
-          <SettingsSection title="Render Tuning">
-            <SettingsSliderRow
-              label="envMapIntensity"
-              value={diag.envMapIntensity}
-              min={0}
-              max={2}
-              step={0.05}
-              onChange={(v) => patchDiag({ envMapIntensity: v })}
-            />
-            <SettingsSliderRow
-              label="Tone map exposure"
-              value={diag.toneMappingExposure}
-              min={0}
-              max={3}
-              step={0.05}
-              onChange={(v) => patchDiag({ toneMappingExposure: v })}
-            />
-            <SettingsSliderRow
-              label="Metalness"
-              value={diag.metalness}
-              min={0}
-              max={1}
-              step={0.01}
-              onChange={(v) => patchDiag({ metalness: v })}
-            />
-            <SettingsCheckboxSliderRow
-              label="Roughness"
-              value={diag.roughness}
-              min={0}
-              max={1}
-              step={0.01}
-              enabled={diag.roughnessOverrideEnabled}
-              onEnabledChange={(v) => patchDiag({ roughnessOverrideEnabled: v })}
-              onChange={(v) => patchDiag({ roughness: v })}
-            />
-            <SettingsSliderRow
-              label="Clearcoat"
-              value={diag.clearcoat}
-              min={0}
-              max={1}
-              step={0.05}
-              onChange={(v) => patchDiag({ clearcoat: v })}
-            />
-          </SettingsSection>
-
-          <SettingsSection title="Scene Lights">
-            <SettingsSliderRow
-              label="Ambient intensity"
-              value={diag.ambientIntensity}
-              min={0}
-              max={2}
-              step={0.05}
-              onChange={(v) => patchDiag({ ambientIntensity: v })}
-            />
-            <SettingsSliderRow
-              label="Directional intensity"
-              value={diag.directionalIntensity}
-              min={0}
-              max={5}
-              step={0.1}
-              onChange={(v) => patchDiag({ directionalIntensity: v })}
-            />
-            <SettingsSliderRow
-              label="Headlight intensity"
-              value={diag.headlightIntensity}
-              min={0}
-              max={5}
-              step={0.1}
-              onChange={(v) => patchDiag({ headlightIntensity: v })}
-            />
-          </SettingsSection>
-
-          <SettingsSection title="Color Path">
-            <SettingsSliderRow
-              label="Color saturation"
-              value={diag.colorSaturation}
-              min={0}
-              max={2}
-              step={0.05}
-              onChange={(v) => patchDiag({ colorSaturation: v })}
-            />
-          </SettingsSection>
-
-          <button
-            onClick={resetAll}
-            className="mt-1 w-full py-1.5 rounded-md text-xs font-medium bg-surface hover:bg-surface-hi text-text-sub hover:text-text transition-colors cursor-pointer"
-            title="Reset all sliders to defaults"
-          >
-            Reset all
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * A labeled group inside the settings panel. Sections give the panel
- * structure as it grows -- display, lighting, gizmos, performance, etc.
- * each get their own section. The label is small-caps to keep visual
- * weight low; rows inside carry the legible labels.
- */
-function SettingsSection({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="text-[10px] uppercase tracking-wider text-text-faint font-medium">
-        {title}
-      </div>
-      <div className="flex flex-col gap-1">{children}</div>
-    </div>
-  );
-}
-
-/**
- * A single boolean-toggle row. Future row variants (dropdown, slider,
- * color) follow the same shape so sections compose declaratively. The
- * whole row is the click target; the checkbox is decorative on the
- * right so the layout reads like a settings list rather than a form.
- */
-function SettingsToggleRow({
-  label,
-  checked,
-  onChange,
-}: {
-  label: string;
-  checked: boolean;
-  onChange: (v: boolean) => void;
-}) {
-  return (
-    <label className="flex items-center justify-between gap-3 px-1.5 py-1 rounded text-xs text-text-sub hover:bg-surface/40 cursor-pointer select-none">
-      <span>{label}</span>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="accent-accent cursor-pointer"
-      />
-    </label>
-  );
-}
-
-/**
- * A labeled slider row. Shows "label: X.XX" on the left and a range
- * input filling the row. Live-applies on every `input` event.
- * `displayDecimals` controls how many decimal places to show in the
- * value badge (default 2); pass 0 for integer-valued sliders like RGB.
- */
-function SettingsSliderRow({
-  label,
-  value,
-  min,
-  max,
-  step,
-  displayDecimals = 2,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  displayDecimals?: number;
-  onChange: (v: number) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-0.5 px-1.5 py-1">
-      <div className="flex items-center justify-between text-xs text-text-sub select-none">
-        <span>{label}</span>
-        <span className="tabular-nums text-text-faint">{value.toFixed(displayDecimals)}</span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full accent-accent cursor-pointer"
-      />
-    </div>
-  );
-}
-
-/**
- * A slider row that has a checkbox guard. The slider is disabled (and
- * visually dimmed) when `enabled` is false, so the user must opt-in
- * before the value takes effect. Used for the roughness override which
- * defaults to unchecked ("don't override").
- */
-function SettingsCheckboxSliderRow({
-  label,
-  value,
-  min,
-  max,
-  step,
-  enabled,
-  onEnabledChange,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  enabled: boolean;
-  onEnabledChange: (v: boolean) => void;
-  onChange: (v: number) => void;
-}) {
-  return (
-    <div className={`flex flex-col gap-0.5 px-1.5 py-1 ${enabled ? "" : "opacity-60"}`}>
-      <div className="flex items-center justify-between text-xs text-text-sub select-none">
-        <label className="flex items-center gap-1.5 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => onEnabledChange(e.target.checked)}
-            className="accent-accent cursor-pointer"
-          />
-          <span>{label}</span>
-        </label>
-        <span className="tabular-nums text-text-faint">{value.toFixed(2)}</span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        disabled={!enabled}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full accent-accent cursor-pointer disabled:cursor-not-allowed"
-      />
-    </div>
-  );
-}
-
 export function SceneView() {
   // Source list: the union of "discovered DataCore entities" and any
   // externally-mounted packages from the escape-hatch picker.
@@ -549,8 +160,36 @@ export function SceneView() {
 
   const [active, setActive] = useState<DecomposedPackageInfo | null>(null);
   const [activeEntityName, setActiveEntityName] = useState<string | null>(null);
-  const [busy, setBusy] = useState<BusyState | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+
+  // Unified progress reporter. Both the Ships export pipeline and the
+  // SOC scene-load pipeline drive this same reporter; the
+  // <ProgressOverlay> renders one bar over many phases. The reporter
+  // owns the phase array; handlers update phases by id. See
+  // `lib/progress-reporter.ts`.
+  //
+  // CRITICAL: do NOT depend on the whole `progress` object in
+  // `useCallback` deps below -- destructure the four mutating
+  // callbacks (which are stable across renders) and depend on those
+  // individually. The reporter's identity changes whenever its phases
+  // state updates, and listing it in deps cascades through every
+  // callback that consumes it -- which then re-creates downstream
+  // props on every progress tick. The previous shape of this code
+  // re-fired SocSceneViewer's load effect on every tick, spawning
+  // overlapping GLTF fetches and saturating Tauri's IPC channel until
+  // the renderer locked up.
+  const progress = useProgressReporter();
+  const {
+    begin: progressBegin,
+    update: progressUpdate,
+    advance: progressAdvance,
+    reset: progressReset,
+  } = progress;
+  // Track which entity / socpak the active progress run belongs to so
+  // late events from prior runs don't leak into the current overlay.
+  const activeRunRef = useRef<{ kind: "ships" | "soc"; key: string } | null>(
+    null,
+  );
   const [status, setStatus] = useState<string>("");
   // Presentation mode for materials. Switching is in-place; the scene
   // is not re-loaded.
@@ -574,11 +213,11 @@ export function SceneView() {
   // socpak through `loadSceneToGltf`, which composes many zones,
   // resolves meshes/materials, and writes a single GLB to the scene
   // cache. The `socResponse` carries the cache path + AABB the
-  // SocSceneViewer needs to render and frame. SocBusyState tracks
-  // progress events while the load is in flight.
+  // SocSceneViewer needs to render and frame. Load progress flows
+  // through the unified `progress` reporter above (3 phases:
+  // backend / fetch / decode).
   const [socResponse, setSocResponse] = useState<LoadSceneResponse | null>(null);
   const [socActivePath, setSocActivePath] = useState<string | null>(null);
-  const [socBusy, setSocBusy] = useState<SocBusyState | null>(null);
   const [socError, setSocError] = useState<string | null>(null);
   // Flight-camera handle published by the SocSceneViewer. Hosted in
   // the Maps tab toolbar via `<ProjectionModePicker>`.
@@ -607,6 +246,13 @@ export function SceneView() {
   );
   const updateSettings = useCallback((patch: Partial<ViewerSettings>) => {
     setViewerSettings((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  // H key handler. Both viewer surfaces forward to this so the binding
+  // stays in lockstep with the Settings panel's "Show pivot orb"
+  // toggle.
+  const togglePivotOrb = useCallback(() => {
+    setViewerSettings((prev) => ({ ...prev, showPivotOrb: !prev.showPivotOrb }));
   }, []);
 
   // Fast Preview toggle. When enabled, the exporter skips interior
@@ -695,6 +341,19 @@ export function SceneView() {
     refreshEntities();
   }, [refreshEntities]);
 
+  // Push the pivot-orb visibility setting onto whichever flight cam
+  // is currently mounted. Two effects (one per surface) so the call
+  // does not fire against a stale handle when the user switches tabs.
+  // The orb is hidden by default at construction in the flight-cam
+  // hook itself, so this is a noop when the setting is at its
+  // default until the user opts in.
+  useEffect(() => {
+    flightCamHandle?.setPivotOrbVisible(viewerSettings.showPivotOrb);
+  }, [flightCamHandle, viewerSettings.showPivotOrb]);
+  useEffect(() => {
+    socFlightCamHandle?.setPivotOrbVisible(viewerSettings.showPivotOrb);
+  }, [socFlightCamHandle, viewerSettings.showPivotOrb]);
+
   // Reset livery and paint-variant list whenever the active package
   // changes. The SceneViewer publishes the new ship's paints via
   // `onPaints` once its scene loads; the dropdown stays empty in the
@@ -706,16 +365,17 @@ export function SceneView() {
   }, [active?.package_dir]);
 
   // Subscribe to scene export events for the lifetime of the view.
+  // Progress and completion drive the unified reporter so the export
+  // shares the same overlay as SOC loads.
   useEffect(() => {
     let cancelled = false;
     const unlisteners: Array<() => void> = [];
 
     onSceneExportProgress((p) => {
       if (cancelled) return;
-      setBusy((prev) => {
-        if (!prev || prev.entityName !== p.entity_name) return prev;
-        return { ...prev, fraction: p.fraction, stage: p.stage };
-      });
+      const run = activeRunRef.current;
+      if (!run || run.kind !== "ships" || run.key !== p.entity_name) return;
+      progressUpdate("export", { fraction: p.fraction, detail: p.stage });
     }).then((unlisten) => {
       if (cancelled) unlisten();
       else unlisteners.push(unlisten);
@@ -723,15 +383,19 @@ export function SceneView() {
 
     onSceneExportDone((r) => {
       if (cancelled) return;
-      setBusy((prev) => {
-        if (!prev || prev.entityName !== r.entity_name) return prev;
-        return null;
-      });
+      const run = activeRunRef.current;
+      if (!run || run.kind !== "ships" || run.key !== r.entity_name) return;
+
       if (r.error) {
+        progressReset();
+        activeRunRef.current = null;
         setActionError(`Export failed: ${r.error}`);
         return;
       }
       if (r.package_dir) {
+        progressAdvance("export");
+        progressReset();
+        activeRunRef.current = null;
         // Refresh the entity list so the cached badge updates, and
         // bump the toolbar stats since a new slot just landed.
         refreshEntities();
@@ -748,7 +412,7 @@ export function SceneView() {
       cancelled = true;
       for (const fn of unlisteners) fn();
     };
-  }, [refreshEntities, refreshCacheStats]);
+  }, [refreshEntities, refreshCacheStats, progressUpdate, progressAdvance, progressReset]);
 
   // Mount the SocpakTree only after the Maps tab is first opened. The
   // tree fires its own root listing on mount, so we want that single
@@ -794,21 +458,19 @@ export function SceneView() {
   }, [activeCategory, socpakIndex, socpakIndexError]);
 
   // Subscribe to SOC scene-load progress events. Translates the
-  // backend's `(phase, current, total, message)` into a single
-  // fraction for the loading bar. Phase weights are deliberately
-  // skewed: resolve dominates wall-clock (~80% of a cold load on
-  // Exec Hangar), so it gets the bulk of the bar.
+  // backend's `(phase, current, total, message)` into the unified
+  // reporter's "backend" phase. The fetch + decode phases are owned
+  // by the SocSceneViewer and update the reporter directly via the
+  // callbacks the parent passes down.
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
     onSceneLoadProgress((p) => {
       if (cancelled) return;
-      const fraction = computeSocFraction(p.phase, p.current, p.total);
-      const stage = p.phase.charAt(0).toUpperCase() + p.phase.slice(1);
-      setSocBusy((prev) => {
-        if (!prev) return prev;
-        return { ...prev, fraction, stage, message: p.message };
-      });
+      const run = activeRunRef.current;
+      if (!run || run.kind !== "soc") return;
+      const fraction = computeSocBackendFraction(p.phase, p.current, p.total);
+      progressUpdate("backend", { fraction, detail: p.message || p.phase });
     }).then((u) => {
       if (cancelled) u();
       else unlisten = u;
@@ -817,7 +479,7 @@ export function SceneView() {
       cancelled = true;
       if (unlisten) unlisten();
     };
-  }, []);
+  }, [progressUpdate]);
 
   // Tear down the pending two-click confirmation timer when the view
   // unmounts so the timeout doesn't fire against a stale setState.
@@ -925,19 +587,25 @@ export function SceneView() {
         if (gen !== generationRef.current) return;
         setActive(null);
         setActiveEntityName(entity.entity_name);
-        setBusy({
-          entityName: entity.entity_name,
-          fraction: 0,
-          stage: "Starting export...",
-        });
+        activeRunRef.current = { kind: "ships", key: entity.entity_name };
+        progressBegin([
+          {
+            id: "export",
+            label: `Exporting ${entity.entity_name}`,
+            weight: 1,
+            fraction: 0,
+            detail: "Starting export...",
+          },
+        ]);
         await startSceneExport(entity.entity_name, opts);
       } catch (err) {
         if (gen !== generationRef.current) return;
-        setBusy(null);
+        progressReset();
+        activeRunRef.current = null;
         setActionError(err instanceof Error ? err.message : String(err));
       }
     },
-    [opts, refreshCacheStats],
+    [opts, refreshCacheStats, progressBegin, progressReset],
   );
 
   const handleCancel = useCallback(async () => {
@@ -946,44 +614,83 @@ export function SceneView() {
     } catch (err) {
       console.error("Cancel failed:", err);
     }
-    setBusy(null);
+    progressReset();
+    activeRunRef.current = null;
     generationRef.current++;
-  }, []);
+  }, [progressReset]);
 
-  const launchMap = useCallback(async (socpakPath: string) => {
-    setSocError(null);
-    setActionError(null);
-    setSocActivePath(socpakPath);
-    setSocResponse(null);
-    setSocBusy({
-      socpakPath,
-      fraction: 0,
-      stage: "Starting",
-      message: "Reading socpak...",
-    });
-    try {
-      const response = await loadSceneToGltf(socpakPath);
-      // If the user navigated away mid-load, drop the result.
-      setSocActivePath((current) => {
-        if (current !== socpakPath) return current;
-        setSocResponse(response);
-        setSocBusy(null);
-        console.log(
-          `[soc-load] cache_hit=${response.cache_hit} ` +
-            `meshes=${response.mesh_count} placements=${response.placement_count} ` +
-            `lights=${response.light_count} materials=${response.materials_resolved}/` +
-            `${response.materials_resolved + response.materials_default} ` +
-            `glb_bytes=${response.glb_bytes} ` +
-            `dropped=${response.dropped_placements} failed_meshes=${response.failed_mesh_paths}`,
-        );
-        return current;
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setSocError(msg);
-      setSocBusy(null);
-    }
-  }, []);
+  const launchMap = useCallback(
+    async (socpakPath: string) => {
+      setSocError(null);
+      setActionError(null);
+      setSocActivePath(socpakPath);
+      // CRITICAL: do NOT clear socResponse here. The previous version
+      // unmounted SocSceneViewer between loads, which threw away the
+      // decode work for the prior scene and forced a full re-walk on
+      // every click. More importantly, dropping it via setState here
+      // and then setting it again 100ms later (cache-hit path) caused
+      // SocSceneViewer to mount, run its load effect, then unmount,
+      // then re-mount -- the load effect's clearChildren() during the
+      // brief mount window left the renderer in a half-built state
+      // that downstream renders couldn't recover from on big maps.
+      // Setting socResponse to the new value below replaces the prop
+      // in-place, which triggers the load effect once, cleanly.
+      activeRunRef.current = { kind: "soc", key: socpakPath };
+      // Three phases for a SOC load. Weights are based on observed
+      // wall-clock on Exec Hangar (cold cache): backend ~10s, fetch
+      // ~1-2s on local disk, decode ~50s and dominates -- so the
+      // aggregate bar moves at a steady visible pace through the
+      // whole load instead of jumping to ~95% the moment the backend
+      // returns and then sitting there for nearly a minute.
+      progressBegin([
+        {
+          id: "backend",
+          label: "Composing scene",
+          weight: 30,
+          fraction: 0,
+          detail: "Reading socpak...",
+        },
+        {
+          id: "fetch",
+          label: "Fetching GLB",
+          weight: 10,
+          fraction: null,
+        },
+        {
+          id: "decode",
+          label: "Resolving textures",
+          weight: 60,
+          fraction: null,
+        },
+      ]);
+      try {
+        const response = await loadSceneToGltf(socpakPath);
+        // If the user navigated away mid-load, drop the result.
+        setSocActivePath((current) => {
+          if (current !== socpakPath) return current;
+          // Backend phase is done; SocSceneViewer will drive fetch +
+          // decode through the reporter directly.
+          progressAdvance("backend");
+          setSocResponse(response);
+          console.info(
+            `[soc-load] cache_hit=${response.cache_hit} ` +
+              `meshes=${response.mesh_count} placements=${response.placement_count} ` +
+              `lights=${response.light_count} materials=${response.materials_resolved}/` +
+              `${response.materials_resolved + response.materials_default} ` +
+              `glb_bytes=${response.glb_bytes} ` +
+              `dropped=${response.dropped_placements} failed_meshes=${response.failed_mesh_paths}`,
+          );
+          return current;
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setSocError(msg);
+        progressReset();
+        activeRunRef.current = null;
+      }
+    },
+    [progressBegin, progressAdvance, progressReset],
+  );
 
   /** Bridge `SocpakTree`'s leaf-click event to the existing load flow. */
   const handleTreeLeafClick = useCallback(
@@ -1005,8 +712,37 @@ export function SceneView() {
     // reacting to in-flight events; the backend keeps building so
     // the user does not have to repeat the wait on the next click.
     setSocActivePath(null);
-    setSocBusy(null);
-  }, []);
+    progressReset();
+    activeRunRef.current = null;
+  }, [progressReset]);
+
+  /** Reporter callback handed to `<SocSceneViewer>` so it can update
+   *  the fetch + decode phases of the unified progress overlay. We
+   *  pass the reporter's `update` directly; the child is trusted to
+   *  pass the right phase id ("fetch" or "decode"). */
+  const updateSocPhase = useCallback(
+    (
+      id: "fetch" | "decode",
+      patch: Partial<{ fraction: number | null; detail: string }>,
+    ) => {
+      // Guard: if the user has navigated away mid-load the reporter
+      // has been reset; this update would otherwise re-introduce a
+      // phantom phase. Keying on activeRunRef rather than reporter
+      // state since reporter.phases isn't read here for stability.
+      if (!activeRunRef.current || activeRunRef.current.kind !== "soc") return;
+      progressUpdate(id, patch);
+    },
+    [progressUpdate],
+  );
+
+  /** Called by `<SocSceneViewer>` when it has finished loading the
+   *  scene (decode complete, materials applied, framing reset). Closes
+   *  the overlay. */
+  const handleSocLoadComplete = useCallback(() => {
+    if (!activeRunRef.current || activeRunRef.current.kind !== "soc") return;
+    progressReset();
+    activeRunRef.current = null;
+  }, [progressReset]);
 
   // Escape hatch: pick an external decomposed root.
   const handleOpenExternal = async () => {
@@ -1223,7 +959,9 @@ export function SceneView() {
             {filtered.map((entity) => {
               const isActive = activeEntityName === entity.entity_name;
               const isBusy =
-                busy !== null && busy.entityName === entity.entity_name;
+                activeRunRef.current?.kind === "ships" &&
+                activeRunRef.current.key === entity.entity_name &&
+                progress.active;
               return (
                 <div
                   key={entity.entity_name}
@@ -1280,49 +1018,42 @@ export function SceneView() {
 
         {/* ── Right pane: viewer / progress ── */}
         <div className="flex-1 relative overflow-hidden min-w-0">
+          {/* Unified progress overlay -- driven by the reporter, used by
+              both Ships exports and SOC scene loads. Stays up across
+              backend / fetch / decode phases so the user has continuous
+              feedback during a multi-stage load. */}
+          {progress.active && (
+            <ProgressOverlay
+              title={
+                activeRunRef.current?.kind === "ships"
+                  ? `Exporting ${activeRunRef.current.key}`
+                  : "Loading scene"
+              }
+              phases={progress.phases}
+              onCancel={
+                activeRunRef.current?.kind === "ships"
+                  ? handleCancel
+                  : handleSocCancel
+              }
+              cancelTitle={
+                activeRunRef.current?.kind === "ships"
+                  ? undefined
+                  : "Stop tracking the load. The backend keeps building so the next click reuses cached output."
+              }
+            />
+          )}
+
           {/* SOC scene-package mode: dedicated viewer for the Maps tab.
               Renders a self-contained GLB emitted by `loadSceneToGltf`
               instead of a decomposed-export package. */}
           {activeCategory === "Maps" && (
             <>
-              {socError && !socBusy && (
+              {socError && !progress.active && (
                 <div className="absolute top-3 right-3 z-10 max-w-md bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
                   {socError}
                 </div>
               )}
-              {socBusy && (
-                <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
-                  <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
-                    <h3 className="text-sm font-semibold text-text">
-                      Loading scene
-                    </h3>
-                    <div className="flex flex-col gap-1.5">
-                      <div className="w-full bg-surface rounded-full h-2 overflow-hidden">
-                        <div
-                          className="bg-accent h-full rounded-full transition-all duration-300"
-                          style={{ width: `${Math.min(socBusy.fraction, 1) * 100}%` }}
-                        />
-                      </div>
-                      <div className="flex items-center justify-between text-[11px] text-text-dim">
-                        <span className="truncate">
-                          {socBusy.message || socBusy.stage || "Working..."}
-                        </span>
-                        <span className="tabular-nums">
-                          {Math.round(socBusy.fraction * 100)}%
-                        </span>
-                      </div>
-                    </div>
-                    <button
-                      onClick={handleSocCancel}
-                      className="w-full py-2 rounded-md text-xs font-medium bg-danger/15 text-danger hover:bg-danger/25 transition-colors cursor-pointer"
-                      title="Stop tracking the load. The backend keeps building so the next click reuses cached output."
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              )}
-              {!socResponse && !socBusy && (
+              {!socResponse && !progress.active && (
                 <div className="absolute inset-0 flex items-center justify-center">
                   <div className="max-w-md text-center px-6">
                     <Box
@@ -1342,16 +1073,22 @@ export function SceneView() {
               )}
               {socResponse && (
                 <>
-                  {/* Top-right toolbar: projection-mode picker hosted by
-                      the parent so it lives in the same flex row as the
-                      ship viewer's controls. */}
-                  <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
-                    <ProjectionModePicker handle={socFlightCamHandle} embedded />
-                  </div>
+                  <ViewerToolbar
+                    flightCamHandle={socFlightCamHandle}
+                    renderStyle={renderStyle}
+                    onRenderStyleChange={setRenderStyle}
+                    settings={viewerSettings}
+                    onSettingsChange={updateSettings}
+                    kind="soc"
+                  />
                   <SocSceneViewer
                     response={socResponse}
                     onStatus={setStatus}
                     onFlightCamReady={setSocFlightCamHandle}
+                    renderStyle={renderStyle}
+                    onPhaseProgress={updateSocPhase}
+                    onLoadComplete={handleSocLoadComplete}
+                    onTogglePivotOrb={togglePivotOrb}
                   />
                 </>
               )}
@@ -1359,45 +1096,13 @@ export function SceneView() {
           )}
 
           {/* Decomposed-export mode: existing scene-viewer pipeline. */}
-          {activeCategory !== "Maps" && actionError && !busy && (
+          {activeCategory !== "Maps" && actionError && !progress.active && (
             <div className="absolute top-3 right-3 z-10 max-w-md bg-danger/15 border border-danger/30 text-danger text-xs px-3 py-2 rounded-md font-mono break-words shadow">
               {actionError}
             </div>
           )}
 
-          {activeCategory !== "Maps" && busy && (
-            <div className="absolute inset-0 z-10 bg-bg/85 backdrop-blur-sm flex items-center justify-center">
-              <div className="w-[420px] bg-bg-alt border border-border rounded-lg p-6 flex flex-col gap-4 shadow-lg">
-                <h3 className="text-sm font-semibold text-text">
-                  Exporting {busy.entityName}
-                </h3>
-                <div className="flex flex-col gap-1.5">
-                  <div className="w-full bg-surface rounded-full h-2 overflow-hidden">
-                    <div
-                      className="bg-accent h-full rounded-full transition-all duration-300"
-                      style={{ width: `${Math.min(busy.fraction, 1) * 100}%` }}
-                    />
-                  </div>
-                  <div className="flex items-center justify-between text-[11px] text-text-dim">
-                    <span className="truncate">
-                      {busy.stage || "Working..."}
-                    </span>
-                    <span className="tabular-nums">
-                      {Math.round(busy.fraction * 100)}%
-                    </span>
-                  </div>
-                </div>
-                <button
-                  onClick={handleCancel}
-                  className="w-full py-2 rounded-md text-xs font-medium bg-danger/15 text-danger hover:bg-danger/25 transition-colors cursor-pointer"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          )}
-
-          {activeCategory !== "Maps" && !active && !busy && (
+          {activeCategory !== "Maps" && !active && !progress.active && (
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="max-w-md text-center px-6">
                 <Box
@@ -1418,57 +1123,49 @@ export function SceneView() {
 
           {activeCategory !== "Maps" && active && (
             <>
-              {/* Top-right control strip: Livery + Style + Settings.
-                  Settings is inline here so it sits immediately right of
-                  Style and the dropdown grows downward from the button. */}
-              <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
-                <ProjectionModePicker handle={flightCamHandle} embedded />
-                {paintVariants.length > 0 && (
-                  <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
-                    <span className="text-text-faint">Livery</span>
-                    <select
-                      value={livery ?? ""}
-                      onChange={(e) =>
-                        setLivery(e.target.value === "" ? null : e.target.value)
-                      }
-                      className="bg-transparent outline-none text-text cursor-pointer"
-                    >
-                      <option value="" className="bg-bg-alt text-text">
-                        Default
-                      </option>
-                      {paintVariants.map((v) => (
-                        <option
-                          key={v.palette_id}
-                          value={v.palette_id}
-                          className="bg-bg-alt text-text"
-                        >
-                          {v.display_name ??
-                            v.subgeometry_tag ??
-                            v.palette_id}
+              <ViewerToolbar
+                flightCamHandle={flightCamHandle}
+                renderStyle={renderStyle}
+                onRenderStyleChange={setRenderStyle}
+                settings={viewerSettings}
+                onSettingsChange={updateSettings}
+                kind="ships"
+                leadingSlot={
+                  paintVariants.length > 0 ? (
+                    <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
+                      <span className="text-text-faint">Livery</span>
+                      <select
+                        value={livery ?? ""}
+                        // Blur after selection so arrow keys go back
+                        // to orbiting the camera instead of cycling
+                        // the dropdown options.
+                        onChange={(e) => {
+                          setLivery(
+                            e.target.value === "" ? null : e.target.value,
+                          );
+                          e.currentTarget.blur();
+                        }}
+                        className="bg-transparent outline-none text-text cursor-pointer"
+                      >
+                        <option value="" className="bg-bg-alt text-text">
+                          Default
                         </option>
-                      ))}
-                    </select>
-                  </label>
-                )}
-                <label className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-bg-alt/90 border border-border text-xs text-text-sub shadow">
-                  <span className="text-text-faint">Style</span>
-                  <select
-                    value={renderStyle}
-                    onChange={(e) => setRenderStyle(e.target.value as RenderStyle)}
-                    className="bg-transparent outline-none text-text cursor-pointer"
-                  >
-                    {RENDER_STYLES.map((opt) => (
-                      <option key={opt.value} value={opt.value} className="bg-bg-alt text-text">
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <SettingsPanel
-                  settings={viewerSettings}
-                  onChange={updateSettings}
-                />
-              </div>
+                        {paintVariants.map((v) => (
+                          <option
+                            key={v.palette_id}
+                            value={v.palette_id}
+                            className="bg-bg-alt text-text"
+                          >
+                            {v.display_name ??
+                              v.subgeometry_tag ??
+                              v.palette_id}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null
+                }
+              />
               <SceneViewer
                 packageInfo={active}
                 renderStyle={renderStyle}
@@ -1480,6 +1177,7 @@ export function SceneView() {
                 onPaints={setPaintVariants}
                 onStatus={setStatus}
                 onFlightCamReady={setFlightCamHandle}
+                onTogglePivotOrb={togglePivotOrb}
               />
             </>
           )}

--- a/crates/starbreaker-3d/src/decomposed.rs
+++ b/crates/starbreaker-3d/src/decomposed.rs
@@ -12,10 +12,30 @@ use crate::nmc::NodeMeshCombo;
 use crate::pipeline::{
     DecomposedExport, ExportOptions, ExportedFile, ExportedFileKind, InteriorCgfEntry,
     LoadedInteriors, MaterialMode,
-    PngCache,
+    PngCache, ROOT_INSTANCE_ID,
 };
 use crate::skeleton::Bone;
 use crate::types::{EntityPayload, Mesh};
+
+/// Decomposed-export contract version. Bump whenever the on-disk
+/// scene.json / palettes.json / material-sidecar shape changes in a way
+/// that the scene viewer cannot transparently fall back from. Every
+/// emitted scene.json carries this value as `contract_version`; the
+/// Tauri cache key suffix appends `_v<N>` so old slots become unreachable
+/// after a bump and can be reaped by the "Clear all cache" button or
+/// `prune_stale_cache` startup hook.
+///
+/// Version history:
+/// - 1: initial sentinel (introduced alongside the cache UI rework). All
+///   prior exports — which never carried `contract_version` — are
+///   treated as unversioned and live in cache slots without `_v<N>`.
+/// - 2: GLB material entries gained `extras.submat_index`, the engine-truth
+///   binding into the paired sidecar's submaterials array. The TS loader
+///   reads it directly via Three.js `material.userData.gltfExtensions
+///   .submat_index`, replacing the 5-strategy name-matching ladder.
+///   Pre-v2 GLBs lack the field; their slots are auto-orphaned and
+///   regenerated.
+pub const CONTRACT_VERSION: u32 = 2;
 
 pub(crate) struct DecomposedInput {
     pub entity_name: String,
@@ -88,6 +108,15 @@ struct SceneInstanceRecord {
     palette_id: Option<String>,
     parent_node_name: Option<String>,
     parent_entity_name: Option<String>,
+    /// Unique per-export id for this child placement. Disambiguates
+    /// sibling placements that share the same `entity_name` (e.g. paired
+    /// weapon mounts). Loaders should prefer keying their attach
+    /// registry on `instance_id` over `entity_name`.
+    instance_id: u32,
+    /// Instance id of the parent placement (root or another child).
+    /// Loaders should prefer this over `parent_entity_name` for
+    /// disambiguating which parent a child belongs to.
+    parent_instance_id: u32,
     source_transform_basis: Option<String>,
     local_transform_sc: Option<[[f32; 4]; 4]>,
     resolved_no_rotation: bool,
@@ -131,11 +160,26 @@ fn empty_scene_graph_mesh() -> Mesh {
 }
 
 fn flat_4x4_to_rows(flat: [f32; 16]) -> [[f32; 4]; 4] {
+    // glTF / glam emit column-major: flat[col * 4 + row].
+    // scene.json local_transform_sc is row-major: rows[row][col].
     [
-        [flat[0], flat[1], flat[2], flat[3]],
-        [flat[4], flat[5], flat[6], flat[7]],
-        [flat[8], flat[9], flat[10], flat[11]],
-        [flat[12], flat[13], flat[14], flat[15]],
+        [flat[0], flat[4], flat[8], flat[12]],
+        [flat[1], flat[5], flat[9], flat[13]],
+        [flat[2], flat[6], flat[10], flat[14]],
+        [flat[3], flat[7], flat[11], flat[15]],
+    ]
+}
+
+/// Transpose a column-major 4x4 (each inner array = one column) into the
+/// row-major nested layout that scene.json transforms use. The in-memory
+/// `InteriorMesh.transform` and `InteriorPayload.container_transform` are
+/// column-major (for glTF), but the JSON contract is row-major.
+fn cols_to_rows_4x4(cols: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
+    [
+        [cols[0][0], cols[1][0], cols[2][0], cols[3][0]],
+        [cols[0][1], cols[1][1], cols[2][1], cols[3][1]],
+        [cols[0][2], cols[1][2], cols[2][2], cols[3][2]],
+        [cols[0][3], cols[1][3], cols[2][3], cols[3][3]],
     ]
 }
 
@@ -236,6 +280,8 @@ fn resolve_child_instance_transforms(input: &DecomposedInput) -> Vec<ResolvedChi
                 offset_rotation: child.offset_rotation,
                 detach_direction: child.detach_direction,
                 port_flags: child.port_flags.clone(),
+                instance_id: child.instance_id,
+                parent_instance_id: child.parent_instance_id,
             },
             &scene_nodes,
             MaterialMode::None,
@@ -634,6 +680,7 @@ pub(crate) fn write_decomposed_export(
             materials,
             opts.texture_mip,
             existing_asset_paths,
+            input.root_palette.as_ref(),
         )
     });
     let root_palette_id = input
@@ -670,6 +717,7 @@ pub(crate) fn write_decomposed_export(
                 materials,
                 opts.texture_mip,
                 existing_asset_paths,
+                variant.palette.as_ref(),
             )
         });
         paint_variant_json.push(serde_json::json!({
@@ -729,6 +777,7 @@ pub(crate) fn write_decomposed_export(
                 materials,
                 opts.texture_mip,
                 existing_asset_paths,
+                child.palette.as_ref(),
             )
         });
         let palette_id = child
@@ -753,6 +802,8 @@ pub(crate) fn write_decomposed_export(
             palette_id,
             parent_node_name: Some(child.parent_node_name.clone()),
             parent_entity_name: Some(child.parent_entity_name.clone()),
+            instance_id: child.instance_id,
+            parent_instance_id: child.parent_instance_id,
             source_transform_basis: Some("cryengine_z_up".to_string()),
             local_transform_sc: Some(resolved_transform.local_transform_sc),
             resolved_no_rotation: resolved_transform.resolved_no_rotation,
@@ -797,9 +848,10 @@ pub(crate) fn write_decomposed_export(
                 .as_ref()
                 .or(container.palette.as_ref());
             let cache_key = format!(
-                "{}|{}",
+                "{}|{}|{}",
                 entry.cgf_path.to_lowercase(),
-                entry.material_path.as_deref().unwrap_or("").to_lowercase()
+                entry.material_path.as_deref().unwrap_or("").to_lowercase(),
+                effective_palette_id.as_deref().unwrap_or(""),
             );
             let (mesh_asset, material_sidecar) = if let Some(cached) = interior_asset_cache.get(&cache_key) {
                 cached.clone()
@@ -826,11 +878,22 @@ pub(crate) fn write_decomposed_export(
                     material_sidecar_relative_path(&source_material_path, &entry.name, opts.texture_mip)
                 });
                 let material_sidecar = interior_material_view.sidecar_materials.as_ref().map(|materials| {
-                    if let Some(requested_path) = requested_material_sidecar.as_ref() {
-                        if files.contains_key(requested_path)
-                            || existing_asset_paths.is_some_and(|paths| paths.contains(&requested_path.to_ascii_lowercase()))
-                        {
-                            return requested_path.clone();
+                    // Only honor the existing-sidecar fast path when there is no
+                    // palette to bake. With a resolved palette the sidecar JSON is
+                    // palette-dependent (HardSurface submaterials carry resolved
+                    // entry colors) and a stale on-disk sidecar would point at the
+                    // wrong palette. The content-hash collision logic in
+                    // insert_binary_file still dedupes by exact bytes when the
+                    // palettes happen to match.
+                    let has_baked_palette = effective_palette_ref.is_some()
+                        && materials_have_palette_routed_submaterial(materials);
+                    if !has_baked_palette {
+                        if let Some(requested_path) = requested_material_sidecar.as_ref() {
+                            if files.contains_key(requested_path)
+                                || existing_asset_paths.is_some_and(|paths| paths.contains(&requested_path.to_ascii_lowercase()))
+                            {
+                                return requested_path.clone();
+                            }
                         }
                     }
                     write_material_sidecar(
@@ -845,6 +908,7 @@ pub(crate) fn write_decomposed_export(
                         materials,
                         opts.texture_mip,
                         existing_asset_paths,
+                        effective_palette_ref,
                     )
                 });
                 let reuse_existing_mesh_asset = (files.contains_key(&requested_mesh_asset)
@@ -1155,6 +1219,7 @@ fn build_scene_manifest_value(
 ) -> serde_json::Value {
     let mut manifest = serde_json::json!({
         "version": 1,
+        "contract_version": CONTRACT_VERSION,
         "export_kind": "Decomposed",
         "package_rule": {
             "root": "caller_selected_export_root",
@@ -1165,6 +1230,7 @@ fn build_scene_manifest_value(
         },
         "root_entity": {
             "entity_name": entity_name,
+            "instance_id": ROOT_INSTANCE_ID,
             "geometry_path": geometry_path,
             "material_path": material_path,
             "mesh_asset": root_mesh_asset,
@@ -1300,6 +1366,8 @@ fn build_livery_manifest_value(records: &BTreeMap<String, LiveryUsage>) -> serde
 fn scene_instance_json(instance: &SceneInstanceRecord) -> serde_json::Value {
     serde_json::json!({
         "entity_name": instance.entity_name,
+        "instance_id": instance.instance_id,
+        "parent_instance_id": instance.parent_instance_id,
         "geometry_path": instance.geometry_path,
         "material_path": instance.material_path,
         "mesh_asset": instance.mesh_asset,
@@ -1322,7 +1390,7 @@ fn interior_container_json(container: &InteriorContainerRecord) -> serde_json::V
     serde_json::json!({
         "name": container.name,
         "palette_id": container.palette_id,
-        "container_transform": container.container_transform,
+        "container_transform": cols_to_rows_4x4(container.container_transform),
         "placements": container.placements.iter().map(|placement| {
             serde_json::json!({
                 "cgf_path": placement.cgf_path,
@@ -1330,7 +1398,7 @@ fn interior_container_json(container: &InteriorContainerRecord) -> serde_json::V
                 "mesh_asset": placement.mesh_asset,
                 "material_sidecar": placement.material_sidecar,
                 "entity_class_guid": placement.entity_class_guid,
-                "transform": placement.transform,
+                "transform": cols_to_rows_4x4(placement.transform),
                 "palette_id": placement.palette_id,
             })
         }).collect::<Vec<_>>(),
@@ -1421,6 +1489,7 @@ fn write_material_sidecar(
     materials: &MtlFile,
     texture_mip: u32,
     existing_asset_paths: Option<&HashSet<String>>,
+    palette: Option<&TintPalette>,
 ) -> String {
     let source_material_path = material_source_path(p4k, materials, material_path, geometry_path);
     let relative_path = material_sidecar_relative_path(&source_material_path, fallback_name, texture_mip);
@@ -1445,6 +1514,7 @@ fn write_material_sidecar(
         &relative_path,
         palettes_manifest_path,
         &extracted,
+        palette,
     );
     insert_json_file(files, relative_path, value)
 }
@@ -1604,6 +1674,7 @@ fn build_material_sidecar_value(
     relative_path: &str,
     palettes_manifest_path: &str,
     extracted: &[ExtractedMaterialEntry],
+    palette: Option<&TintPalette>,
 ) -> serde_json::Value {
     let source_stem = source_material_path
         .rsplit('/')
@@ -1612,6 +1683,7 @@ fn build_material_sidecar_value(
         .strip_suffix(".mtl")
         .unwrap_or(source_material_path);
     let blender_material_names = preferred_blender_material_names(&materials.materials, source_stem);
+    let resolved_palette_id = palette.map(palette_id);
 
     serde_json::json!({
         "version": 1,
@@ -1625,6 +1697,7 @@ fn build_material_sidecar_value(
         "palette_contract": {
             "shared_manifest": palettes_manifest_path,
             "scene_instance_field": "palette_id",
+            "resolved_palette_id": resolved_palette_id,
         },
         "paint_override": materials.paint_override.as_ref().map(paint_override_json),
         "submaterials": materials.materials.iter().enumerate().map(|(index, material)| {
@@ -1635,6 +1708,8 @@ fn build_material_sidecar_value(
                 &blender_material_names[index],
                 index,
                 &extracted[index],
+                palette,
+                resolved_palette_id.as_deref(),
             )
         }).collect::<Vec<_>>(),
     })
@@ -1666,6 +1741,8 @@ fn build_submaterial_json(
     blender_material_name: &str,
     index: usize,
     extracted: &ExtractedMaterialEntry,
+    palette: Option<&TintPalette>,
+    resolved_palette_id: Option<&str>,
 ) -> serde_json::Value {
     let semantic_slots = material.semantic_texture_slots();
     let decoded_flags = material.decoded_string_gen_mask();
@@ -1680,6 +1757,11 @@ fn build_submaterial_json(
         .filter(|binding| binding.is_virtual)
         .map(|binding| binding.path.clone())
         .collect::<Vec<_>>();
+    let tint_palette_json = build_submaterial_tint_palette_json(
+        material,
+        palette,
+        resolved_palette_id,
+    );
 
     serde_json::json!({
         "index": index,
@@ -1687,6 +1769,7 @@ fn build_submaterial_json(
         "blender_material_name": blender_material_name,
         "shader": material.shader,
         "shader_family": material.shader_family().as_str(),
+        "tint_palette": tint_palette_json,
         "authored_attributes": authored_attributes_json(&material.authored_attributes),
         "authored_public_params": raw_public_params_json(&material.public_params),
         "authored_child_blocks": authored_blocks_json(&material.authored_child_blocks),
@@ -2202,6 +2285,82 @@ fn palette_channel_json(channel: u8, is_glass: bool) -> Option<serde_json::Value
     }
 }
 
+/// Build the per-submaterial `tint_palette` JSON block. Emitted when the
+/// submaterial belongs to a palette-driven shader family (HardSurface) and
+/// the entity has a resolved TintPaletteTree palette. Carries the full
+/// resolved entry colors plus the channel this submaterial reads from so
+/// downstream consumers can apply
+/// `final_diffuse = entry.tint_color * (tiling_texture / 255)`
+/// without re-doing palette lookup themselves.
+fn build_submaterial_tint_palette_json(
+    material: &SubMaterial,
+    palette: Option<&TintPalette>,
+    resolved_palette_id: Option<&str>,
+) -> Option<serde_json::Value> {
+    let palette = palette?;
+    let family = material.shader_family();
+    if !matches!(family, crate::mtl::ShaderFamily::HardSurface) {
+        return None;
+    }
+    let assigned_channel = resolve_submaterial_palette_channel(material);
+    let entries = serde_json::Value::Array(vec![
+        tint_palette_entry_json("entryA", &palette.primary, &palette.finish.primary),
+        tint_palette_entry_json("entryB", &palette.secondary, &palette.finish.secondary),
+        tint_palette_entry_json("entryC", &palette.tertiary, &palette.finish.tertiary),
+    ]);
+    Some(serde_json::json!({
+        "palette_id": resolved_palette_id,
+        "palette_source_name": palette.source_name,
+        "assigned_channel": assigned_channel,
+        "entries": entries,
+    }))
+}
+
+fn tint_palette_entry_json(
+    channel: &str,
+    tint_color: &[f32; 3],
+    finish: &crate::mtl::TintPaletteFinishEntry,
+) -> serde_json::Value {
+    serde_json::json!({
+        "channel": channel,
+        "tint_color": tint_color,
+        "spec_color": finish.specular,
+        "glossiness": finish.glossiness,
+    })
+}
+
+/// True when at least one submaterial in the file is a palette-driven
+/// HardSurface entry whose sidecar emission depends on the resolved palette.
+fn materials_have_palette_routed_submaterial(materials: &MtlFile) -> bool {
+    materials.materials.iter().any(|material| {
+        matches!(material.shader_family(), crate::mtl::ShaderFamily::HardSurface)
+    })
+}
+
+/// Resolve which palette entry channel a submaterial reads from.
+/// Prefers the authoritative MTL `PaletteTint` value when present, then
+/// falls back to the `Paint_Primary` / `_Secondary` / `_Tertiary` naming
+/// convention. Returns `None` when nothing matches so consumers can decide
+/// their own resolution policy.
+fn resolve_submaterial_palette_channel(material: &SubMaterial) -> Option<&'static str> {
+    match material.palette_tint {
+        1 => return Some("entryA"),
+        2 => return Some("entryB"),
+        3 => return Some("entryC"),
+        _ => {}
+    }
+    let lower = material.name.to_ascii_lowercase();
+    if lower.starts_with("paint_primary") {
+        Some("entryA")
+    } else if lower.starts_with("paint_secondary") {
+        Some("entryB")
+    } else if lower.starts_with("paint_tertiary") {
+        Some("entryC")
+    } else {
+        None
+    }
+}
+
 fn texture_ref_json(texture_ref: &TextureExportRef) -> serde_json::Value {
     let mut value = serde_json::Map::from_iter([
         ("role".to_string(), serde_json::json!(texture_ref.role)),
@@ -2695,6 +2854,7 @@ mod tests {
             "Data/Objects/Ships/Test/hull.materials.json",
             "Packages/ARGO MOLE/palettes.json",
             &extracted,
+            None,
         );
 
         assert_eq!(value["source_material_path"], serde_json::json!("Data/Objects/Ships/Test/hull.mtl"));
@@ -2740,6 +2900,208 @@ mod tests {
         assert_eq!(value["submaterials"][0]["virtual_inputs"][0], serde_json::json!("$TintPaletteDecal"));
     }
 
+    fn sample_palette_for_tint_test() -> TintPalette {
+        TintPalette {
+            source_name: Some("rsi_polaris_default".into()),
+            display_name: Some("Polaris Default".into()),
+            primary: [0.10, 0.20, 0.30],
+            secondary: [0.30, 0.20, 0.10],
+            tertiary: [0.40, 0.50, 0.60],
+            glass: [0.05, 0.05, 0.10],
+            decal_color_r: None,
+            decal_color_g: None,
+            decal_color_b: None,
+            decal_texture: None,
+            finish: crate::mtl::TintPaletteFinish {
+                primary: crate::mtl::TintPaletteFinishEntry {
+                    specular: Some([0.9, 0.9, 0.9]),
+                    glossiness: Some(0.55),
+                },
+                secondary: crate::mtl::TintPaletteFinishEntry {
+                    specular: Some([0.5, 0.5, 0.5]),
+                    glossiness: Some(0.42),
+                },
+                tertiary: crate::mtl::TintPaletteFinishEntry {
+                    specular: Some([0.2, 0.2, 0.2]),
+                    glossiness: Some(0.30),
+                },
+                glass: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn material_sidecar_emits_tint_palette_for_hardsurface_with_palette_routing() {
+        let mut material = sample_submaterial();
+        material.shader = "HardSurface".into();
+        material.layers.clear();
+        material.palette_tint = 1; // entryA / primary
+
+        let materials = MtlFile {
+            materials: vec![material],
+            source_path: Some("Data/Objects/Ships/Test/hull.mtl".into()),
+            paint_override: None,
+            material_set: Default::default(),
+        };
+        let extracted = vec![ExtractedMaterialEntry::default()];
+        let palette = sample_palette_for_tint_test();
+
+        let value = build_material_sidecar_value(
+            &materials,
+            "Data/Objects/Ships/Test/hull.mtl",
+            "Data/Objects/Ships/Test/hull.materials.json",
+            "Packages/Test/palettes.json",
+            &extracted,
+            Some(&palette),
+        );
+
+        let tint = &value["submaterials"][0]["tint_palette"];
+        assert_eq!(tint["palette_source_name"], serde_json::json!("rsi_polaris_default"));
+        assert_eq!(tint["palette_id"], serde_json::json!("palette/rsi_polaris_default"));
+        assert_eq!(tint["assigned_channel"], serde_json::json!("entryA"));
+        let entries = tint["entries"].as_array().expect("entries array");
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0]["channel"], serde_json::json!("entryA"));
+        let tint_a = entries[0]["tint_color"].as_array().expect("tint_color array");
+        assert_eq!(tint_a.len(), 3);
+        assert!((tint_a[0].as_f64().unwrap() - 0.10).abs() < 1e-5);
+        assert!((tint_a[1].as_f64().unwrap() - 0.20).abs() < 1e-5);
+        assert!((tint_a[2].as_f64().unwrap() - 0.30).abs() < 1e-5);
+        let spec_a = entries[0]["spec_color"].as_array().expect("spec_color array");
+        assert!((spec_a[0].as_f64().unwrap() - 0.9).abs() < 1e-5);
+        let glossiness = entries[0]["glossiness"]
+            .as_f64()
+            .expect("glossiness numeric");
+        assert!((glossiness - 0.55).abs() < 1e-5);
+        assert_eq!(entries[1]["channel"], serde_json::json!("entryB"));
+        assert_eq!(entries[2]["channel"], serde_json::json!("entryC"));
+        assert_eq!(
+            value["palette_contract"]["resolved_palette_id"],
+            serde_json::json!("palette/rsi_polaris_default")
+        );
+    }
+
+    #[test]
+    fn material_sidecar_tint_palette_uses_paint_name_when_routing_absent() {
+        let mut material = sample_submaterial();
+        material.name = "Paint_Secondary_decals".into();
+        material.shader = "HardSurface".into();
+        material.layers.clear();
+        material.palette_tint = 0; // no MTL routing -> fall back to name
+
+        let materials = MtlFile {
+            materials: vec![material],
+            source_path: Some("Data/Objects/Ships/Test/hull.mtl".into()),
+            paint_override: None,
+            material_set: Default::default(),
+        };
+        let extracted = vec![ExtractedMaterialEntry::default()];
+        let palette = sample_palette_for_tint_test();
+
+        let value = build_material_sidecar_value(
+            &materials,
+            "Data/Objects/Ships/Test/hull.mtl",
+            "Data/Objects/Ships/Test/hull.materials.json",
+            "Packages/Test/palettes.json",
+            &extracted,
+            Some(&palette),
+        );
+
+        assert_eq!(
+            value["submaterials"][0]["tint_palette"]["assigned_channel"],
+            serde_json::json!("entryB")
+        );
+    }
+
+    #[test]
+    fn material_sidecar_omits_tint_palette_when_no_palette_resolved() {
+        let mut material = sample_submaterial();
+        material.shader = "HardSurface".into();
+        material.layers.clear();
+        material.palette_tint = 1;
+
+        let materials = MtlFile {
+            materials: vec![material],
+            source_path: Some("Data/Objects/Ships/Test/hull.mtl".into()),
+            paint_override: None,
+            material_set: Default::default(),
+        };
+        let extracted = vec![ExtractedMaterialEntry::default()];
+
+        let value = build_material_sidecar_value(
+            &materials,
+            "Data/Objects/Ships/Test/hull.mtl",
+            "Data/Objects/Ships/Test/hull.materials.json",
+            "Packages/Test/palettes.json",
+            &extracted,
+            None,
+        );
+
+        assert!(value["submaterials"][0]["tint_palette"].is_null());
+        assert!(value["palette_contract"]["resolved_palette_id"].is_null());
+    }
+
+    #[test]
+    fn material_sidecar_omits_tint_palette_for_non_hardsurface() {
+        // Illum/GlassPBR/etc. submaterials should not carry a baked tint
+        // palette even when the entity has one resolved.
+        let mut material = sample_submaterial();
+        material.shader = "Illum".into();
+        material.layers.clear();
+        material.palette_tint = 0;
+
+        let materials = MtlFile {
+            materials: vec![material],
+            source_path: Some("Data/Objects/Ships/Test/hull.mtl".into()),
+            paint_override: None,
+            material_set: Default::default(),
+        };
+        let extracted = vec![ExtractedMaterialEntry::default()];
+        let palette = sample_palette_for_tint_test();
+
+        let value = build_material_sidecar_value(
+            &materials,
+            "Data/Objects/Ships/Test/hull.mtl",
+            "Data/Objects/Ships/Test/hull.materials.json",
+            "Packages/Test/palettes.json",
+            &extracted,
+            Some(&palette),
+        );
+
+        assert!(value["submaterials"][0]["tint_palette"].is_null());
+    }
+
+    #[test]
+    fn material_sidecar_tint_palette_has_no_assigned_channel_when_unknown() {
+        let mut material = sample_submaterial();
+        material.name = "metal_random".into();
+        material.shader = "HardSurface".into();
+        material.layers.clear();
+        material.palette_tint = 0;
+
+        let materials = MtlFile {
+            materials: vec![material],
+            source_path: Some("Data/Objects/Ships/Test/hull.mtl".into()),
+            paint_override: None,
+            material_set: Default::default(),
+        };
+        let extracted = vec![ExtractedMaterialEntry::default()];
+        let palette = sample_palette_for_tint_test();
+
+        let value = build_material_sidecar_value(
+            &materials,
+            "Data/Objects/Ships/Test/hull.mtl",
+            "Data/Objects/Ships/Test/hull.materials.json",
+            "Packages/Test/palettes.json",
+            &extracted,
+            Some(&palette),
+        );
+
+        let tint = &value["submaterials"][0]["tint_palette"];
+        assert!(tint["assigned_channel"].is_null());
+        assert_eq!(tint["entries"].as_array().map(|e| e.len()), Some(3));
+    }
+
     #[test]
     fn material_sidecar_json_preserves_iridescence_support_fields() {
         let mut material = sample_submaterial();
@@ -2778,6 +3140,7 @@ mod tests {
             "Data/Objects/Ships/Test/hull.materials.json",
             "Packages/ARGO MOLE/palettes.json",
             &extracted,
+            None,
         );
 
         assert_eq!(value["submaterials"][0]["decoded_feature_flags"]["has_iridescence"], serde_json::json!(true));
@@ -2839,6 +3202,7 @@ mod tests {
             "Data/Objects/Ships/Test/hull.materials.json",
             "Packages/ARGO MOLE/palettes.json",
             &extracted,
+            None,
         );
 
         assert_eq!(value["submaterials"][0]["blender_material_name"], serde_json::json!("hull:hull_panel_0"));
@@ -3259,6 +3623,8 @@ mod tests {
             palette_id: Some("palette/test".into()),
             parent_node_name: Some("hardpoint_weapon_left".into()),
             parent_entity_name: Some("root".into()),
+            instance_id: 1,
+            parent_instance_id: ROOT_INSTANCE_ID,
             source_transform_basis: Some("cryengine_z_up".into()),
             local_transform_sc: Some(crate::socpak::build_container_transform([1.0, 2.0, 3.0], [0.0, 90.0, 0.0])),
             resolved_no_rotation: false,
@@ -3309,11 +3675,14 @@ mod tests {
         );
 
         assert_eq!(value["root_entity"]["mesh_asset"], serde_json::json!("Data/Objects/Ships/Test/root.glb"));
+        assert_eq!(value["root_entity"]["instance_id"], serde_json::json!(ROOT_INSTANCE_ID));
         assert_eq!(value["children"][0]["mesh_asset"], serde_json::json!("Data/Objects/Ships/Test/child.glb"));
         assert_eq!(value["children"][0]["parent_node_name"], serde_json::json!("hardpoint_weapon_left"));
         assert_eq!(value["children"][0]["source_transform_basis"], serde_json::json!("cryengine_z_up"));
         assert!(value["children"][0]["local_transform_sc"].is_array());
         assert_eq!(value["children"][0]["resolved_no_rotation"], serde_json::json!(false));
+        assert_eq!(value["children"][0]["instance_id"], serde_json::json!(1));
+        assert_eq!(value["children"][0]["parent_instance_id"], serde_json::json!(ROOT_INSTANCE_ID));
         assert_eq!(value["interiors"][0]["placements"][0]["mesh_asset"], serde_json::json!("Data/Objects/Ships/Test/interior_panel.glb"));
         assert_eq!(value["package_rule"]["package_dir"], serde_json::json!("Packages/ARGO MOLE"));
         assert_eq!(value["package_rule"]["normalized_p4k_relative_paths"], serde_json::json!(true));

--- a/crates/starbreaker-3d/src/gltf/glb_builder.rs
+++ b/crates/starbreaker-3d/src/gltf/glb_builder.rs
@@ -2363,6 +2363,18 @@ fn build_material(
 
     let mat_extras = {
         let mut map = serde_json::Map::new();
+        // Top-level binding hint for the TS loader: the submaterial array
+        // index in the paired `*.materials.json` sidecar. The Rust GLB
+        // writer and the sidecar writer both emit submaterials in
+        // `materials.iter().enumerate()` order, so this index is the
+        // engine-truth cross-reference. Names diverge across naming
+        // spaces (MTL-source vs Blender-semantic, `_mtl_` vs `:` vs
+        // bare-name) but indices do not.
+        //
+        // GLTFLoader copies `material.extras` to `material.userData
+        // .gltfExtensions` on the JS side, so the loader reads it as a
+        // single property lookup — no name parsing, no fallback ladder.
+        map.insert("submat_index".into(), serde_json::json!(sub.material_id));
         if let Some(m) = mtl_sub {
             if !m.name.is_empty() {
                 map.insert("source_name".into(), serde_json::json!(m.name));

--- a/crates/starbreaker-3d/src/gltf/mod.rs
+++ b/crates/starbreaker-3d/src/gltf/mod.rs
@@ -940,6 +940,8 @@ mod tests {
             offset_rotation: [0.0; 3],
             detach_direction: [0.0; 3],
             port_flags: String::new(),
+            instance_id: 0,
+            parent_instance_id: 0,
         }
     }
 

--- a/crates/starbreaker-3d/src/gltf/mod.rs
+++ b/crates/starbreaker-3d/src/gltf/mod.rs
@@ -168,8 +168,9 @@ pub fn write_glb_with_progress(
     progress: Option<&Progress>,
 ) -> Result<Vec<u8>, Error> {
     let mut builder = GlbBuilder::new();
+    let entity_name = opts.metadata.entity_name.as_deref().unwrap_or("<unknown>");
 
-    log::info!("[mem-phase] start write_glb");
+    log::info!("[mem-phase] start write_glb name={}", entity_name);
     report_progress(progress, 0.05, "Packing root mesh");
     // ---- Pack root entity (drop textures after packing) ----
     let mut scene_nodes = if let Some(root_mesh) = input.root_mesh {

--- a/crates/starbreaker-3d/src/lib.rs
+++ b/crates/starbreaker-3d/src/lib.rs
@@ -1,6 +1,11 @@
 pub mod dequant;
 pub(crate) mod decomposed;
 pub mod error;
+
+/// Decomposed-export contract version. Re-exported from the internal
+/// `decomposed` module so the Tauri cache layer can stamp it onto cache
+/// keys and the scene viewer can detect schema bumps.
+pub use decomposed::CONTRACT_VERSION as DECOMPOSED_CONTRACT_VERSION;
 pub(crate) mod gltf;
 pub(crate) mod included_objects;
 pub mod ivo;

--- a/crates/starbreaker-3d/src/lib.rs
+++ b/crates/starbreaker-3d/src/lib.rs
@@ -13,6 +13,7 @@ pub mod mtl;
 pub mod nmc;
 pub(crate) mod pipeline;
 pub mod skeleton;
+pub mod soc;
 pub(crate) mod socpak;
 pub mod types;
 pub mod animation;

--- a/crates/starbreaker-3d/src/mtl.rs
+++ b/crates/starbreaker-3d/src/mtl.rs
@@ -1132,22 +1132,20 @@ pub fn extract_mtl_name(data: &[u8]) -> Option<String> {
 
 /// Decode a CrCh `MtlName` chunk's raw payload into the asset's MTL path.
 ///
-/// Layout matches the Lumberyard `CryHeaders.h` / `CGFLoader.cpp`
-/// definitions for the legacy CryEngine MtlName chunk: a fixed 128-byte
-/// null-terminated `char` name at a version-dependent offset within the
-/// payload.
+/// Layout: a fixed 128-byte null-terminated `char` name at a
+/// version-dependent offset within the chunk payload.
 ///
 /// Two chunk versions are observed in current content:
 ///   - **0x0800** — fixed 408-byte struct. Name at offset `0x08` (after
-///     `i32 nFlags` and `i32 nFlags2`).
+///     two `i32` flag fields).
 ///   - **0x0802** — variable-length, fixed 132-byte header. Name at
 ///     offset `0x00` — flags were dropped from the header.
 ///
 /// For an unknown version the offset-0 layout is used as a fallback;
 /// it's the dominant case in current content. The fallback is benign
-/// for an unrecognised 0x0800-style chunk because nFlags is almost
-/// always all-zero, so the decode produces an empty string and the
-/// caller treats that as "no MtlName".
+/// for an unrecognised 0x0800-style chunk because the prefixed flag
+/// fields are almost always all-zero, so the decode produces an empty
+/// string and the caller treats that as "no MtlName".
 ///
 /// Backslashes in the stored path are normalised to forward slashes to
 /// match the canonicalisation the rest of the pipeline uses.

--- a/crates/starbreaker-3d/src/mtl.rs
+++ b/crates/starbreaker-3d/src/mtl.rs
@@ -1100,19 +1100,78 @@ fn parse_rgb(s: &str) -> [f32; 3] {
     }
 }
 
-/// Extract the MtlName string from a .cgf/.skin metadata IVO file.
+/// Extract the MtlName string from a .cgf / .cgfm / .cga / .skin metadata file.
+///
+/// Handles both chunk file formats StarBreaker recognises:
+///   - **IVO** — newer Star Citizen content. MtlName chunk type
+///     `0x83353333`, payload is a flat 128-byte null-terminated name
+///     parsed by `MaterialName::read`.
+///   - **CrCh** — legacy CryEngine content (still common for older ships
+///     and components). MtlName chunk type `0x1014`, with a version-keyed
+///     layout — see `extract_crch_mtl_name` below.
+///
+/// Returns `None` only if no MtlName chunk is present or its payload is
+/// too short for the version's expected layout. Empty names are also
+/// rejected (treated as "no MtlName declared").
 pub fn extract_mtl_name(data: &[u8]) -> Option<String> {
     let chunk_file = ChunkFile::from_bytes(data).ok()?;
-    let ivo = match &chunk_file {
-        ChunkFile::Ivo(ivo) => ivo,
-        ChunkFile::CrCh(_) => return None,
-    };
+    match &chunk_file {
+        ChunkFile::Ivo(ivo) => ivo
+            .chunks()
+            .iter()
+            .find(|c| c.chunk_type == starbreaker_chunks::known_types::ivo::MTL_NAME_IVO320)
+            .and_then(|entry| MaterialName::read(ivo.chunk_data(entry)).ok())
+            .map(|m| m.name),
+        ChunkFile::CrCh(crch) => crch
+            .chunks()
+            .iter()
+            .find(|c| c.chunk_type == starbreaker_chunks::known_types::crch::MTL_NAME)
+            .and_then(|entry| extract_crch_mtl_name(crch.chunk_data(entry), entry.version)),
+    }
+}
 
-    ivo.chunks()
+/// Decode a CrCh `MtlName` chunk's raw payload into the asset's MTL path.
+///
+/// Layout matches the Lumberyard `CryHeaders.h` / `CGFLoader.cpp`
+/// definitions for the legacy CryEngine MtlName chunk: a fixed 128-byte
+/// null-terminated `char` name at a version-dependent offset within the
+/// payload.
+///
+/// Two chunk versions are observed in current content:
+///   - **0x0800** — fixed 408-byte struct. Name at offset `0x08` (after
+///     `i32 nFlags` and `i32 nFlags2`).
+///   - **0x0802** — variable-length, fixed 132-byte header. Name at
+///     offset `0x00` — flags were dropped from the header.
+///
+/// For an unknown version the offset-0 layout is used as a fallback;
+/// it's the dominant case in current content. The fallback is benign
+/// for an unrecognised 0x0800-style chunk because nFlags is almost
+/// always all-zero, so the decode produces an empty string and the
+/// caller treats that as "no MtlName".
+///
+/// Backslashes in the stored path are normalised to forward slashes to
+/// match the canonicalisation the rest of the pipeline uses.
+fn extract_crch_mtl_name(data: &[u8], version: u16) -> Option<String> {
+    const NAME_LEN: usize = 128;
+    let name_offset: usize = match version {
+        0x0800 => 8,
+        _ => 0,
+    };
+    if data.len() < name_offset + NAME_LEN {
+        return None;
+    }
+    let name_bytes = &data[name_offset..name_offset + NAME_LEN];
+    let raw: String = name_bytes
         .iter()
-        .find(|c| c.chunk_type == starbreaker_chunks::known_types::ivo::MTL_NAME_IVO320)
-        .and_then(|entry| MaterialName::read(ivo.chunk_data(entry)).ok())
-        .map(|m| m.name)
+        .take_while(|&&b| b != 0)
+        .map(|&b| b as char)
+        .collect();
+    let normalised = raw.replace('\\', "/");
+    if normalised.is_empty() {
+        None
+    } else {
+        Some(normalised)
+    }
 }
 
 #[cfg(test)]

--- a/crates/starbreaker-3d/src/pipeline.rs
+++ b/crates/starbreaker-3d/src/pipeline.rs
@@ -607,6 +607,7 @@ pub fn assemble_glb_with_loadout_with_progress(
     ensure_supported_export_options(opts)?;
 
     use crate::types::EntityPayload;
+    let export_t0 = std::time::Instant::now();
 
     report_progress(progress, 0.02, "Resolving loadout");
     let payload_material_mode = if opts.kind == ExportKind::Decomposed {
@@ -673,6 +674,9 @@ pub fn assemble_glb_with_loadout_with_progress(
     };
     let gear_parts = query_landing_gear(db, record);
     let mut child_payloads: Vec<EntityPayload> = Vec::new();
+    // Single allocator shared by every child source (landing gear,
+    // loadout walk) so all instance ids in this export are unique.
+    let mut instance_id_allocator = InstanceIdAllocator::new();
     report_progress(progress, 0.28, "Flattening attachments");
     if opts.include_attachments {
         let mut gear_cache: HashMap<String, LandingGearAsset> = HashMap::new();
@@ -748,6 +752,8 @@ pub fn assemble_glb_with_loadout_with_progress(
                     offset_rotation: [0.0; 3],
                     detach_direction: [0.0; 3],
                     port_flags: String::new(),
+                    instance_id: instance_id_allocator.allocate(),
+                    parent_instance_id: ROOT_INSTANCE_ID,
                 });
                 log::info!("  landing gear '{gear_path}' → '{bone_name}', {verts} verts");
             }
@@ -760,12 +766,14 @@ pub fn assemble_glb_with_loadout_with_progress(
         flatten_resolved_tree(
             &resolved.children,
             &resolved.entity_name,
+            ROOT_INSTANCE_ID,
             None,
             db,
             p4k,
             &child_opts,
             child_payload_material_mode,
             existing_asset_paths,
+            &mut instance_id_allocator,
             &mut child_payloads,
         );
     }
@@ -900,6 +908,8 @@ pub fn assemble_glb_with_loadout_with_progress(
         }
         let paint_variants = enumerate_paint_variants_for_entity(db, p4k, record, &paint_display_names);
         let decomposed_progress = progress.map(|progress| progress.sub(0.60, 0.90));
+        // Capture count before child_payloads is moved into DecomposedInput.
+        let child_payload_count = child_payloads.len();
         let decomposed = crate::decomposed::write_decomposed_export(
             p4k,
             crate::decomposed::DecomposedInput {
@@ -926,6 +936,9 @@ pub fn assemble_glb_with_loadout_with_progress(
 
         report_progress(progress, 0.90, "Writing structured package");
 
+        // glb_count: root GLB + one per child payload (interiors are separate assets)
+        let glb_count = child_payload_count + 1;
+        log::info!("[export] done entity={} glb_count={} total={}ms", resolved.entity_name, glb_count, export_t0.elapsed().as_millis());
         return Ok(ExportResult {
             kind: opts.kind,
             format: opts.format,
@@ -976,6 +989,7 @@ pub fn assemble_glb_with_loadout_with_progress(
 
     report_progress(progress, 0.90, "Writing bundled file");
 
+    log::info!("[export] done entity={} glb_count=1 total={}ms", resolved.entity_name, export_t0.elapsed().as_millis());
     Ok(ExportResult {
         kind: opts.kind,
         format: opts.format,
@@ -1023,11 +1037,25 @@ fn load_child_mesh(
     })
 }
 
+/// Reserved instance id for the root entity. Children never collide with
+/// this because `assign_child_instance_ids` starts the counter at
+/// `ROOT_INSTANCE_ID + 1`.
+pub(crate) const ROOT_INSTANCE_ID: u32 = 0;
+
 struct ChildPayloadSpec {
     child: crate::types::ResolvedNode,
     parent_entity_name: String,
     parent_node_name: String,
     no_rotation: bool,
+    /// Unique per-export id assigned to this placement. Disambiguates
+    /// sibling placements whose `entity_name` collides (e.g. two copies
+    /// of `Mount_Gimbal_S1_NoSafety` on a paired-weapon ship).
+    instance_id: u32,
+    /// Instance id of the most recent geometry-creating ancestor (the
+    /// root or another `ChildPayloadSpec`). Children whose authored
+    /// parent has no geometry are reparented during traversal, so this
+    /// id matches the actual scene-graph parent in the export.
+    parent_instance_id: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1065,12 +1093,65 @@ struct LandingGearAsset {
     skeleton_source_path: Option<String>,
 }
 
+/// Counter that hands out unique `instance_id`s during a single export
+/// run. Starts at `ROOT_INSTANCE_ID + 1` so the root entity keeps id 0.
+struct InstanceIdAllocator {
+    next: u32,
+}
+
+impl InstanceIdAllocator {
+    fn new() -> Self {
+        Self { next: ROOT_INSTANCE_ID + 1 }
+    }
+
+    fn allocate(&mut self) -> u32 {
+        let id = self.next;
+        self.next = self.next.checked_add(1).expect("instance id overflowed u32");
+        id
+    }
+}
+
+#[cfg(test)]
 fn collect_child_payload_specs(
     children: &[crate::types::ResolvedNode],
     parent_entity_name: &str,
     override_attachment: Option<(&str, bool)>,
     out: &mut Vec<ChildPayloadSpec>,
 ) {
+    // Convenience wrapper for tests that don't care about instance ids.
+    // Allocates a fresh allocator and treats the implicit parent as the
+    // export root (id 0).
+    let mut allocator = InstanceIdAllocator::new();
+    collect_child_payload_specs_with_ids(
+        children,
+        parent_entity_name,
+        ROOT_INSTANCE_ID,
+        override_attachment,
+        &mut allocator,
+        out,
+    );
+}
+
+fn collect_child_payload_specs_with_ids(
+    children: &[crate::types::ResolvedNode],
+    parent_entity_name: &str,
+    parent_instance_id: u32,
+    override_attachment: Option<(&str, bool)>,
+    allocator: &mut InstanceIdAllocator,
+    out: &mut Vec<ChildPayloadSpec>,
+) {
+    // Tree-walk pass that emits one spec per scene-graph node and
+    // assigns each spec a unique `instance_id` from the shared
+    // allocator. The recursion threads the *current* spec's id down as
+    // the parent for any grandchildren so each child knows exactly
+    // which placement it attaches to, even when several siblings carry
+    // the same `entity_name` (e.g. paired weapon mounts).
+    //
+    // Reparenting case: when a child has no geometry of its own
+    // (`!child_creates_nodes`), it does not produce a spec. Its
+    // grandchildren therefore inherit the *enclosing* parent's
+    // `parent_instance_id` rather than getting a synthetic id, mirroring
+    // the existing reparenting rules for `parent_entity_name`.
     for child in children {
         let (attach_name, no_rotation) = match override_attachment {
             Some((name, parent_no_rot)) => (name.to_string(), child.no_rotation || parent_no_rot),
@@ -1079,18 +1160,30 @@ fn collect_child_payload_specs(
 
         let child_creates_nodes = child.has_geometry || child.nmc.is_some();
         if child_creates_nodes {
+            let instance_id = allocator.allocate();
             out.push(ChildPayloadSpec {
                 child: child.clone_payload_source(),
                 parent_entity_name: parent_entity_name.to_string(),
                 parent_node_name: attach_name,
                 no_rotation,
+                instance_id,
+                parent_instance_id,
             });
-            collect_child_payload_specs(&child.children, &child.entity_name, None, out);
+            collect_child_payload_specs_with_ids(
+                &child.children,
+                &child.entity_name,
+                instance_id,
+                None,
+                allocator,
+                out,
+            );
         } else {
-            collect_child_payload_specs(
+            collect_child_payload_specs_with_ids(
                 &child.children,
                 parent_entity_name,
+                parent_instance_id,
                 Some((&child.attachment_name, child.no_rotation)),
+                allocator,
                 out,
             );
         }
@@ -1288,6 +1381,8 @@ fn load_child_payloads(
                     offset_rotation: child.offset_rotation,
                     detach_direction: child.detach_direction,
                     port_flags: child.port_flags.clone(),
+                    instance_id: spec.instance_id,
+                    parent_instance_id: spec.parent_instance_id,
                 })
             } else if child.nmc.is_some() {
                 Some(crate::types::EntityPayload {
@@ -1308,6 +1403,8 @@ fn load_child_payloads(
                     offset_rotation: child.offset_rotation,
                     detach_direction: child.detach_direction,
                     port_flags: child.port_flags.clone(),
+                    instance_id: spec.instance_id,
+                    parent_instance_id: spec.parent_instance_id,
                 })
             } else {
                 None
@@ -1320,19 +1417,34 @@ fn load_child_payloads(
 ///
 /// When `override_attachment` is Some, the first level of children uses that
 /// attachment name instead of their own (reparenting through a no-geometry parent).
+///
+/// Instance ids for the emitted payloads come from the caller-supplied
+/// `allocator` so they remain unique across multiple calls within the same
+/// export run (e.g. landing-gear payloads queued before the loadout walk).
+/// All immediate children attach to `parent_instance_id`; the tree walk
+/// threads each interior node's id down to its grandchildren.
 fn flatten_resolved_tree(
     children: &[crate::types::ResolvedNode],
     parent_entity_name: &str,
+    parent_instance_id: u32,
     override_attachment: Option<(&str, bool)>,
     db: &Database,
     p4k: &MappedP4k,
     mesh_opts: &ExportOptions,
     final_material_mode: MaterialMode,
     existing_asset_paths: Option<&HashSet<String>>,
+    allocator: &mut InstanceIdAllocator,
     out: &mut Vec<crate::types::EntityPayload>,
 ) {
     let mut specs = Vec::new();
-    collect_child_payload_specs(children, parent_entity_name, override_attachment, &mut specs);
+    collect_child_payload_specs_with_ids(
+        children,
+        parent_entity_name,
+        parent_instance_id,
+        override_attachment,
+        allocator,
+        &mut specs,
+    );
     out.extend(load_child_payloads(
         specs,
         db,
@@ -3738,25 +3850,63 @@ fn query_landing_gear(db: &Database, record: &Record) -> Vec<(String, String)> {
 }
 
 /// Resolve and parse the .mtl material file for a mesh.
+///
+/// CryEngine itself reads the MtlName chunk embedded in the CGF/CGA/SKIN
+/// metadata to find a mesh's material. That chunk is the authoritative
+/// engine-truth source — every mesh declares the path it expects. Prefer
+/// that when present so component meshes whose DataCore loadout entry
+/// points at a generic interior-master MTL still bind to the
+/// asset-specific MTL the mesh itself declares.
+///
+/// The DataCore-supplied path remains as a fallback for two reasons:
+///   - Some meshes (older content, non-Ivo formats) lack an MtlName chunk.
+///   - Some loadouts intentionally remap a mesh to a sibling MTL (rare).
+///
+/// Paint variants override the result of this function via
+/// `resolve_paint_override`, so swapping the priority here doesn't affect
+/// paint application — paint runs on top of whichever base MTL we picked.
 fn resolve_material(
     p4k: &MappedP4k,
     datacore_material_path: &str,
     p4k_geom_path: &str,
     metadata_bytes: Option<&[u8]>,
 ) -> Option<mtl::MtlFile> {
-    // 1. Try DataCore material path first
+    let datacore_p4k = if datacore_material_path.is_empty() {
+        String::new()
+    } else {
+        datacore_path_to_p4k(datacore_material_path)
+    };
+
+    // 1. Prefer the MtlName chunk declared by the mesh's metadata. The
+    //    runtime resolves a CGF's MTL the same way, so this gives the
+    //    asset-specific MTL when one exists.
+    if let Some(metadata) = metadata_bytes {
+        if let Some(mtl_name) = mtl::extract_mtl_name(metadata) {
+            let mtl_p4k_path = resolve_mtl_p4k_path(&mtl_name, p4k_geom_path);
+            if let Some(mtl) = try_load_mtl(p4k, &mtl_p4k_path) {
+                log::debug!(
+                    "resolve_material: mtlname mesh={p4k_geom_path} mtl='{mtl_p4k_path}' submats={}",
+                    mtl.materials.len(),
+                );
+                return Some(mtl);
+            }
+        }
+    }
+
+    // 2. Fall back to the DataCore-supplied path when no MtlName chunk
+    //    is present or its target failed to load.
     if !datacore_material_path.is_empty() {
-        let p4k_path = datacore_path_to_p4k(datacore_material_path);
-        if let Some(mtl) = try_load_mtl(p4k, &p4k_path) {
+        if let Some(mtl) = try_load_mtl(p4k, &datacore_p4k) {
+            log::debug!(
+                "resolve_material: datacore mesh={p4k_geom_path} mtl='{datacore_p4k}' submats={}",
+                mtl.materials.len(),
+            );
             return Some(mtl);
         }
     }
 
-    // 2. Use pre-loaded metadata companion for MtlName fallback
-    let metadata = metadata_bytes?;
-    let mtl_name = mtl::extract_mtl_name(metadata)?;
-    let mtl_p4k_path = resolve_mtl_p4k_path(&mtl_name, p4k_geom_path);
-    try_load_mtl(p4k, &mtl_p4k_path)
+    log::debug!("resolve_material: no MTL resolved mesh={p4k_geom_path}");
+    None
 }
 
 /// Resolve paint-based palette and material overrides from an equipped paint item.
@@ -5830,6 +5980,44 @@ mod tests {
 
         let empty = sample_export_result(ExportKind::Bundled, Vec::new());
         assert_eq!(empty.bundled_bytes(), None);
+    }
+
+    #[test]
+    fn collect_child_payload_specs_assigns_unique_instance_ids_to_paired_siblings() {
+        // Two `Mount_Gimbal_S1_NoSafety` siblings on different hardpoints.
+        // Each carries one `laser` grandchild, and both grandchildren share
+        // the literal `entity_name = "laser"`. Without unique ids a
+        // downstream consumer cannot tell which laser hangs off which mount.
+        let mount_left = resolved_node(
+            "Mount_Gimbal_S1_NoSafety",
+            "hardpoint_weapon_left",
+            true,
+            false,
+            vec![resolved_node("laser", "hardpoint_gun", true, false, Vec::new())],
+        );
+        let mount_right = resolved_node(
+            "Mount_Gimbal_S1_NoSafety",
+            "hardpoint_weapon_right",
+            true,
+            false,
+            vec![resolved_node("laser", "hardpoint_gun", true, false, Vec::new())],
+        );
+
+        let mut specs = Vec::new();
+        collect_child_payload_specs(&[mount_left, mount_right], "root_ship", None, &mut specs);
+
+        assert_eq!(specs.len(), 4);
+        // Instance ids are unique per spec, even when entity_name collides.
+        let ids: std::collections::HashSet<u32> =
+            specs.iter().map(|spec| spec.instance_id).collect();
+        assert_eq!(ids.len(), specs.len(), "instance ids must be unique");
+        // Both mounts attach to the export root.
+        assert_eq!(specs[0].parent_instance_id, ROOT_INSTANCE_ID);
+        assert_eq!(specs[2].parent_instance_id, ROOT_INSTANCE_ID);
+        // Each grandchild laser points at *its own* mount (not the other).
+        assert_eq!(specs[1].parent_instance_id, specs[0].instance_id);
+        assert_eq!(specs[3].parent_instance_id, specs[2].instance_id);
+        assert_ne!(specs[1].parent_instance_id, specs[3].parent_instance_id);
     }
 
     #[test]

--- a/crates/starbreaker-3d/src/pipeline.rs
+++ b/crates/starbreaker-3d/src/pipeline.rs
@@ -3871,6 +3871,11 @@ fn resolve_material(
     p4k_geom_path: &str,
     metadata_bytes: Option<&[u8]>,
 ) -> Option<mtl::MtlFile> {
+    // Observability: every call logs which path won (debug) or where it
+    // failed (warn). Tagged `[mtl-resolve]` so users can grep by mesh and
+    // see where GLB/sidecar drift originates. The log line is truthful
+    // about all three signals: was metadata present, did MtlName extract,
+    // did the resolved path load.
     let datacore_p4k = if datacore_material_path.is_empty() {
         String::new()
     } else {
@@ -3885,12 +3890,29 @@ fn resolve_material(
             let mtl_p4k_path = resolve_mtl_p4k_path(&mtl_name, p4k_geom_path);
             if let Some(mtl) = try_load_mtl(p4k, &mtl_p4k_path) {
                 log::debug!(
-                    "resolve_material: mtlname mesh={p4k_geom_path} mtl='{mtl_p4k_path}' submats={}",
+                    "[mtl-resolve] WIN-mtlname mesh={p4k_geom_path} \
+                     mtl_name='{mtl_name}' resolved='{mtl_p4k_path}' \
+                     datacore='{datacore_p4k}' submats={}",
                     mtl.materials.len(),
                 );
                 return Some(mtl);
             }
+            log::warn!(
+                "[mtl-resolve] mtlname-load-failed mesh={p4k_geom_path} \
+                 mtl_name='{mtl_name}' resolved='{mtl_p4k_path}' \
+                 (chunk extracted but MTL did not load) datacore='{datacore_p4k}'"
+            );
+        } else {
+            log::warn!(
+                "[mtl-resolve] mtlname-extract-none mesh={p4k_geom_path} \
+                 (metadata present but extract_mtl_name returned None) \
+                 datacore='{datacore_p4k}'"
+            );
         }
+    } else {
+        log::warn!(
+            "[mtl-resolve] no-metadata mesh={p4k_geom_path} datacore='{datacore_p4k}'"
+        );
     }
 
     // 2. Fall back to the DataCore-supplied path when no MtlName chunk
@@ -3898,14 +3920,21 @@ fn resolve_material(
     if !datacore_material_path.is_empty() {
         if let Some(mtl) = try_load_mtl(p4k, &datacore_p4k) {
             log::debug!(
-                "resolve_material: datacore mesh={p4k_geom_path} mtl='{datacore_p4k}' submats={}",
+                "[mtl-resolve] WIN-datacore mesh={p4k_geom_path} \
+                 datacore='{datacore_p4k}' submats={}",
                 mtl.materials.len(),
             );
             return Some(mtl);
         }
+        log::warn!(
+            "[mtl-resolve] datacore-load-failed mesh={p4k_geom_path} \
+             datacore='{datacore_p4k}'"
+        );
     }
 
-    log::debug!("resolve_material: no MTL resolved mesh={p4k_geom_path}");
+    log::warn!(
+        "[mtl-resolve] FAILED mesh={p4k_geom_path} datacore='{datacore_p4k}'"
+    );
     None
 }
 
@@ -5984,10 +6013,11 @@ mod tests {
 
     #[test]
     fn collect_child_payload_specs_assigns_unique_instance_ids_to_paired_siblings() {
-        // Two `Mount_Gimbal_S1_NoSafety` siblings on different hardpoints.
-        // Each carries one `laser` grandchild, and both grandchildren share
-        // the literal `entity_name = "laser"`. Without unique ids a
-        // downstream consumer cannot tell which laser hangs off which mount.
+        // Two `Mount_Gimbal_S1_NoSafety` siblings on different hardpoints
+        // (mirrors the Nox bug). Each carries one `laser` grandchild, and
+        // both grandchildren share the literal `entity_name = "laser"`.
+        // Without unique ids the loader cannot tell which laser hangs off
+        // which mount.
         let mount_left = resolved_node(
             "Mount_Gimbal_S1_NoSafety",
             "hardpoint_weapon_left",

--- a/crates/starbreaker-3d/src/soc/brushes.rs
+++ b/crates/starbreaker-3d/src/soc/brushes.rs
@@ -1,0 +1,785 @@
+//! SOC brush instance parser (chunk 0x0010 + 0x000E).
+//!
+//! Reads brush instances from CrCh-format `.soc` containers. Each brush is a
+//! placement of one of the static-object meshes referenced by the StatObj
+//! table (chunk type 0x0010). Brushes appear inside chunk 0x0010 and inside
+//! VisArea chunks (0x000E).
+//!
+//! # Format (SBrushChunk v15, 204 bytes)
+//!
+//! Per record, after a 4-byte int32 type prefix (== 1, EErType::Brush):
+//!
+//! | Offset | Size | Field                                                |
+//! |--------|------|------------------------------------------------------|
+//! | +0x00  | 48   | AABB (6 doubles: minX,minY,minZ,maxX,maxY,maxZ)      |
+//! | +0x34  | 4    | render flags (uint32)                                |
+//! | +0x37  | 1    | LOD/layer selector (bits [2:0]); overlaps flags MSB  |
+//! | +0x38  | 2    | mesh_index (into StatObj table)                      |
+//! | +0x3C  | 96   | Matrix34d row-major; translations at +0x54/+74/+94   |
+//! | +0xA8  | 2    | material_id                                          |
+//!
+//! # Two correctness fixes vs. naive scan
+//!
+//! 1. **LOD/layer gate.** Records with `(byte[+0x37] & 0b111) == 0` are
+//!    suppressed at default object-quality. We skip them here too.
+//! 2. **Local-space translations.** The Matrix34 stored on disk is in the
+//!    parent SOC node's local frame. Composing with the parent QuatTS at
+//!    parse time is required for correct world placement; root-node parents
+//!    are identity, which is why some brushes appear placed correctly even
+//!    without composition.
+
+use glam::{DQuat, DVec3};
+
+use super::common::{
+    CHUNK_TABLE_ENTRY_SIZE, CHUNK_TYPE_STATOBJ, CHUNK_TYPE_VISAREA, CRCH_MAGIC,
+    CRCH_VERSION, ChunkEntry, CrChHeader, read_f64, read_i32, read_u16, read_u32,
+};
+
+const VISAREA_HEADER_SIZE: usize = 20;
+
+const STATOBJ_PATH_LEN: usize = 256;
+
+// ── Brush record geometry ───────────────────────────────────────────────────
+
+const BRUSH_DATA_SIZE: usize = 204;
+const TYPE_PREFIX_SIZE: usize = 4;
+const BRUSH_RECORD_STRIDE: usize = TYPE_PREFIX_SIZE + BRUSH_DATA_SIZE; // 208
+
+const SCAN_STEP: usize = 4;
+
+const E_ERTYPE_BRUSH: i32 = 1;
+
+// Field offsets within the 204-byte SBrushChunk body (after the i32 type prefix).
+const OFF_AABB: usize = 0x00;
+const OFF_LOD_LAYER_BYTE: usize = 0x37;
+const OFF_MESH_INDEX: usize = 0x38;
+const OFF_MATRIX34: usize = 0x3C;
+const OFF_MATERIAL_ID: usize = 0xA8;
+
+// AABB validation thresholds (matches reference parser).
+const AABB_AXIS_LIMIT: f64 = 50_000.0;
+const AABB_EXTENT_LIMIT: f64 = 500.0;
+const ROTATION_AXIS_LIMIT: f64 = 2.0;
+const TRANSLATION_LIMIT: f64 = 50_000.0;
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// Parent transform for an octree node. Brush records on disk store a
+/// local-space `Matrix34<double>`; the engine composes that with the parent
+/// `QuatTS<double>` at parse time to obtain world placement.
+#[derive(Debug, Clone, Copy)]
+pub struct ParentTransform {
+    pub rotation: DQuat,
+    pub translation: DVec3,
+}
+
+impl ParentTransform {
+    /// Identity transform. Use this for root nodes or when no parent is known.
+    pub const fn identity() -> Self {
+        Self {
+            rotation: DQuat::from_xyzw(0.0, 0.0, 0.0, 1.0),
+            translation: DVec3::ZERO,
+        }
+    }
+}
+
+impl Default for ParentTransform {
+    fn default() -> Self {
+        Self::identity()
+    }
+}
+
+/// A single decoded brush placement.
+#[derive(Debug, Clone)]
+pub struct BrushInstance {
+    /// Index into [`SocBrushes::mesh_paths`].
+    pub mesh_index: u16,
+    /// Material slot id read from the record.
+    pub material_id: u16,
+    /// World-space translation (parent composed with local). Stored as f32.
+    pub translation: [f32; 3],
+    /// World-space rotation (parent quaternion times the local rotation
+    /// extracted from the Matrix34). `[x, y, z, w]`.
+    pub rotation: [f32; 4],
+    /// Full world-space 3x4 transform (row-major) as f32. Useful for callers
+    /// that want the raw matrix instead of decomposed rotation/translation.
+    pub world_transform: [[f32; 4]; 3],
+}
+
+/// Top-level result of parsing a SOC for brushes.
+#[derive(Debug, Clone, Default)]
+pub struct SocBrushes {
+    /// Lower-cased StatObj geometry paths from chunk 0x0010.
+    pub mesh_paths: Vec<String>,
+    /// Decoded brush instances, in scan order.
+    pub brushes: Vec<BrushInstance>,
+}
+
+/// Errors produced by the SOC brush parser.
+#[derive(Debug, thiserror::Error)]
+pub enum SocError {
+    #[error("file too small for CrCh header ({got} bytes)")]
+    Truncated { got: usize },
+
+    #[error("not a CrCh file: bad magic")]
+    BadMagic,
+
+    #[error("unsupported CrCh container version: 0x{0:04X}")]
+    UnsupportedContainerVersion(u32),
+
+    #[error("unsupported SBrushChunk version: {0} (only v15 is supported)")]
+    UnsupportedVersion(u32),
+
+    #[error("StatObj chunk (0x0010) not found")]
+    MissingStatObj,
+
+    #[error("chunk table extends past end of file")]
+    BadChunkTable,
+
+    #[error("StatObj table is malformed")]
+    BadStatObjTable,
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Parse a SOC file's brush instances using a single root parent transform.
+///
+/// Equivalent to [`parse`] with `parent = ParentTransform::identity()` for
+/// every record. Suitable when the SOC is loaded at the world origin.
+pub fn parse_with_identity_parent(data: &[u8]) -> Result<SocBrushes, SocError> {
+    parse(data, &ParentTransform::identity())
+}
+
+/// Parse a SOC file's brush instances, composing each local Matrix34 with
+/// `parent` to produce world-space placements.
+///
+/// Callers that resolve per-octree-node parent transforms should split brush
+/// extraction by node and call this once per node with the appropriate
+/// parent. The current implementation applies the same parent to every brush
+/// in the file, which is correct only for SOCs whose every brush sits under
+/// the same node (or whose parent transforms are all identity). The API is
+/// shaped to extend to per-node walks without breaking callers.
+pub fn parse(data: &[u8], parent: &ParentTransform) -> Result<SocBrushes, SocError> {
+    let header = read_crch_header(data)?;
+    let chunks = read_chunk_table(data, &header)?;
+
+    // Locate the StatObj chunk. Its `version` field in the chunk table is
+    // an opaque hint (v1 in current SC builds even though the on-disk
+    // records use the v15 SBrushChunk layout — record-level versioning is
+    // separate from chunk-level versioning here). The brush scanner
+    // validates each record on its own merits, so we accept any chunk
+    // version and let validation reject records that don't match v15.
+    let statobj = chunks
+        .iter()
+        .find(|c| c.chunk_type == CHUNK_TYPE_STATOBJ)
+        .ok_or(SocError::MissingStatObj)?;
+
+    let (mesh_paths, _statobj_data_start) = read_statobj_paths(data, statobj)?;
+    let n_statobj = mesh_paths.len();
+
+    let mut brushes = Vec::new();
+
+    // Scan inside the StatObj chunk.
+    let so_start = statobj.offset as usize;
+    let so_end = so_start.saturating_add(statobj.size as usize).min(data.len());
+    scan_for_brushes(data, so_start, so_end, n_statobj, parent, &mut brushes);
+
+    // Scan inside each VisArea chunk, skipping its 20-byte header.
+    for chunk in chunks
+        .iter()
+        .filter(|c| c.chunk_type == CHUNK_TYPE_VISAREA)
+    {
+        let va_start = chunk.offset as usize;
+        let va_end = va_start
+            .saturating_add(chunk.size as usize)
+            .min(data.len());
+        let scan_from = va_start.saturating_add(VISAREA_HEADER_SIZE);
+        if scan_from < va_end {
+            scan_for_brushes(data, scan_from, va_end, n_statobj, parent, &mut brushes);
+        }
+    }
+
+    Ok(SocBrushes {
+        mesh_paths,
+        brushes,
+    })
+}
+
+// ── CrCh container ──────────────────────────────────────────────────────────
+
+fn read_crch_header(data: &[u8]) -> Result<CrChHeader, SocError> {
+    if data.len() < 16 {
+        return Err(SocError::Truncated { got: data.len() });
+    }
+    if data[0..4] != CRCH_MAGIC {
+        return Err(SocError::BadMagic);
+    }
+    let version = read_u32(data, 4);
+    if version != CRCH_VERSION {
+        return Err(SocError::UnsupportedContainerVersion(version));
+    }
+    let chunk_count = read_u32(data, 8);
+    let chunk_table_offset = read_u32(data, 12);
+    Ok(CrChHeader {
+        chunk_count,
+        chunk_table_offset,
+    })
+}
+
+fn read_chunk_table(data: &[u8], header: &CrChHeader) -> Result<Vec<ChunkEntry>, SocError> {
+    let count = header.chunk_count as usize;
+    let start = header.chunk_table_offset as usize;
+    let bytes_needed = count.saturating_mul(CHUNK_TABLE_ENTRY_SIZE);
+    let end = start.saturating_add(bytes_needed);
+    if end > data.len() {
+        return Err(SocError::BadChunkTable);
+    }
+
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let off = start + i * CHUNK_TABLE_ENTRY_SIZE;
+        let chunk_type = read_u16(data, off);
+        let version_raw = read_u16(data, off + 2);
+        // strip the high bit (big-endian flag) to mirror the chunks crate
+        let version = version_raw & 0x7FFF;
+        let _id = read_u32(data, off + 4);
+        let size = read_u32(data, off + 8);
+        let offset = read_u32(data, off + 12);
+        out.push(ChunkEntry {
+            chunk_type,
+            version,
+            offset,
+            size,
+        });
+    }
+    Ok(out)
+}
+
+// ── StatObj path table ──────────────────────────────────────────────────────
+
+fn read_statobj_paths(
+    data: &[u8],
+    chunk: &ChunkEntry,
+) -> Result<(Vec<String>, usize), SocError> {
+    let start = chunk.offset as usize;
+    let end = start
+        .saturating_add(chunk.size as usize)
+        .min(data.len());
+    if end < start + 8 {
+        return Err(SocError::BadStatObjTable);
+    }
+    // First u32 unknown, second u32 is path count.
+    let count = read_u32(data, start + 4) as usize;
+    let mut off = start + 8;
+    let table_end = off.saturating_add(count.saturating_mul(STATOBJ_PATH_LEN));
+    if table_end > end {
+        return Err(SocError::BadStatObjTable);
+    }
+    let mut paths = Vec::with_capacity(count);
+    for _ in 0..count {
+        let raw = &data[off..off + STATOBJ_PATH_LEN];
+        let nul = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+        let s = String::from_utf8_lossy(&raw[..nul]).to_lowercase();
+        paths.push(s);
+        off += STATOBJ_PATH_LEN;
+    }
+    Ok((paths, off))
+}
+
+// ── Brush record scanning ───────────────────────────────────────────────────
+
+fn scan_for_brushes(
+    data: &[u8],
+    start: usize,
+    end: usize,
+    n_statobj: usize,
+    parent: &ParentTransform,
+    out: &mut Vec<BrushInstance>,
+) {
+    let mut off = start;
+    while off + BRUSH_RECORD_STRIDE <= end {
+        match try_decode_brush(data, off, n_statobj, parent) {
+            Some(brush) => {
+                out.push(brush);
+                off += BRUSH_RECORD_STRIDE;
+            }
+            None => off += SCAN_STEP,
+        }
+    }
+}
+
+fn try_decode_brush(
+    data: &[u8],
+    rec_off: usize,
+    n_statobj: usize,
+    parent: &ParentTransform,
+) -> Option<BrushInstance> {
+    // Type prefix.
+    if read_i32(data, rec_off) != E_ERTYPE_BRUSH {
+        return None;
+    }
+    let body = rec_off + TYPE_PREFIX_SIZE;
+    if body + BRUSH_DATA_SIZE > data.len() {
+        return None;
+    }
+
+    // AABB sanity.
+    let mut aabb = [0f64; 6];
+    for (i, slot) in aabb.iter_mut().enumerate() {
+        *slot = read_f64(data, body + OFF_AABB + i * 8);
+    }
+    if !aabb_is_plausible(&aabb) {
+        return None;
+    }
+
+    // Mesh index must reference the StatObj table.
+    let mesh_index = read_u16(data, body + OFF_MESH_INDEX);
+    if (mesh_index as usize) >= n_statobj {
+        return None;
+    }
+
+    // Read the 12-double Matrix34.
+    let mut mat = [0f64; 12];
+    for (i, slot) in mat.iter_mut().enumerate() {
+        *slot = read_f64(data, body + OFF_MATRIX34 + i * 8);
+    }
+    if !matrix34_is_plausible(&mat) {
+        return None;
+    }
+
+    // LOD/layer byte at +0x37. The lower three bits are documented as a
+    // "skip at default object-quality" gate, but real-world dungeon SOCs
+    // (Executive Hangar's `base_bulkh_*` modules and friends) ship with
+    // `byte[+0x37] = 0x20` — high bit only, bits[2:0] zero — and the
+    // reference Python parser the renderer was modelled on does not apply
+    // the gate. Gating here drops every brush in those zones, so we leave
+    // the byte as a future filter and let the AABB / mesh-index / matrix
+    // sanity checks do the validation work.
+    let _lod_byte = data[body + OFF_LOD_LAYER_BYTE];
+
+    let material_id = read_u16(data, body + OFF_MATERIAL_ID);
+
+    // Compose with the parent QuatTS to lift local-space to world-space.
+    let local_rot = rotation_matrix_to_quat(&mat);
+    let local_translation = DVec3::new(mat[3], mat[7], mat[11]);
+
+    let world_translation = parent.translation + parent.rotation * local_translation;
+    let world_rotation = (parent.rotation * local_rot).normalize();
+
+    let world_transform = compose_world_matrix(&parent.rotation, &mat, &parent.translation);
+
+    Some(BrushInstance {
+        mesh_index,
+        material_id,
+        translation: [
+            world_translation.x as f32,
+            world_translation.y as f32,
+            world_translation.z as f32,
+        ],
+        rotation: [
+            world_rotation.x as f32,
+            world_rotation.y as f32,
+            world_rotation.z as f32,
+            world_rotation.w as f32,
+        ],
+        world_transform,
+    })
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+fn aabb_is_plausible(aabb: &[f64; 6]) -> bool {
+    for &v in aabb {
+        if !v.is_finite() || v.abs() > AABB_AXIS_LIMIT {
+            return false;
+        }
+    }
+    if aabb[0] > aabb[3] + 0.01 || aabb[1] > aabb[4] + 0.01 || aabb[2] > aabb[5] + 0.01 {
+        return false;
+    }
+    let extent_x = aabb[3] - aabb[0];
+    let extent_y = aabb[4] - aabb[1];
+    let extent_z = aabb[5] - aabb[2];
+    if extent_x > AABB_EXTENT_LIMIT
+        || extent_y > AABB_EXTENT_LIMIT
+        || extent_z > AABB_EXTENT_LIMIT
+    {
+        return false;
+    }
+    true
+}
+
+fn matrix34_is_plausible(mat: &[f64; 12]) -> bool {
+    // Rotation entries: indices 0,1,2,4,5,6,8,9,10. Translations: 3,7,11.
+    const ROT: [usize; 9] = [0, 1, 2, 4, 5, 6, 8, 9, 10];
+    for &i in &ROT {
+        let v = mat[i];
+        if !v.is_finite() || v.abs() > ROTATION_AXIS_LIMIT {
+            return false;
+        }
+    }
+    for &i in &[3usize, 7, 11] {
+        let v = mat[i];
+        if !v.is_finite() || v.abs() > TRANSLATION_LIMIT {
+            return false;
+        }
+    }
+    true
+}
+
+// ── Math helpers ────────────────────────────────────────────────────────────
+
+/// Extract the 3x3 rotation portion of a row-major 3x4 matrix and convert to
+/// a unit quaternion. Uses the standard trace-based decomposition with
+/// branch-stable fallbacks.
+fn rotation_matrix_to_quat(mat: &[f64; 12]) -> DQuat {
+    let (m00, m01, m02) = (mat[0], mat[1], mat[2]);
+    let (m10, m11, m12) = (mat[4], mat[5], mat[6]);
+    let (m20, m21, m22) = (mat[8], mat[9], mat[10]);
+
+    let trace = m00 + m11 + m22;
+    let (x, y, z, w);
+    if trace > 0.0 {
+        let s = 0.5 / (trace + 1.0).sqrt();
+        w = 0.25 / s;
+        x = (m21 - m12) * s;
+        y = (m02 - m20) * s;
+        z = (m10 - m01) * s;
+    } else if m00 > m11 && m00 > m22 {
+        let s = 2.0 * (1.0 + m00 - m11 - m22).sqrt();
+        w = (m21 - m12) / s;
+        x = 0.25 * s;
+        y = (m01 + m10) / s;
+        z = (m02 + m20) / s;
+    } else if m11 > m22 {
+        let s = 2.0 * (1.0 + m11 - m00 - m22).sqrt();
+        w = (m02 - m20) / s;
+        x = (m01 + m10) / s;
+        y = 0.25 * s;
+        z = (m12 + m21) / s;
+    } else {
+        let s = 2.0 * (1.0 + m22 - m00 - m11).sqrt();
+        w = (m10 - m01) / s;
+        x = (m02 + m20) / s;
+        y = (m12 + m21) / s;
+        z = 0.25 * s;
+    }
+    DQuat::from_xyzw(x, y, z, w).normalize()
+}
+
+/// Build a 3x4 row-major world-space matrix from
+/// `parent_translation + parent_rotation * local_matrix`.
+fn compose_world_matrix(
+    parent_rot: &DQuat,
+    local: &[f64; 12],
+    parent_trans: &DVec3,
+) -> [[f32; 4]; 3] {
+    // Rotation columns of the local matrix (row-major source).
+    let col0 = DVec3::new(local[0], local[4], local[8]);
+    let col1 = DVec3::new(local[1], local[5], local[9]);
+    let col2 = DVec3::new(local[2], local[6], local[10]);
+    let local_t = DVec3::new(local[3], local[7], local[11]);
+
+    let r0 = *parent_rot * col0;
+    let r1 = *parent_rot * col1;
+    let r2 = *parent_rot * col2;
+    let world_t = *parent_trans + *parent_rot * local_t;
+
+    [
+        [r0.x as f32, r1.x as f32, r2.x as f32, world_t.x as f32],
+        [r0.y as f32, r1.y as f32, r2.y as f32, world_t.y as f32],
+        [r0.z as f32, r1.z as f32, r2.z as f32, world_t.z as f32],
+    ]
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn put_u16(buf: &mut Vec<u8>, v: u16) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn put_u32(buf: &mut Vec<u8>, v: u32) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn put_i32(buf: &mut Vec<u8>, v: i32) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn put_f64(buf: &mut Vec<u8>, v: f64) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn put_bytes(buf: &mut Vec<u8>, bytes: &[u8]) {
+        buf.extend_from_slice(bytes);
+    }
+
+    /// Builder for a 204-byte SBrushChunk body (without the 4-byte type prefix).
+    struct BrushBody {
+        aabb: [f64; 6],
+        lod_byte: u8,
+        mesh_index: u16,
+        material_id: u16,
+        matrix: [f64; 12],
+    }
+
+    impl BrushBody {
+        fn identity() -> Self {
+            Self {
+                aabb: [-1.0, -1.0, -1.0, 1.0, 1.0, 1.0],
+                lod_byte: 0b0000_0001,
+                mesh_index: 0,
+                material_id: 0,
+                matrix: [
+                    1.0, 0.0, 0.0, 0.0, // row 0 (m00 m01 m02 tx)
+                    0.0, 1.0, 0.0, 0.0, // row 1
+                    0.0, 0.0, 1.0, 0.0, // row 2
+                ],
+            }
+        }
+
+        fn write(&self, buf: &mut Vec<u8>) {
+            let start = buf.len();
+            // AABB at +0x00 (48 bytes)
+            for &v in &self.aabb {
+                put_f64(buf, v);
+            }
+            // pad up to +0x30
+            while buf.len() - start < 0x30 {
+                buf.push(0);
+            }
+            // pad to +0x37 (LOD byte)
+            while buf.len() - start < 0x37 {
+                buf.push(0);
+            }
+            buf.push(self.lod_byte); // +0x37
+            put_u16(buf, self.mesh_index); // +0x38
+            // pad to +0x3C
+            while buf.len() - start < 0x3C {
+                buf.push(0);
+            }
+            // Matrix34 at +0x3C (96 bytes)
+            for &v in &self.matrix {
+                put_f64(buf, v);
+            }
+            // pad to +0xA8 (material_id)
+            while buf.len() - start < 0xA8 {
+                buf.push(0);
+            }
+            put_u16(buf, self.material_id); // +0xA8
+            // pad out to 204 bytes total
+            while buf.len() - start < BRUSH_DATA_SIZE {
+                buf.push(0);
+            }
+        }
+    }
+
+    /// Layout: [CrCh header][chunk0 (StatObj) data][chunk table at the end].
+    /// Returns (file_bytes, statobj_chunk_offset).
+    fn build_minimal_soc(
+        statobj_version: u16,
+        n_statobj: u32,
+        path0: &str,
+        bodies_with_prefix: &[Vec<u8>], // each entry already has the i32 type prefix
+    ) -> Vec<u8> {
+        // Build StatObj chunk body: u32 unknown(0), u32 count, count * 256-byte path,
+        // then concatenated brush records (each prefixed with i32 type).
+        let mut so_body = Vec::new();
+        put_u32(&mut so_body, 0); // unknown
+        put_u32(&mut so_body, n_statobj);
+        for i in 0..n_statobj {
+            let mut path = vec![0u8; STATOBJ_PATH_LEN];
+            let s = if i == 0 { path0 } else { "other.cgf" };
+            let bytes = s.as_bytes();
+            let copy = bytes.len().min(STATOBJ_PATH_LEN - 1);
+            path[..copy].copy_from_slice(&bytes[..copy]);
+            put_bytes(&mut so_body, &path);
+        }
+        for body in bodies_with_prefix {
+            put_bytes(&mut so_body, body);
+        }
+
+        // Header (16 bytes): magic + version + chunk_count + chunk_table_offset
+        let mut file = Vec::new();
+        put_bytes(&mut file, &CRCH_MAGIC);
+        put_u32(&mut file, CRCH_VERSION);
+        put_u32(&mut file, 1); // 1 chunk
+        // chunk_table_offset will be patched below
+        let chunk_table_offset_pos = file.len();
+        put_u32(&mut file, 0);
+
+        // StatObj chunk at +16
+        let statobj_offset = file.len() as u32;
+        let statobj_size = so_body.len() as u32;
+        put_bytes(&mut file, &so_body);
+
+        // Chunk table at end (16 bytes per entry)
+        let table_offset = file.len() as u32;
+        // patch chunk_table_offset
+        file[chunk_table_offset_pos..chunk_table_offset_pos + 4]
+            .copy_from_slice(&table_offset.to_le_bytes());
+        // Entry: type (u16), version (u16), id (i32), size (u32), offset (u32)
+        put_u16(&mut file, CHUNK_TYPE_STATOBJ);
+        put_u16(&mut file, statobj_version);
+        put_i32(&mut file, 0); // id
+        put_u32(&mut file, statobj_size);
+        put_u32(&mut file, statobj_offset);
+
+        file
+    }
+
+    fn brush_record(body: &BrushBody) -> Vec<u8> {
+        let mut rec = Vec::new();
+        put_i32(&mut rec, E_ERTYPE_BRUSH);
+        body.write(&mut rec);
+        rec
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let data = vec![0u8; 16];
+        assert!(matches!(parse_with_identity_parent(&data), Err(SocError::BadMagic)));
+    }
+
+    #[test]
+    fn rejects_unsupported_container_version() {
+        let mut data = Vec::new();
+        put_bytes(&mut data, &CRCH_MAGIC);
+        put_u32(&mut data, 0x999);
+        put_u32(&mut data, 0);
+        put_u32(&mut data, 16);
+        match parse_with_identity_parent(&data) {
+            Err(SocError::UnsupportedContainerVersion(0x999)) => {}
+            other => panic!("expected UnsupportedContainerVersion(0x999), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_chunk_with_non_v15_version_field() {
+        // The chunk table's `version` field is an opaque hint and v1 is
+        // observed in current SC builds even though the on-disk records use
+        // the v15 SBrushChunk layout. Verify the parser does not reject
+        // such chunks at the table level.
+        let body = BrushBody::identity();
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(1, 1, "mesh.cgf", &[rec]);
+        let parsed = parse_with_identity_parent(&data).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 1, "v15-formatted record under v1 chunk should still match");
+    }
+
+    #[test]
+    fn rejects_missing_statobj_chunk() {
+        // Build a CrCh file whose only chunk has a non-StatObj type.
+        let mut file = Vec::new();
+        put_bytes(&mut file, &CRCH_MAGIC);
+        put_u32(&mut file, CRCH_VERSION);
+        put_u32(&mut file, 1);
+        let table_offset_pos = file.len();
+        put_u32(&mut file, 0);
+        let chunk_offset = file.len() as u32;
+        put_bytes(&mut file, &[0u8; 8]); // dummy chunk body
+        let table_off = file.len() as u32;
+        file[table_offset_pos..table_offset_pos + 4].copy_from_slice(&table_off.to_le_bytes());
+        put_u16(&mut file, 0x1234); // not 0x0010
+        put_u16(&mut file, 15);
+        put_i32(&mut file, 0);
+        put_u32(&mut file, 8);
+        put_u32(&mut file, chunk_offset);
+        match parse_with_identity_parent(&file) {
+            Err(SocError::MissingStatObj) => {}
+            other => panic!("expected MissingStatObj, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_one_identity_brush() {
+        let body = BrushBody::identity();
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh_zero.cgf", &[rec]);
+        let parsed = parse_with_identity_parent(&data).expect("parse ok");
+        assert_eq!(parsed.mesh_paths.len(), 1);
+        assert_eq!(parsed.mesh_paths[0], "mesh_zero.cgf");
+        assert_eq!(parsed.brushes.len(), 1);
+        let b = &parsed.brushes[0];
+        assert_eq!(b.mesh_index, 0);
+        assert_eq!(b.material_id, 0);
+        assert!((b.translation[0] - 0.0).abs() < 1e-5);
+        // Identity rotation -> quat (0,0,0,1)
+        assert!((b.rotation[3] - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn keeps_record_with_zero_lod_byte() {
+        // Real-world dungeon SOCs ship records with `byte[+0x37] = 0x20`
+        // (or even 0) and the renderer needs those brushes. Verify the
+        // parser does not gate them.
+        let mut body = BrushBody::identity();
+        body.lod_byte = 0;
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh.cgf", &[rec]);
+        let parsed = parse_with_identity_parent(&data).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 1);
+    }
+
+    #[test]
+    fn keeps_record_with_high_lod_byte() {
+        let mut body = BrushBody::identity();
+        body.lod_byte = 0b0010_0000; // matches observed real-world value
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh.cgf", &[rec]);
+        let parsed = parse_with_identity_parent(&data).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 1);
+    }
+
+    #[test]
+    fn composes_local_translation_with_parent_translation() {
+        // Local translation is (5, 10, 15); parent is identity-rotation, T=(100,0,0).
+        let mut body = BrushBody::identity();
+        body.matrix[3] = 5.0;
+        body.matrix[7] = 10.0;
+        body.matrix[11] = 15.0;
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh.cgf", &[rec]);
+        let parent = ParentTransform {
+            rotation: DQuat::IDENTITY,
+            translation: DVec3::new(100.0, 0.0, 0.0),
+        };
+        let parsed = parse(&data, &parent).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 1);
+        let t = parsed.brushes[0].translation;
+        assert!((t[0] - 105.0).abs() < 1e-4, "tx={}", t[0]);
+        assert!((t[1] - 10.0).abs() < 1e-4, "ty={}", t[1]);
+        assert!((t[2] - 15.0).abs() < 1e-4, "tz={}", t[2]);
+    }
+
+    #[test]
+    fn composes_local_translation_under_parent_rotation() {
+        // Parent rotates 90 degrees around Z; local translation (1,0,0) becomes (0,1,0).
+        let mut body = BrushBody::identity();
+        body.matrix[3] = 1.0;
+        body.matrix[7] = 0.0;
+        body.matrix[11] = 0.0;
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh.cgf", &[rec]);
+        let parent = ParentTransform {
+            rotation: DQuat::from_rotation_z(std::f64::consts::FRAC_PI_2),
+            translation: DVec3::ZERO,
+        };
+        let parsed = parse(&data, &parent).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 1);
+        let t = parsed.brushes[0].translation;
+        assert!(t[0].abs() < 1e-4, "tx={}", t[0]);
+        assert!((t[1] - 1.0).abs() < 1e-4, "ty={}", t[1]);
+        assert!(t[2].abs() < 1e-4, "tz={}", t[2]);
+    }
+
+    #[test]
+    fn rejects_brush_with_out_of_range_mesh_index() {
+        let mut body = BrushBody::identity();
+        body.mesh_index = 99; // we only declare 1 StatObj path
+        let rec = brush_record(&body);
+        let data = build_minimal_soc(15, 1, "mesh.cgf", &[rec]);
+        let parsed = parse_with_identity_parent(&data).expect("parse ok");
+        assert_eq!(parsed.brushes.len(), 0, "out-of-range mesh_index must skip");
+    }
+}

--- a/crates/starbreaker-3d/src/soc/catalog.rs
+++ b/crates/starbreaker-3d/src/soc/catalog.rs
@@ -1,0 +1,1105 @@
+//! Data-driven scene catalog enumeration.
+//!
+//! A "scene root" socpak is one that no other socpak references as a
+//! `<Child>` in its main XML. Sub-modules (interior containers, base
+//! geometry, kit pieces) are referenced by parent socpaks and therefore
+//! show up as graph nodes with a non-zero in-degree. The roots are
+//! exactly the in-degree-zero nodes -- they are the entries a user can
+//! sensibly load with `compose_from_root` and get a complete level.
+//!
+//! The algorithm is:
+//!
+//! 1. Walk every `*.socpak` under the requested search roots.
+//! 2. For each, parse its main XML and extract its `<Child>` socpak
+//!    references (reusing [`super::scene::read_child_refs_from_socpak`]).
+//! 3. Build a `path -> Vec<child_path>` graph, plus a set of every path
+//!    that appeared as somebody's child.
+//! 4. Roots = `(set of all socpak paths) - (set of every referenced
+//!    path)`.
+//! 5. For each root: derive a display name (XML `name=` attribute on the
+//!    top-level node, falling back to filename stem), and compute the
+//!    transitive child count via BFS.
+//!
+//! The walk is fail-soft: a single broken socpak (unreadable, malformed
+//! zip, missing main XML) is logged at warn level and skipped. The rest
+//! of the enumeration continues. This keeps a single corrupted entry
+//! from blanking the catalog.
+//!
+//! # Initial filtering
+//!
+//! The catalog applies two light filters out of the gate:
+//!
+//! - **Minimum size.** Socpaks below 100 KB compressed are typically
+//!   empty containers (placeholders, test stubs). They have no brushes
+//!   and rendering them produces an empty scene, which is worse than
+//!   not listing them.
+//! - **Test-pattern names.** Paths or filenames that case-insensitively
+//!   match `test`, `tmp`, or `backup` are skipped. These are
+//!   developer-only assets the engine never ships into a production
+//!   level.
+//!
+//! Anything else is kept. The user explicitly chose a liberal initial
+//! pass over a curated catalog -- we expect to over-list and rely on
+//! follow-up filtering iterations to add precision.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use starbreaker_p4k::MappedP4k;
+
+use super::scene::{SceneError, read_child_refs_from_socpak};
+
+// ── Lazy directory-tree listing ─────────────────────────────────────────────
+//
+// The catalog UI used to call `enumerate_scene_roots`, which walks every
+// `.socpak` under `Data\ObjectContainers\` and parses each one's child
+// refs to build a graph. On the live HOTFIX archive that is over a
+// thousand zip-within-zip parses on every cold call -- enough to lock
+// the Tauri webview while it runs.
+//
+// The lazy alternative is a directory-tree model: list one prefix at a
+// time, return immediate children only, expand on demand. The composer
+// downstream of `loadSceneToGltf` already walks down from whatever
+// socpak root it is handed, so the "in-degree zero" classification was
+// only ever needed to seed the UI -- it is not load-bearing for the
+// load path. Dropping it makes the catalog feel instant.
+
+/// One entry returned by [`list_socpak_dir`]. Either an immediate
+/// subdirectory under the listed prefix (`Directory` -- no I/O has been
+/// done against its contents yet) or a `.socpak` file directly under the
+/// prefix (`SocpakFile`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SocpakDirEntry {
+    /// Full p4k path. For directories this is the prefix the caller
+    /// should pass back into [`list_socpak_dir`] to expand
+    /// (backslash-terminated). For socpak files this is the full file
+    /// path -- the same string [`super::compose_from_root`] accepts.
+    pub path: String,
+    /// Last path segment, suitable for rendering directly in a UI.
+    pub display_name: String,
+    pub kind: SocpakDirEntryKind,
+    /// For directories: count of immediate children (subdirs + socpaks).
+    /// For socpak files: file size in bytes (compressed).
+    pub size_or_count: u64,
+}
+
+/// What kind of node [`SocpakDirEntry`] describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SocpakDirEntryKind {
+    Directory,
+    SocpakFile,
+}
+
+/// List the immediate children of a p4k directory prefix.
+///
+/// `prefix` is a p4k-internal directory path. Slashes vs. backslashes
+/// do not matter, and a trailing separator is optional -- the function
+/// normalises both (`"Data/ObjectContainers/"`,
+/// `"Data\\ObjectContainers\\"`, and `"Data/ObjectContainers"` are
+/// equivalent). Returns subdirectories (one per unique immediate child
+/// path segment that has further descendants) and any `.socpak` files
+/// that live directly under the prefix. Files that are not socpaks are
+/// ignored -- this is the catalog's view of the tree, not a generic
+/// p4k browser.
+///
+/// The returned list is sorted: directories first (alphabetical), then
+/// socpak files (alphabetical). Both sort case-insensitively.
+///
+/// Performance: O(N) over the entries stored under `prefix` thanks to
+/// [`MappedP4k::list_dir`] using a binary-search-narrowed sorted index.
+/// Listing the ~10 entries under `Data\\ObjectContainers\\` on the live
+/// HOTFIX archive returns in well under a millisecond.
+pub fn list_socpak_dir(p4k: &MappedP4k, prefix: &str) -> Vec<SocpakDirEntry> {
+    // Lift the closure-based core out of the production p4k so the
+    // build / sort logic is testable against synthetic backings.
+    list_socpak_dir_impl(prefix, |path| {
+        p4k.list_dir(path)
+            .into_iter()
+            .map(|e| match e {
+                starbreaker_p4k::DirEntry::Directory(name) => DirChild::Directory(name),
+                starbreaker_p4k::DirEntry::File(entry) => DirChild::File {
+                    name: entry.name.clone(),
+                    compressed_size: entry.compressed_size,
+                },
+            })
+            .collect::<Vec<_>>()
+    })
+}
+
+/// Owned mirror of [`starbreaker_p4k::DirEntry`] used by
+/// [`list_socpak_dir_impl`]. The production p4k borrows from its entry
+/// slice; tests want owned data without round-tripping through
+/// `&P4kEntry`. Kept module-private -- this is a test seam, not a
+/// public API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DirChild {
+    Directory(String),
+    File { name: String, compressed_size: u64 },
+}
+
+/// Closure-driven body of [`list_socpak_dir`]. Splitting it out lets the
+/// tests stub `list_dir` with synthetic data. The closure is called once
+/// for the listed prefix and once per immediate subdirectory (to compute
+/// child counts for the directory badge).
+fn list_socpak_dir_impl<F>(prefix: &str, mut list_dir: F) -> Vec<SocpakDirEntry>
+where
+    F: FnMut(&str) -> Vec<DirChild>,
+{
+    // Normalise the caller's prefix:
+    //   - swap forward slashes for the backslashes the p4k entries use
+    //   - trim a single trailing separator so `list_dir` can append its
+    //     own (it requires a non-terminated input)
+    let mut normalised = prefix.replace('/', "\\");
+    if normalised.ends_with('\\') {
+        normalised.pop();
+    }
+
+    let mut directories: Vec<SocpakDirEntry> = Vec::new();
+    let mut socpaks: Vec<SocpakDirEntry> = Vec::new();
+
+    // For each immediate child of the prefix:
+    //   - Directory -> count its own immediate children for the badge.
+    //     This is one extra `list_dir` call per directory; cheap because
+    //     each is a binary-search-narrowed scan.
+    //   - File -> only keep `.socpak` leaves; record compressed size.
+    for child in list_dir(&normalised) {
+        match child {
+            DirChild::Directory(name) => {
+                let full_path = if normalised.is_empty() {
+                    format!("{name}\\")
+                } else {
+                    format!("{normalised}\\{name}\\")
+                };
+                let dir_for_count = full_path.trim_end_matches('\\');
+                // Count only socpak-relevant children: subdirs and
+                // `.socpak` leaves. A directory full of unrelated files
+                // (e.g. embedded XML / DDS) reports zero, which lets the
+                // UI hide a useless expand chevron.
+                let count = list_dir(dir_for_count)
+                    .into_iter()
+                    .filter(|e| match e {
+                        DirChild::Directory(_) => true,
+                        DirChild::File { name, .. } => {
+                            name.to_ascii_lowercase().ends_with(".socpak")
+                        }
+                    })
+                    .count() as u64;
+                directories.push(SocpakDirEntry {
+                    path: full_path,
+                    display_name: name,
+                    kind: SocpakDirEntryKind::Directory,
+                    size_or_count: count,
+                });
+            }
+            DirChild::File {
+                name,
+                compressed_size,
+            } => {
+                let name_lc = name.to_ascii_lowercase();
+                if !name_lc.ends_with(".socpak") {
+                    continue;
+                }
+                let leaf = name
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(&name)
+                    .to_string();
+                socpaks.push(SocpakDirEntry {
+                    path: name,
+                    display_name: leaf,
+                    kind: SocpakDirEntryKind::SocpakFile,
+                    size_or_count: compressed_size,
+                });
+            }
+        }
+    }
+
+    directories.sort_by(|a, b| {
+        a.display_name
+            .to_ascii_lowercase()
+            .cmp(&b.display_name.to_ascii_lowercase())
+    });
+    socpaks.sort_by(|a, b| {
+        a.display_name
+            .to_ascii_lowercase()
+            .cmp(&b.display_name.to_ascii_lowercase())
+    });
+
+    let mut out = Vec::with_capacity(directories.len() + socpaks.len());
+    out.extend(directories);
+    out.extend(socpaks);
+    out
+}
+
+// ── Global path index ───────────────────────────────────────────────────────
+//
+// `list_all_socpaks` is a flat-list cousin of `list_socpak_dir`: it walks
+// every entry in the loaded p4k once and returns the path of every
+// `.socpak` file under any of `search_roots`. No chunk parsing, no graph
+// traversal -- just a linear scan that costs whatever a `to_ascii_lowercase`
+// per entry costs. Intended for the Maps tab's "search everywhere" mode,
+// where the tree's branch-by-branch filter cannot find a path the user
+// has not yet expanded.
+//
+// Returned paths are sorted alphabetically (case-insensitive) so callers
+// can do straight substring matching without extra sort work.
+
+/// Enumerate every `.socpak` path under the requested search roots.
+///
+/// `search_roots` are p4k-internal directory prefixes (e.g.
+/// `"Data/ObjectContainers/"`). Slash flavour and trailing-separator are
+/// normalised internally. Pass an empty slice to scan the entire archive
+/// (rarely useful: socpaks live almost exclusively under
+/// `Data\ObjectContainers\`).
+///
+/// The returned list is sorted by path, case-insensitively. The function
+/// does not parse any socpak content -- if the caller needs sub-zone
+/// counts or display names, [`enumerate_scene_roots`] is the right tool.
+///
+/// Performance: O(N) over `p4k.entries()` plus an alphabetical sort over
+/// the matched subset. On the live HOTFIX archive (~1700 socpaks under
+/// the standard root) this completes in a few hundred milliseconds at
+/// most -- the dominant cost is the `to_ascii_lowercase` per entry.
+pub fn list_all_socpaks(p4k: &MappedP4k, search_roots: &[&str]) -> Vec<String> {
+    list_all_socpaks_impl(search_roots, p4k.entries().iter().map(|e| e.name.as_str()))
+}
+
+/// Iterator-driven body of [`list_all_socpaks`]. Splitting it out lets
+/// the tests pass synthetic entry names without round-tripping through
+/// a `MappedP4k`.
+fn list_all_socpaks_impl<'a, I>(search_roots: &[&str], names: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let normalised_roots: Vec<String> = search_roots.iter().map(|r| normalise_root(r)).collect();
+
+    let mut out: Vec<String> = Vec::new();
+    for name in names {
+        let name_lc = name.to_ascii_lowercase();
+        if !name_lc.ends_with(".socpak") {
+            continue;
+        }
+        if !normalised_roots.is_empty() {
+            // Compare against the canonical form (no leading `data\`)
+            // so `"Data/ObjectContainers/"` and the raw entry path with
+            // the `Data\` prefix line up the same way the graph
+            // enumeration does.
+            let canon = canonicalise_path(name);
+            if !normalised_roots.iter().any(|r| canon.starts_with(r)) {
+                continue;
+            }
+        }
+        out.push(name.to_string());
+    }
+
+    out.sort_by(|a, b| a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()));
+    out
+}
+
+// ── Filter constants ────────────────────────────────────────────────────────
+
+/// Skip socpaks whose compressed size on disk is below this threshold.
+/// Real scenes carry at least one populated SOC payload; anything
+/// smaller is a placeholder. 100 KB is conservative -- the smallest
+/// actual scene socpak we have observed sits around 250 KB.
+pub const MIN_SOCPAK_SIZE_BYTES: u64 = 100 * 1024;
+
+/// Lower-cased substring patterns that mark a socpak as test / scratch /
+/// backup data. A path or filename containing any of these is skipped.
+const TEST_PATH_PATTERNS: &[&str] = &["test", "tmp", "backup"];
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// Source of the catalog entry. Today every entry is `GraphRoot`; the
+/// `Other` variant is a placeholder for future heuristic-augmented
+/// sources (XML metadata tags, DataCore-driven catalogs, etc.) so we
+/// can introduce new sources without a contract bump on the
+/// frontend-facing JSON.
+///
+/// The `as_snake_case` accessor returns the same string the Tauri
+/// command serialises (kept manual so the consumer crate does not
+/// have to take a serde dependency through the catalog API).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SceneSourceKind {
+    /// Found by graph traversal, in-degree 0 in the reference graph.
+    GraphRoot,
+    /// Reserved for future heuristic-augmented sources.
+    Other,
+}
+
+impl SceneSourceKind {
+    /// Stable snake-case identifier for serialisation. Mirrors what a
+    /// `#[serde(rename_all = "snake_case")]` derive would produce, so
+    /// future migration is a one-line swap.
+    pub fn as_snake_case(self) -> &'static str {
+        match self {
+            SceneSourceKind::GraphRoot => "graph_root",
+            SceneSourceKind::Other => "other",
+        }
+    }
+}
+
+/// One catalog entry the frontend will offer to the user.
+#[derive(Debug, Clone)]
+pub struct SceneCatalogEntry {
+    /// Canonical p4k path of the root socpak (backslash-separated, with
+    /// the leading `Data\` segment).
+    pub path: String,
+    /// Best-effort human-readable display name.
+    pub display_name: String,
+    /// Count of transitively-reachable child socpaks. Useful as a
+    /// rough "scene complexity" hint: leaf modules end up at 0,
+    /// assembly trees with one tier of children land in single
+    /// digits, multi-zone hangars and dungeons climb into the dozens.
+    pub sub_zone_count: usize,
+    /// Provenance of this entry. See [`SceneSourceKind`].
+    pub source_kind: SceneSourceKind,
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Walk the loaded p4k under each of `search_roots`, find every
+/// `*.socpak`, and return the in-degree-zero nodes of the reference
+/// graph as catalog entries.
+///
+/// `search_roots` are p4k-internal directory prefixes (e.g.
+/// `"Data/ObjectContainers/"`). Slashes vs. backslashes do not matter --
+/// the function normalises both. Pass an empty slice to scan the entire
+/// archive; that is rarely what you want because socpaks live almost
+/// exclusively under `Data\ObjectContainers\`.
+///
+/// The returned list is sorted by `display_name` (case-insensitive)
+/// before being handed back, so downstream UIs do not have to re-sort.
+pub fn enumerate_scene_roots(
+    p4k: &MappedP4k,
+    search_roots: &[&str],
+) -> Result<Vec<SceneCatalogEntry>, SceneError> {
+    // Phase 1: collect every candidate socpak that passes the cheap
+    // filename / size filter. Map keys are canonical (lowercased,
+    // backslash-normalised) paths so the graph dedupes case variants;
+    // the value carries the original-case path so we can return it
+    // verbatim to the frontend (some SOC paths preserve case for
+    // display purposes).
+    let normalised_roots: Vec<String> = search_roots.iter().map(|r| normalise_root(r)).collect();
+
+    let mut original_path: HashMap<String, String> = HashMap::new();
+    for entry in p4k.entries() {
+        let name_lc = entry.name.to_ascii_lowercase();
+        if !name_lc.ends_with(".socpak") {
+            continue;
+        }
+        // Compare against the canonical form (no `data\` prefix) so
+        // root specs like `"Data/ObjectContainers/"` line up with
+        // p4k entry names like `"Data\ObjectContainers\..."`.
+        let canon_name = canonicalise_path(&entry.name);
+        if !normalised_roots.is_empty()
+            && !normalised_roots.iter().any(|r| canon_name.starts_with(r))
+        {
+            continue;
+        }
+        if entry.compressed_size < MIN_SOCPAK_SIZE_BYTES {
+            continue;
+        }
+        if matches_test_pattern(&name_lc) {
+            continue;
+        }
+        original_path
+            .entry(canon_name)
+            .or_insert_with(|| entry.name.clone());
+    }
+
+    // Phase 2: parse each candidate's child refs. Soft-fail on parse
+    // errors so one broken socpak cannot abort the whole scan. The
+    // resulting graph keys / values are canonicalised so cross-socpak
+    // references with different casing line up.
+    let mut graph: HashMap<String, Vec<String>> = HashMap::with_capacity(original_path.len());
+    let mut referenced: HashSet<String> = HashSet::new();
+    for (key, original) in &original_path {
+        let children = match read_child_refs_from_socpak(p4k, original) {
+            Ok(refs) => refs,
+            Err(err) => {
+                log::warn!(
+                    "scene-catalog: failed to read child refs from {original}: {err}"
+                );
+                graph.insert(key.clone(), Vec::new());
+                continue;
+            }
+        };
+        let mut child_keys: Vec<String> = Vec::with_capacity(children.len());
+        for child in children {
+            let child_key = canonicalise_path(&child.name);
+            referenced.insert(child_key.clone());
+            child_keys.push(child_key);
+        }
+        graph.insert(key.clone(), child_keys);
+    }
+
+    // Phase 3: roots are nodes whose canonical key is not in the
+    // referenced set.
+    let mut entries: Vec<SceneCatalogEntry> = Vec::new();
+    for (key, original) in &original_path {
+        if referenced.contains(key) {
+            continue;
+        }
+        let display_name = derive_display_name(p4k, original);
+        let sub_zone_count = transitive_child_count(&graph, key);
+        entries.push(SceneCatalogEntry {
+            path: original.clone(),
+            display_name,
+            sub_zone_count,
+            source_kind: SceneSourceKind::GraphRoot,
+        });
+    }
+
+    entries.sort_by(|a, b| {
+        a.display_name
+            .to_ascii_lowercase()
+            .cmp(&b.display_name.to_ascii_lowercase())
+    });
+
+    Ok(entries)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Lowercase a path, replace forward slashes with backslashes, and
+/// strip any leading `data\` so two casings of the same path hash
+/// identically. Returned values are stable canonical keys for the
+/// graph; the original-case string is kept separately for display.
+fn canonicalise_path(path: &str) -> String {
+    let lowered = path.to_ascii_lowercase().replace('/', "\\");
+    lowered
+        .strip_prefix("data\\")
+        .map(|s| s.to_string())
+        .unwrap_or(lowered)
+}
+
+/// Normalise a search root the same way [`canonicalise_path`] does
+/// internal nodes, then ensure it ends with a backslash so prefix
+/// matches stay anchored at directory boundaries (otherwise
+/// `"objectcontainers"` would match a path `"objectcontainers_old\..."`).
+fn normalise_root(root: &str) -> String {
+    if root.is_empty() {
+        return String::new();
+    }
+    let mut canon = canonicalise_path(root);
+    if !canon.ends_with('\\') {
+        canon.push('\\');
+    }
+    canon
+}
+
+/// Return true when the (lower-cased) path contains any test-pattern
+/// substring.
+fn matches_test_pattern(path_lc: &str) -> bool {
+    TEST_PATH_PATTERNS.iter().any(|pat| path_lc.contains(pat))
+}
+
+/// Compute the number of socpaks reachable through the child graph
+/// from `start`, exclusive of the start itself. Uses a visited-set BFS
+/// so cycles or shared submodules count exactly once. Missing graph
+/// edges (children that reference socpaks that did not pass the size
+/// or test-pattern filter, and therefore have no entry in `graph`)
+/// stop the walk on that branch -- they would not be loadable by the
+/// composer anyway.
+fn transitive_child_count(graph: &HashMap<String, Vec<String>>, start: &str) -> usize {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    if let Some(children) = graph.get(start) {
+        for c in children {
+            if seen.insert(c.clone()) {
+                queue.push_back(c.clone());
+            }
+        }
+    }
+
+    while let Some(node) = queue.pop_front() {
+        if let Some(children) = graph.get(&node) {
+            for c in children {
+                if seen.insert(c.clone()) {
+                    queue.push_back(c.clone());
+                }
+            }
+        }
+    }
+
+    seen.len()
+}
+
+/// Derive a display name for a root socpak. Tries:
+///
+/// 1. The `name=` attribute on the top-level XML node, when present.
+/// 2. The socpak filename stem.
+/// 3. The full path (only if the stem is empty, which should never
+///    happen for a real p4k entry).
+fn derive_display_name(p4k: &MappedP4k, socpak_path: &str) -> String {
+    if let Some(name) = read_root_name_attr(p4k, socpak_path) {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let stem = filename_stem(socpak_path);
+    if !stem.is_empty() {
+        return stem;
+    }
+    socpak_path.to_string()
+}
+
+/// Return the filename stem (last path segment with any `.socpak`
+/// suffix removed). Tolerant of either separator.
+fn filename_stem(path: &str) -> String {
+    let tail = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    let stem = tail
+        .strip_suffix(".socpak")
+        .or_else(|| tail.strip_suffix(".SOCPAK"))
+        .unwrap_or(tail);
+    stem.to_string()
+}
+
+/// Try to read the `name=` attribute on the socpak's top-level XML
+/// node. Returns `None` for any failure -- callers fall back to the
+/// filename stem.
+fn read_root_name_attr(p4k: &MappedP4k, socpak_path: &str) -> Option<String> {
+    let entry = p4k.entry_case_insensitive(socpak_path)?;
+    let socpak_bytes = p4k.read(entry).ok()?;
+    let inner = starbreaker_p4k::P4kArchive::from_bytes(&socpak_bytes).ok()?;
+
+    // Find the main XML using the same heuristic the composer uses
+    // (first non-editor / non-metadata `.xml` at the socpak root).
+    let mut xml_entry = None;
+    for e in inner.entries() {
+        let name_lc = e.name.to_ascii_lowercase();
+        if !name_lc.ends_with(".xml") {
+            continue;
+        }
+        if name_lc.contains("editor")
+            || name_lc.contains("metadata")
+            || name_lc.contains("entdata")
+            || name_lc.contains("entxml")
+        {
+            continue;
+        }
+        xml_entry = Some(e);
+        break;
+    }
+    let xml_bytes = inner.read(xml_entry?).ok()?;
+
+    extract_root_name(&xml_bytes)
+}
+
+/// Extract the `name=` attribute on whatever the top-level / root XML
+/// node turns out to be. Handles both CryXmlB and plain-text XML.
+fn extract_root_name(xml_bytes: &[u8]) -> Option<String> {
+    if starbreaker_cryxml::is_cryxmlb(xml_bytes) {
+        let xml = starbreaker_cryxml::from_bytes(xml_bytes).ok()?;
+        let root = xml.root();
+        for (k, v) in xml.node_attributes(root) {
+            if k.eq_ignore_ascii_case("name") {
+                return Some(v.to_string());
+            }
+        }
+        return None;
+    }
+
+    let text = std::str::from_utf8(xml_bytes).ok()?;
+    extract_root_name_text(text)
+}
+
+/// Plain-text-XML version of the root-name extraction. Looks for the
+/// first non-comment, non-PI tag and pulls its `name=` attribute. We
+/// avoid pulling in a full XML parser here because the SOC main-XML
+/// shape is well-defined and the engine writes its attribute strings
+/// verbatim.
+fn extract_root_name_text(xml: &str) -> Option<String> {
+    let mut cursor = 0;
+    let bytes = xml.as_bytes();
+    while cursor < bytes.len() {
+        // Find next '<'
+        let lt = xml[cursor..].find('<')? + cursor;
+        if lt + 1 >= bytes.len() {
+            return None;
+        }
+        let next = bytes[lt + 1];
+        // Skip processing instructions and comments
+        if next == b'?' || next == b'!' {
+            // Find matching '>' and continue
+            let close = xml[lt..].find('>')? + lt;
+            cursor = close + 1;
+            continue;
+        }
+        // Found a real tag; grab its head up to the next '>' or '/'
+        let close_rel = xml[lt + 1..].find('>')?;
+        let block = &xml[lt + 1..lt + 1 + close_rel];
+        // Pull `name="..."` out of the block.
+        return extract_attr_value(block, "name");
+    }
+    None
+}
+
+/// Pull `key="value"` from a tag-head block. Mirrors the helper in
+/// `scene.rs`. Tolerates surrounding attributes; matches on the literal
+/// space-prefixed needle so a key like `pos` does not match `position`.
+fn extract_attr_value(block: &str, key: &str) -> Option<String> {
+    let needle_space = format!(" {key}=\"");
+    let start = if let Some(idx) = block.find(&needle_space) {
+        idx + needle_space.len()
+    } else {
+        // Fall back to the first attribute on the tag (no leading
+        // space): `<Tag name="...">`.
+        let needle = format!("{key}=\"");
+        let idx = block.find(&needle)?;
+        // Make sure this is not a substring of a longer attribute name
+        // (e.g. `displayname="..."`).
+        if idx > 0 {
+            let prev = block.as_bytes()[idx - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'_' {
+                return None;
+            }
+        }
+        idx + needle.len()
+    };
+    let rest = &block[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalise_path_strips_data_prefix_and_normalises_separators() {
+        assert_eq!(
+            canonicalise_path("Data\\ObjectContainers\\Foo.socpak"),
+            "objectcontainers\\foo.socpak"
+        );
+        assert_eq!(
+            canonicalise_path("data/objectcontainers/foo.socpak"),
+            "objectcontainers\\foo.socpak"
+        );
+        // Already-canonical paths round-trip.
+        assert_eq!(
+            canonicalise_path("objectcontainers\\foo.socpak"),
+            "objectcontainers\\foo.socpak"
+        );
+    }
+
+    #[test]
+    fn normalise_root_appends_separator_and_lowercases() {
+        assert_eq!(normalise_root("Data/ObjectContainers"), "objectcontainers\\");
+        assert_eq!(
+            normalise_root("Data\\ObjectContainers\\"),
+            "objectcontainers\\"
+        );
+        assert_eq!(normalise_root(""), "");
+    }
+
+    #[test]
+    fn matches_test_pattern_catches_common_developer_paths() {
+        assert!(matches_test_pattern("data\\objectcontainers\\test\\foo.socpak"));
+        assert!(matches_test_pattern("data\\foo\\bar_tmp.socpak"));
+        assert!(matches_test_pattern("data\\foo\\backup\\bar.socpak"));
+        assert!(!matches_test_pattern(
+            "data\\objectcontainers\\pyro\\hangar.socpak"
+        ));
+    }
+
+    #[test]
+    fn filename_stem_strips_socpak_suffix() {
+        assert_eq!(filename_stem("Data\\foo\\bar.socpak"), "bar");
+        assert_eq!(filename_stem("Data/foo/baz.socpak"), "baz");
+        assert_eq!(filename_stem("naked.socpak"), "naked");
+        // No suffix: pass through.
+        assert_eq!(filename_stem("nothing"), "nothing");
+    }
+
+    #[test]
+    fn extract_root_name_text_pulls_attribute_from_first_tag() {
+        let xml = r#"<?xml version="1.0"?><Object name="Exec_Hangar" pos="0,0,0"/>"#;
+        assert_eq!(
+            extract_root_name_text(xml).as_deref(),
+            Some("Exec_Hangar")
+        );
+    }
+
+    #[test]
+    fn extract_root_name_text_ignores_comments_and_processing_instructions() {
+        let xml = r#"<?xml version="1.0"?>
+            <!-- comment -->
+            <Object name="Foo"/>
+        "#;
+        assert_eq!(extract_root_name_text(xml).as_deref(), Some("Foo"));
+    }
+
+    #[test]
+    fn extract_root_name_text_returns_none_when_attribute_absent() {
+        let xml = r#"<Object pos="0,0,0"/>"#;
+        assert_eq!(extract_root_name_text(xml), None);
+    }
+
+    #[test]
+    fn extract_attr_value_does_not_match_attribute_prefixes() {
+        // `displayname` should not match the `name` lookup.
+        let block = r#"Object displayname="Wrong" pos="0,0,0""#;
+        assert_eq!(extract_attr_value(block, "name"), None);
+
+        let block_ok = r#"Object name="Right" pos="0,0,0""#;
+        assert_eq!(
+            extract_attr_value(block_ok, "name"),
+            Some("Right".to_string())
+        );
+    }
+
+    #[test]
+    fn transitive_child_count_walks_tree_uniquely() {
+        // Build a small graph:
+        //   root -> a, b
+        //   a    -> c
+        //   b    -> c        (c shared between a and b)
+        //   c    -> (none)
+        let mut g: HashMap<String, Vec<String>> = HashMap::new();
+        g.insert("root".into(), vec!["a".into(), "b".into()]);
+        g.insert("a".into(), vec!["c".into()]);
+        g.insert("b".into(), vec!["c".into()]);
+        g.insert("c".into(), vec![]);
+
+        // From root: { a, b, c } = 3 unique.
+        assert_eq!(transitive_child_count(&g, "root"), 3);
+        // From a: just { c }.
+        assert_eq!(transitive_child_count(&g, "a"), 1);
+        // From a leaf: 0.
+        assert_eq!(transitive_child_count(&g, "c"), 0);
+    }
+
+    #[test]
+    fn transitive_child_count_handles_cycles() {
+        let mut g: HashMap<String, Vec<String>> = HashMap::new();
+        // a -> b -> a (cycle). Visited set guards against the loop.
+        g.insert("a".into(), vec!["b".into()]);
+        g.insert("b".into(), vec!["a".into()]);
+        assert_eq!(transitive_child_count(&g, "a"), 2); // a, b once each
+    }
+
+    #[test]
+    fn transitive_child_count_stops_at_missing_edges() {
+        let mut g: HashMap<String, Vec<String>> = HashMap::new();
+        // root references a child we filtered out (no entry in graph).
+        g.insert("root".into(), vec!["filtered_out".into()]);
+        // Walk visits the missing child once -- it counts toward
+        // sub_zone_count even though we cannot recurse through it. The
+        // alternative (skip-not-in-graph) would bias counts downward
+        // for any root that points at a small / test-named submodule.
+        assert_eq!(transitive_child_count(&g, "root"), 1);
+    }
+
+    #[test]
+    fn min_socpak_size_threshold_picks_realistic_floor() {
+        // Sanity: a 50 KB socpak is under the threshold; 200 KB is over.
+        assert!(50 * 1024 < MIN_SOCPAK_SIZE_BYTES);
+        assert!(200 * 1024 >= MIN_SOCPAK_SIZE_BYTES);
+    }
+
+    // ── Lazy directory listing (`list_socpak_dir_impl`) ────────────────────
+    //
+    // The production entry point (`list_socpak_dir`) takes a `MappedP4k`
+    // which can only be built from a real on-disk archive, so these
+    // tests target the closure-driven inner function. A small
+    // `HashMap<String, Vec<DirChild>>` stands in for the p4k's directory
+    // index; the closure looks up the requested directory and returns
+    // an owned clone (production hands back borrowed entries -- the
+    // test seam does not need that optimisation).
+
+    fn make_dir(name: &str) -> DirChild {
+        DirChild::Directory(name.to_string())
+    }
+
+    fn make_file(name: &str, size: u64) -> DirChild {
+        DirChild::File {
+            name: name.to_string(),
+            compressed_size: size,
+        }
+    }
+
+    #[test]
+    fn list_socpak_dir_groups_directories_before_files() {
+        // Layout under `Data\ObjectContainers`:
+        //   Data\ObjectContainers\PU\          (subdir, has child)
+        //   Data\ObjectContainers\Stations\    (subdir, has child)
+        //   Data\ObjectContainers\loose.socpak (file)
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert(
+            "Data\\ObjectContainers".into(),
+            vec![
+                make_dir("PU"),
+                make_dir("Stations"),
+                make_file("Data\\ObjectContainers\\loose.socpak", 4096),
+            ],
+        );
+        backing.insert(
+            "Data\\ObjectContainers\\PU".into(),
+            vec![make_file("Data\\ObjectContainers\\PU\\zone.socpak", 8192)],
+        );
+        backing.insert(
+            "Data\\ObjectContainers\\Stations".into(),
+            vec![make_dir("alpha")],
+        );
+
+        let result = list_socpak_dir_impl("Data/ObjectContainers/", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        // Directories first, alphabetically, then socpak files.
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].display_name, "PU");
+        assert_eq!(result[0].kind, SocpakDirEntryKind::Directory);
+        assert_eq!(result[1].display_name, "Stations");
+        assert_eq!(result[1].kind, SocpakDirEntryKind::Directory);
+        assert_eq!(result[2].display_name, "loose.socpak");
+        assert_eq!(result[2].kind, SocpakDirEntryKind::SocpakFile);
+        assert_eq!(result[2].size_or_count, 4096);
+    }
+
+    #[test]
+    fn list_socpak_dir_normalises_prefix_with_or_without_trailing_separator() {
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert(
+            "Data\\ObjectContainers".into(),
+            vec![make_file("Data\\ObjectContainers\\foo.socpak", 1)],
+        );
+
+        // Forward slashes, trailing separator.
+        let a = list_socpak_dir_impl("Data/ObjectContainers/", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+        // Backslashes, no trailing separator.
+        let b = list_socpak_dir_impl("Data\\ObjectContainers", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+        // Backslashes, trailing separator.
+        let c = list_socpak_dir_impl("Data\\ObjectContainers\\", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].display_name, "foo.socpak");
+    }
+
+    #[test]
+    fn list_socpak_dir_skips_non_socpak_files() {
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert(
+            "Data\\ObjectContainers".into(),
+            vec![
+                make_file("Data\\ObjectContainers\\readme.txt", 100),
+                make_file("Data\\ObjectContainers\\index.xml", 200),
+                make_file("Data\\ObjectContainers\\real.socpak", 4096),
+            ],
+        );
+
+        let result = list_socpak_dir_impl("Data/ObjectContainers/", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].display_name, "real.socpak");
+    }
+
+    #[test]
+    fn list_socpak_dir_directory_entries_carry_child_count() {
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert("root".into(), vec![make_dir("PU")]);
+        // PU directly contains 2 subdirs and 1 socpak that count, plus
+        // 1 unrelated file that should NOT count.
+        backing.insert(
+            "root\\PU".into(),
+            vec![
+                make_dir("loc"),
+                make_dir("zones"),
+                make_file("root\\PU\\hangar.socpak", 1),
+                make_file("root\\PU\\manifest.xml", 1),
+            ],
+        );
+
+        let result = list_socpak_dir_impl("root", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SocpakDirEntryKind::Directory);
+        assert_eq!(
+            result[0].size_or_count, 3,
+            "PU has 2 subdirs + 1 socpak that count toward the badge"
+        );
+    }
+
+    #[test]
+    fn list_socpak_dir_socpak_filter_is_case_insensitive() {
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert(
+            "Data\\OC".into(),
+            vec![
+                make_file("Data\\OC\\Foo.SOCPAK", 1),
+                make_file("Data\\OC\\BAR.socpak", 2),
+                make_file("Data\\OC\\baz.SocPak", 3),
+            ],
+        );
+
+        let result = list_socpak_dir_impl("Data\\OC", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        assert_eq!(result.len(), 3);
+        // Sorted case-insensitively by display_name.
+        assert_eq!(result[0].display_name, "BAR.socpak");
+        assert_eq!(result[1].display_name, "baz.SocPak");
+        assert_eq!(result[2].display_name, "Foo.SOCPAK");
+    }
+
+    #[test]
+    fn list_socpak_dir_directory_path_terminates_with_separator() {
+        // Caller round-trips `path` back into another `list_socpak_dir`
+        // call to expand a branch -- so directory paths MUST end with
+        // a trailing separator the way the function expects on input.
+        let mut backing: std::collections::HashMap<String, Vec<DirChild>> =
+            std::collections::HashMap::new();
+        backing.insert(
+            "Data\\ObjectContainers".into(),
+            vec![make_dir("PU")],
+        );
+        backing.insert("Data\\ObjectContainers\\PU".into(), vec![]);
+
+        let result = list_socpak_dir_impl("Data/ObjectContainers/", |p| {
+            backing.get(p).cloned().unwrap_or_default()
+        });
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result[0].path.ends_with('\\'),
+            "directory path must end with a separator: {}",
+            result[0].path
+        );
+        assert_eq!(result[0].path, "Data\\ObjectContainers\\PU\\");
+    }
+
+    // ── Global path index (`list_all_socpaks_impl`) ────────────────────────
+    //
+    // The production entry point (`list_all_socpaks`) needs a real
+    // `MappedP4k`, so these tests target the iterator-driven inner
+    // function and pass synthetic entry names directly.
+
+    #[test]
+    fn list_all_socpaks_filters_non_socpak_entries() {
+        let names = [
+            "Data\\ObjectContainers\\PU\\hangar.socpak",
+            "Data\\ObjectContainers\\PU\\readme.txt",
+            "Data\\ObjectContainers\\PU\\manifest.xml",
+            "Data\\ObjectContainers\\PU\\dungeon.socpak",
+        ];
+        let out = list_all_socpaks_impl(&["Data/ObjectContainers/"], names.iter().copied());
+        assert_eq!(
+            out,
+            vec![
+                "Data\\ObjectContainers\\PU\\dungeon.socpak".to_string(),
+                "Data\\ObjectContainers\\PU\\hangar.socpak".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_all_socpaks_returns_sorted_alphabetically_case_insensitive() {
+        let names = [
+            "Data\\ObjectContainers\\PU\\Zulu.socpak",
+            "Data\\ObjectContainers\\PU\\alpha.socpak",
+            "Data\\ObjectContainers\\PU\\Beta.SOCPAK",
+            "Data\\ObjectContainers\\PU\\charlie.socpak",
+        ];
+        let out = list_all_socpaks_impl(&["Data/ObjectContainers/"], names.iter().copied());
+        assert_eq!(
+            out,
+            vec![
+                "Data\\ObjectContainers\\PU\\alpha.socpak".to_string(),
+                "Data\\ObjectContainers\\PU\\Beta.SOCPAK".to_string(),
+                "Data\\ObjectContainers\\PU\\charlie.socpak".to_string(),
+                "Data\\ObjectContainers\\PU\\Zulu.socpak".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_all_socpaks_respects_search_roots() {
+        let names = [
+            "Data\\ObjectContainers\\PU\\inside.socpak",
+            "Data\\Other\\elsewhere.socpak",
+            "Data\\ObjectContainers\\Stations\\alpha.socpak",
+        ];
+        // Only entries under `Data\\ObjectContainers\\` should pass.
+        let out = list_all_socpaks_impl(&["Data/ObjectContainers/"], names.iter().copied());
+        assert_eq!(
+            out,
+            vec![
+                "Data\\ObjectContainers\\PU\\inside.socpak".to_string(),
+                "Data\\ObjectContainers\\Stations\\alpha.socpak".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_all_socpaks_empty_roots_means_scan_everything() {
+        let names = [
+            "Data\\ObjectContainers\\inside.socpak",
+            "Data\\Other\\elsewhere.socpak",
+            "totally\\unrelated.socpak",
+        ];
+        let out = list_all_socpaks_impl(&[], names.iter().copied());
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn list_all_socpaks_normalises_search_root_separators() {
+        let names = ["Data\\ObjectContainers\\PU\\inside.socpak"];
+        // All three forms of the search root should match.
+        let a = list_all_socpaks_impl(&["Data/ObjectContainers/"], names.iter().copied());
+        let b = list_all_socpaks_impl(&["Data\\ObjectContainers"], names.iter().copied());
+        let c = list_all_socpaks_impl(&["Data\\ObjectContainers\\"], names.iter().copied());
+        assert_eq!(a.len(), 1);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    /// Synthetic graph test: a single root with two children, neither
+    /// of which is referenced by anyone else, yields exactly the root.
+    #[test]
+    fn root_detection_on_synthetic_graph() {
+        // Set of all paths.
+        let all: Vec<&str> = vec!["root.socpak", "child_a.socpak", "child_b.socpak"];
+        // Graph: root references both children; children reference
+        // nothing.
+        let mut g: HashMap<String, Vec<String>> = HashMap::new();
+        g.insert("root.socpak".into(), vec!["child_a.socpak".into(), "child_b.socpak".into()]);
+        g.insert("child_a.socpak".into(), vec![]);
+        g.insert("child_b.socpak".into(), vec![]);
+
+        let referenced: HashSet<String> = g
+            .values()
+            .flat_map(|v| v.iter().cloned())
+            .collect();
+
+        let roots: Vec<&str> = all
+            .iter()
+            .copied()
+            .filter(|p| !referenced.contains(*p))
+            .collect();
+
+        assert_eq!(roots, vec!["root.socpak"]);
+    }
+}

--- a/crates/starbreaker-3d/src/soc/common.rs
+++ b/crates/starbreaker-3d/src/soc/common.rs
@@ -1,0 +1,139 @@
+//! Shared CrCh container parsing helpers used by every SOC submodule.
+//!
+//! A `.soc` file is a CrCh-format binary blob with a 16-byte header and a
+//! chunk table. Each submodule (brushes, entities, visarea, scene) needs to
+//! locate its chunks and read primitive types out of the same byte slice;
+//! keeping the constants and byte-readers in one place ensures the modules
+//! stay numerically consistent.
+
+// ── CrCh container constants ────────────────────────────────────────────────
+
+pub(super) const CRCH_MAGIC: [u8; 4] = *b"CrCh";
+pub(super) const CRCH_VERSION: u32 = 0x0746;
+
+pub(super) const CHUNK_TABLE_ENTRY_SIZE: usize = 16;
+
+pub(super) const CHUNK_TYPE_CRYXMLB: u16 = 0x0004;
+pub(super) const CHUNK_TYPE_VISAREA: u16 = 0x000E;
+pub(super) const CHUNK_TYPE_STATOBJ: u16 = 0x0010;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CrChHeader {
+    pub chunk_count: u32,
+    pub chunk_table_offset: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ChunkEntry {
+    pub chunk_type: u16,
+    /// Chunk-level version field. Currently `1` in shipping builds even
+    /// though brush records inside the chunk use the v15 layout, so it is
+    /// treated as opaque and not used to gate parsing.
+    #[allow(dead_code)]
+    pub version: u16,
+    pub offset: u32,
+    pub size: u32,
+}
+
+// ── Byte readers ────────────────────────────────────────────────────────────
+
+#[inline]
+pub(super) fn read_u16(data: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes([data[off], data[off + 1]])
+}
+
+#[inline]
+pub(super) fn read_u32(data: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([
+        data[off],
+        data[off + 1],
+        data[off + 2],
+        data[off + 3],
+    ])
+}
+
+#[inline]
+pub(super) fn read_i32(data: &[u8], off: usize) -> i32 {
+    i32::from_le_bytes([
+        data[off],
+        data[off + 1],
+        data[off + 2],
+        data[off + 3],
+    ])
+}
+
+#[inline]
+pub(super) fn read_f32(data: &[u8], off: usize) -> f32 {
+    let mut buf = [0u8; 4];
+    buf.copy_from_slice(&data[off..off + 4]);
+    f32::from_le_bytes(buf)
+}
+
+#[inline]
+pub(super) fn read_f64(data: &[u8], off: usize) -> f64 {
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&data[off..off + 8]);
+    f64::from_le_bytes(buf)
+}
+
+// ── Container header + chunk table ──────────────────────────────────────────
+
+/// Result of inspecting a `.soc` file's CrCh container header. Every
+/// submodule produces its own `Result` type, so this helper stays
+/// error-agnostic: callers map the `Option` / range checks to their own
+/// error variants.
+pub(super) fn parse_crch_header(data: &[u8]) -> Option<CrChHeader> {
+    if data.len() < 16 {
+        return None;
+    }
+    if data[0..4] != CRCH_MAGIC {
+        return None;
+    }
+    let version = read_u32(data, 4);
+    if version != CRCH_VERSION {
+        return None;
+    }
+    Some(CrChHeader {
+        chunk_count: read_u32(data, 8),
+        chunk_table_offset: read_u32(data, 12),
+    })
+}
+
+/// Read every entry in the chunk table. Returns `None` when the table
+/// extends past the end of the buffer.
+pub(super) fn parse_chunk_table(data: &[u8], header: &CrChHeader) -> Option<Vec<ChunkEntry>> {
+    let count = header.chunk_count as usize;
+    let start = header.chunk_table_offset as usize;
+    let bytes_needed = count.saturating_mul(CHUNK_TABLE_ENTRY_SIZE);
+    let end = start.saturating_add(bytes_needed);
+    if end > data.len() {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let off = start + i * CHUNK_TABLE_ENTRY_SIZE;
+        let chunk_type = read_u16(data, off);
+        let version_raw = read_u16(data, off + 2);
+        let version = version_raw & 0x7FFF;
+        let _id = read_u32(data, off + 4);
+        let size = read_u32(data, off + 8);
+        let offset = read_u32(data, off + 12);
+        out.push(ChunkEntry {
+            chunk_type,
+            version,
+            offset,
+            size,
+        });
+    }
+    Some(out)
+}
+
+/// Borrow a chunk's body bytes from the file blob, clipped to file end.
+pub(super) fn chunk_slice<'a>(data: &'a [u8], chunk: &ChunkEntry) -> &'a [u8] {
+    let start = (chunk.offset as usize).min(data.len());
+    let end = start
+        .saturating_add(chunk.size as usize)
+        .min(data.len());
+    &data[start..end]
+}

--- a/crates/starbreaker-3d/src/soc/entities.rs
+++ b/crates/starbreaker-3d/src/soc/entities.rs
@@ -1,0 +1,401 @@
+//! Entity placements parsed from a SOC's CryXmlB chunk (0x0004).
+//!
+//! Each `.soc` file embeds a CryXmlB tree under chunk type 0x0004. The tree
+//! lists `<Entity>` records that the engine spawns when the container is
+//! activated: lights, doors, loot points, audio triggers, etc. This module
+//! decodes a useful subset, focusing on what a renderer needs to draw the
+//! scene: light placements, doors, and any entity that references a brush
+//! mesh through the StatObj table.
+//!
+//! Decoding leans on the existing [`starbreaker_cryxml`] zero-copy reader
+//! rather than re-implementing a binary XML decoder.
+//!
+//! # Lights
+//!
+//! Light entities use one of these `EntityClass` strings: `Light`, `LightBox`,
+//! `LightGroup`, `LightGroupPoweredItem`. The viewer needs at minimum the
+//! world-space placement (position, rotation) and a stable name. Light
+//! intensity / colour / radius live deeper inside `PropertiesDataCore`; that
+//! is where the existing socpak loader looks. For the SOC parser port we
+//! emit the basic placement plus the entity class so the consumer can decide
+//! whether to drive a punctual light or a baked light group.
+
+use super::brushes::{ParentTransform, SocError};
+use super::common::{
+    CHUNK_TYPE_CRYXMLB, CHUNK_TYPE_STATOBJ, chunk_slice, parse_chunk_table, parse_crch_header,
+    read_u32,
+};
+use glam::{DQuat, DVec3};
+
+const STATOBJ_PATH_LEN: usize = 256;
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// Coarse classification driven off the `EntityClass` attribute. The renderer
+/// uses this to decide which payload to honour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntityKind {
+    /// `Light`, `LightBox`, `LightGroup`, `LightGroupPoweredItem`.
+    Light,
+    /// Anything matching `Door*` or `Door_*`.
+    Door,
+    /// Loot points (`LootPoint`, `LootSpawner`, `LootContainer*`).
+    Loot,
+    /// Anything else worth surfacing (entities that reference a CGF mesh).
+    Other,
+}
+
+/// One decoded entity placement from chunk 0x0004.
+#[derive(Debug, Clone)]
+pub struct EntityPlacement {
+    /// `Name` attribute on the entity node (may be empty).
+    pub name: String,
+    /// Raw `EntityClass` string.
+    pub entity_class: String,
+    /// Coarse classification.
+    pub kind: EntityKind,
+    /// World-space translation (parent QuatTS composed with the entity's
+    /// own pos vector).
+    pub translation: [f32; 3],
+    /// World-space rotation as a quaternion `[x, y, z, w]`.
+    pub rotation: [f32; 4],
+    /// Resolved mesh path, populated when the entity references a brush
+    /// mesh via `GeomLink/BrushID` or a child `Geometry` node with `path`.
+    pub mesh_path: Option<String>,
+    /// Index into the SOC's StatObj table when the entity used a `BrushID`
+    /// to reference a brush mesh. `None` when the mesh path came from a
+    /// direct `Geometry` reference or could not be resolved.
+    pub mesh_index: Option<u16>,
+}
+
+/// Lights, doors, loot points, mesh-referencing entities — all parsed from
+/// the CryXmlB chunk of a single SOC.
+#[derive(Debug, Clone, Default)]
+pub struct SocEntities {
+    /// Lower-cased StatObj geometry paths (same set as the brush parser
+    /// produces, hoisted here for `BrushID` resolution). Empty when the SOC
+    /// has no StatObj chunk.
+    pub mesh_paths: Vec<String>,
+    /// All decoded entities, in source order.
+    pub entities: Vec<EntityPlacement>,
+}
+
+impl SocEntities {
+    /// View only the light placements.
+    pub fn lights(&self) -> impl Iterator<Item = &EntityPlacement> {
+        self.entities.iter().filter(|e| e.kind == EntityKind::Light)
+    }
+
+    /// View only the door placements.
+    pub fn doors(&self) -> impl Iterator<Item = &EntityPlacement> {
+        self.entities.iter().filter(|e| e.kind == EntityKind::Door)
+    }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Parse entity placements from a SOC, composing their `Pos`/`Rotate`
+/// attributes with `parent` to produce world-space placements. SOCs that lack
+/// a CryXmlB chunk (some meta-only containers) return an empty result rather
+/// than an error.
+pub fn parse(data: &[u8], parent: &ParentTransform) -> Result<SocEntities, SocError> {
+    let header = parse_crch_header(data).ok_or(SocError::BadMagic)?;
+    let chunks = parse_chunk_table(data, &header).ok_or(SocError::BadChunkTable)?;
+
+    // StatObj table is optional for entity parsing, but when present it lets
+    // us resolve `BrushID` references to mesh paths.
+    let mesh_paths = chunks
+        .iter()
+        .find(|c| c.chunk_type == CHUNK_TYPE_STATOBJ)
+        .map(|c| read_statobj_paths(data, c))
+        .unwrap_or_default();
+
+    // Find the CryXmlB chunk; absence is benign — emit empty entities.
+    let Some(xml_chunk) = chunks.iter().find(|c| c.chunk_type == CHUNK_TYPE_CRYXMLB) else {
+        return Ok(SocEntities {
+            mesh_paths,
+            entities: Vec::new(),
+        });
+    };
+
+    let xml_bytes = chunk_slice(data, xml_chunk);
+    let entities = parse_cryxml_entities(xml_bytes, parent, &mesh_paths);
+
+    Ok(SocEntities {
+        mesh_paths,
+        entities,
+    })
+}
+
+// ── StatObj path table read (mirrors brushes.rs) ────────────────────────────
+
+fn read_statobj_paths(data: &[u8], chunk: &super::common::ChunkEntry) -> Vec<String> {
+    let start = chunk.offset as usize;
+    let end = start
+        .saturating_add(chunk.size as usize)
+        .min(data.len());
+    if end < start + 8 {
+        return Vec::new();
+    }
+    let count = read_u32(data, start + 4) as usize;
+    let mut off = start + 8;
+    let table_end = off.saturating_add(count.saturating_mul(STATOBJ_PATH_LEN));
+    if table_end > end {
+        return Vec::new();
+    }
+    let mut paths = Vec::with_capacity(count);
+    for _ in 0..count {
+        let raw = &data[off..off + STATOBJ_PATH_LEN];
+        let nul = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+        let s = String::from_utf8_lossy(&raw[..nul]).to_lowercase();
+        paths.push(s);
+        off += STATOBJ_PATH_LEN;
+    }
+    paths
+}
+
+// ── CryXmlB walk ────────────────────────────────────────────────────────────
+
+fn parse_cryxml_entities(
+    xml_bytes: &[u8],
+    parent: &ParentTransform,
+    mesh_paths: &[String],
+) -> Vec<EntityPlacement> {
+    let xml = match starbreaker_cryxml::from_bytes(xml_bytes) {
+        Ok(x) => x,
+        Err(_) => return Vec::new(),
+    };
+
+    let root = xml.root();
+    let root_tag = xml.node_tag(root);
+
+    // Same root-tag set as the existing socpak loader.
+    let entity_root = if root_tag == "Entities" || root_tag == "SCOC_Entities" {
+        Some(root)
+    } else {
+        xml.node_children(root).find(|child| {
+            let tag = xml.node_tag(child);
+            tag == "Entities" || tag == "SCOC_Entities"
+        })
+    };
+
+    let Some(entity_root) = entity_root else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for entity in xml.node_children(entity_root) {
+        if xml.node_tag(entity) != "Entity" {
+            continue;
+        }
+
+        let attrs: std::collections::HashMap<&str, &str> =
+            xml.node_attributes(entity).collect();
+        let entity_class = attrs.get("EntityClass").copied().unwrap_or("").to_string();
+        let kind = classify(&entity_class);
+
+        // Filter rule (per brief): keep lights, doors, loot, and any entity
+        // that references a brush mesh. Skip the rest to keep the output
+        // small. Entities can still reference a mesh through
+        // `GeomLink`/`Geometry` even when the class is not light/door/loot.
+        let (mesh_path, mesh_index) = resolve_entity_mesh(&xml, entity, mesh_paths);
+        if matches!(kind, EntityKind::Other) && mesh_path.is_none() {
+            continue;
+        }
+
+        let name = attrs.get("Name").copied().unwrap_or("").to_string();
+        let pos = parse_csv_pos(attrs.get("Pos").copied());
+        let rot_quat = parse_csv_rotate(attrs.get("Rotate").copied());
+
+        let world_translation = parent.translation + parent.rotation * pos;
+        let world_rotation = (parent.rotation * rot_quat).normalize();
+
+        out.push(EntityPlacement {
+            name,
+            entity_class,
+            kind,
+            translation: [
+                world_translation.x as f32,
+                world_translation.y as f32,
+                world_translation.z as f32,
+            ],
+            rotation: [
+                world_rotation.x as f32,
+                world_rotation.y as f32,
+                world_rotation.z as f32,
+                world_rotation.w as f32,
+            ],
+            mesh_path,
+            mesh_index,
+        });
+    }
+
+    out
+}
+
+fn classify(entity_class: &str) -> EntityKind {
+    match entity_class {
+        "Light" | "LightBox" | "LightGroup" | "LightGroupPoweredItem" => EntityKind::Light,
+        s if s.starts_with("Door") => EntityKind::Door,
+        s if s.starts_with("Loot") => EntityKind::Loot,
+        _ => EntityKind::Other,
+    }
+}
+
+/// Resolve an `<Entity>` to a mesh path via two strategies:
+/// `GeomLink/BrushID` -> StatObj index, then any descendant
+/// `<Geometry path="..."/>`.
+fn resolve_entity_mesh(
+    xml: &starbreaker_cryxml::CryXml,
+    entity: &starbreaker_cryxml::CryXmlNode,
+    mesh_paths: &[String],
+) -> (Option<String>, Option<u16>) {
+    // Strategy 1: GeomLink with BrushID.
+    if let Some(brush_id) = find_descendant_attr(xml, entity, "GeomLink", "BrushID", 8)
+        && let Ok(id) = brush_id.parse::<i32>()
+        && id >= 0
+        && (id as usize) < mesh_paths.len()
+    {
+        return (Some(mesh_paths[id as usize].clone()), Some(id as u16));
+    }
+
+    // Strategy 2: any descendant <Geometry path="...">.
+    if let Some(path) = find_descendant_attr(xml, entity, "Geometry", "path", 8)
+        && !path.is_empty()
+    {
+        return (Some(path.to_string()), None);
+    }
+
+    (None, None)
+}
+
+/// Walk descendants up to `max_depth`, returning the first node with tag
+/// `tag` that has the requested attribute.
+fn find_descendant_attr<'a>(
+    xml: &'a starbreaker_cryxml::CryXml,
+    parent: &'a starbreaker_cryxml::CryXmlNode,
+    tag: &str,
+    attr: &str,
+    max_depth: u32,
+) -> Option<&'a str> {
+    if max_depth == 0 {
+        return None;
+    }
+    for child in xml.node_children(parent) {
+        if xml.node_tag(child) == tag {
+            for (k, v) in xml.node_attributes(child) {
+                if k == attr {
+                    return Some(v);
+                }
+            }
+        }
+        if let Some(found) = find_descendant_attr(xml, child, tag, attr, max_depth - 1) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+// ── String parsers ──────────────────────────────────────────────────────────
+
+fn parse_csv_pos(s: Option<&str>) -> DVec3 {
+    let Some(s) = s else { return DVec3::ZERO };
+    let mut iter = s.split(',').filter_map(|p| p.trim().parse::<f64>().ok());
+    let x = iter.next().unwrap_or(0.0);
+    let y = iter.next().unwrap_or(0.0);
+    let z = iter.next().unwrap_or(0.0);
+    DVec3::new(x, y, z)
+}
+
+/// CryEngine `Rotate` attribute is `w,x,y,z` (scalar first). Glam's
+/// `DQuat::from_xyzw` expects `[x, y, z, w]`, so we re-order here.
+fn parse_csv_rotate(s: Option<&str>) -> DQuat {
+    let Some(s) = s else { return DQuat::IDENTITY };
+    let mut iter = s.split(',').filter_map(|p| p.trim().parse::<f64>().ok());
+    let w = iter.next().unwrap_or(1.0);
+    let x = iter.next().unwrap_or(0.0);
+    let y = iter.next().unwrap_or(0.0);
+    let z = iter.next().unwrap_or(0.0);
+    DQuat::from_xyzw(x, y, z, w).normalize()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_recognises_light_classes() {
+        assert_eq!(classify("Light"), EntityKind::Light);
+        assert_eq!(classify("LightBox"), EntityKind::Light);
+        assert_eq!(classify("LightGroup"), EntityKind::Light);
+        assert_eq!(classify("LightGroupPoweredItem"), EntityKind::Light);
+    }
+
+    #[test]
+    fn classify_recognises_doors_and_loot() {
+        assert_eq!(classify("Door"), EntityKind::Door);
+        assert_eq!(classify("Door_Sliding"), EntityKind::Door);
+        assert_eq!(classify("LootPoint"), EntityKind::Loot);
+        assert_eq!(classify("LootSpawner"), EntityKind::Loot);
+        assert_eq!(classify("ActionArea"), EntityKind::Other);
+    }
+
+    #[test]
+    fn parse_csv_rotate_handles_w_first_quaternion() {
+        // CryEngine "1,0,0,0" is identity in (w, x, y, z) order.
+        let q = parse_csv_rotate(Some("1,0,0,0"));
+        assert!((q.w - 1.0).abs() < 1e-6);
+        assert!(q.x.abs() < 1e-6);
+        assert!(q.y.abs() < 1e-6);
+        assert!(q.z.abs() < 1e-6);
+
+        // 90 deg rotation about Z: w=cos(45)=0.7071, z=sin(45)=0.7071
+        let q = parse_csv_rotate(Some("0.7071068,0,0,0.7071068"));
+        assert!((q.w - 0.7071068).abs() < 1e-5);
+        assert!((q.z - 0.7071068).abs() < 1e-5);
+    }
+
+    #[test]
+    fn parse_csv_pos_handles_short_inputs() {
+        assert_eq!(parse_csv_pos(Some("1,2,3")), DVec3::new(1.0, 2.0, 3.0));
+        assert_eq!(parse_csv_pos(None), DVec3::ZERO);
+        assert_eq!(parse_csv_pos(Some("")), DVec3::ZERO);
+    }
+
+    #[test]
+    fn parse_returns_empty_when_no_cryxml_chunk() {
+        // Build a minimal CrCh file with only a StatObj chunk. The entity
+        // parser must not error — it should return empty placements.
+        let data = build_crch_with_only_statobj();
+        let parsed = parse(&data, &ParentTransform::identity()).expect("parse ok");
+        assert!(parsed.entities.is_empty());
+    }
+
+    fn build_crch_with_only_statobj() -> Vec<u8> {
+        // 16-byte header + 8-byte StatObj body + 16-byte chunk-table entry.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"CrCh");
+        data.extend_from_slice(&0x0746u32.to_le_bytes()); // version
+        data.extend_from_slice(&1u32.to_le_bytes()); // chunk_count
+        let table_offset_pos = data.len();
+        data.extend_from_slice(&0u32.to_le_bytes()); // chunk_table_offset (patched)
+
+        let statobj_offset = data.len() as u32;
+        data.extend_from_slice(&0u32.to_le_bytes()); // unknown
+        data.extend_from_slice(&0u32.to_le_bytes()); // count = 0
+        let statobj_size = (data.len() as u32) - statobj_offset;
+
+        let table_off = data.len() as u32;
+        data[table_offset_pos..table_offset_pos + 4]
+            .copy_from_slice(&table_off.to_le_bytes());
+        // Entry: type, version, id, size, offset
+        data.extend_from_slice(&0x0010u16.to_le_bytes());
+        data.extend_from_slice(&15u16.to_le_bytes());
+        data.extend_from_slice(&0i32.to_le_bytes());
+        data.extend_from_slice(&statobj_size.to_le_bytes());
+        data.extend_from_slice(&statobj_offset.to_le_bytes());
+        data
+    }
+}

--- a/crates/starbreaker-3d/src/soc/mod.rs
+++ b/crates/starbreaker-3d/src/soc/mod.rs
@@ -1,0 +1,59 @@
+//! SOC (Static Object Container) parser suite.
+//!
+//! `.soc` files are CrCh-format binary blobs that hold the static-object
+//! data for one logical "zone" — its brush instances (chunk 0x0010), its
+//! entity placements (chunk 0x0004), and its visibility-area / portal
+//! graph (chunk 0x000E). A whole level (e.g. an Executive Hangar) is
+//! composed by nesting many SOC files together: a top-level "assembly"
+//! socpak references one or more child socpaks with per-child
+//! position / rotation, and each of those may in turn reference its own
+//! children. This module exposes the four pieces required to walk that
+//! graph:
+//!
+//! - [`brushes`] — chunk 0x0010 brush-instance scan + LOD gate +
+//!   parent-QuatTS composition.
+//! - [`entities`] — chunk 0x0004 CryXmlB walk for lights / doors / loot
+//!   / mesh-bearing entities.
+//! - [`visarea`] — chunk 0x000E vis-area / portal records.
+//! - [`scene`] — multi-zone composition (`CZoneSystem::GetTransform`-
+//!   style transform chaining).
+//!
+//! The brush parser is the only part with hard-format-version checking;
+//! the others soft-fail when a chunk is missing or the version doesn't
+//! match v15 (other versions appear in older builds and player-hangar
+//! variants, which are out of scope for this iteration).
+
+mod common;
+
+pub mod brushes;
+pub mod catalog;
+pub mod entities;
+pub mod render;
+pub mod scene;
+pub mod visarea;
+
+// Re-export the brush parser API at the module root to preserve the
+// public surface that callers (and existing tests) already rely on.
+pub use brushes::{
+    BrushInstance, ParentTransform, SocBrushes, SocError, parse, parse_with_identity_parent,
+};
+
+// Catalog enumeration (data-driven Maps tab list).
+pub use catalog::{
+    MIN_SOCPAK_SIZE_BYTES, SceneCatalogEntry, SceneSourceKind, SocpakDirEntry,
+    SocpakDirEntryKind, enumerate_scene_roots, list_all_socpaks, list_socpak_dir,
+};
+
+// Entity / visarea / scene types are namespaced under their submodules
+// so the names stay legible at the call site.
+pub use entities::{EntityKind, EntityPlacement, SocEntities};
+pub use render::{
+    DEFAULT_MAX_EMITTED_LIGHTS, EmitOptions, GlbEmitSummary, LightDescriptor, LightInstance,
+    LightKind, MeshPlacement, RenderableScene, ResolvedMesh, emit_glb, emit_glb_with_options,
+    resolve_scene, resolve_scene_with_progress,
+};
+pub use scene::{
+    ChildSocpakRef, ComposedScene, SceneError, SceneZone, compose_from_flat_list,
+    compose_from_root, read_child_refs_from_socpak,
+};
+pub use visarea::{SocVisAreas, VisAreaRecord, VisAreaRole};

--- a/crates/starbreaker-3d/src/soc/render.rs
+++ b/crates/starbreaker-3d/src/soc/render.rs
@@ -1,0 +1,1635 @@
+//! Mesh resolution + glTF emission for SOC scenes.
+//!
+//! This module turns a [`super::scene::ComposedScene`] into a self-contained
+//! `.glb` byte vector that the existing GLB loader (Three.js GLTFLoader, the
+//! viewer's mesh decoder) can ingest. The output is organised so the next
+//! iteration can wire it into a Tauri command and render it in the Maps
+//! tab without further format work.
+//!
+//! # Pipeline
+//!
+//! 1. **Resolve meshes.** Every brush placement in the scene references a
+//!    StatObj path (a `.cgf` / `.cgfm` pair under `Data\Objects`). We walk
+//!    the unique-mesh set, look up the geometry bytes through the
+//!    [`MappedP4k`] handle, and parse them with the existing
+//!    [`crate::parse_skin_with_options`] entry point. Failed loads are
+//!    logged and the offending instance is dropped from the output rather
+//!    than aborting the whole scene.
+//! 2. **Dedupe.** The dedupe key is the canonical mesh path
+//!    (lower-cased, backslash-normalised). The reuse rate is high — Exec
+//!    Hangar collapses tens of thousands of brush placements down to a few
+//!    thousand unique CGFs, which keeps the emitted glTF small enough for
+//!    the frontend to load through `URL.createObjectURL`.
+//! 3. **Resolve materials.** For each unique mesh we follow the same
+//!    "MtlName chunk first, sibling `.mtl` second" priority the existing
+//!    pipeline uses (via [`crate::mtl::extract_mtl_name`] and a sibling
+//!    fallback). Failures degrade to a neutral default material so the
+//!    emitter never aborts.
+//! 4. **Emit a single GLB.** One glTF mesh per unique CGF, one node per
+//!    placement carrying the world-space 4x4, lights as
+//!    `KHR_lights_punctual` entries, materials with a `submat_index`
+//!    extra so a downstream loader can bind by index without re-parsing
+//!    names.
+//!
+//! All file paths exchanged with [`MappedP4k`] use Windows-style
+//! backslashes and the `Data\` prefix when needed, matching the
+//! convention the in-tree p4k library expects.
+
+use std::collections::HashMap;
+
+use glam::{DQuat, DVec3, Mat4};
+use gltf_json as json;
+use json::validation::Checked;
+use starbreaker_p4k::MappedP4k;
+
+use crate::Mesh;
+use crate::mtl;
+use crate::parse_skin_with_options;
+use crate::soc::entities::{EntityKind, EntityPlacement};
+use crate::soc::scene::ComposedScene;
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// One unique mesh used by the renderable scene, resolved against the p4k.
+#[derive(Debug, Clone)]
+pub struct ResolvedMesh {
+    /// Canonical path used as the dedupe key. Lower-cased, backslash form.
+    pub canonical_path: String,
+    /// Geometry decoded from the CGF / CGFM pair.
+    pub mesh: Mesh,
+    /// Material file resolved for this mesh, when one was found.
+    pub material: Option<mtl::MtlFile>,
+}
+
+/// One placement of a [`ResolvedMesh`] at a world-space transform.
+#[derive(Debug, Clone)]
+pub struct MeshPlacement {
+    /// Index into [`RenderableScene::meshes`].
+    pub mesh_index: usize,
+    /// World-space transform stored row-major as 3x4 (the SOC parser
+    /// stores `[[f32; 4]; 3]`); we promote it to a 4x4 column-major
+    /// matrix at glTF emission time.
+    pub world_transform: [[f32; 4]; 3],
+    /// Stable identifier — the global brush index in the source
+    /// composed scene. Useful for downstream debugging and for matching
+    /// node names back to source data.
+    pub instance_id: u32,
+}
+
+/// Light source variants the emitter can encode through
+/// `KHR_lights_punctual`.
+#[derive(Debug, Clone)]
+pub enum LightKind {
+    Point,
+    Spot {
+        /// Inner cone angle in radians.
+        inner_cone: f32,
+        /// Outer cone angle in radians.
+        outer_cone: f32,
+    },
+    Directional,
+}
+
+/// Per-light descriptor, neutral enough that the frontend can map it onto
+/// `THREE.PointLight` / `SpotLight` / `DirectionalLight` without further
+/// translation.
+#[derive(Debug, Clone)]
+pub struct LightDescriptor {
+    /// Original entity name (may be empty).
+    pub name: String,
+    pub kind: LightKind,
+    /// Linear RGB color, `[0,1]` per channel.
+    pub color: [f32; 3],
+    /// Candela for point / spot, lux for directional.
+    pub intensity: f32,
+    /// Range cutoff in metres, `0.0` for "engine default".
+    pub range: f32,
+}
+
+/// One light placed at a world-space transform.
+#[derive(Debug, Clone)]
+pub struct LightInstance {
+    pub world_transform: [[f32; 4]; 3],
+    pub descriptor: LightDescriptor,
+}
+
+/// A scene whose meshes have been resolved and whose placements + lights
+/// are ready for glTF emission.
+#[derive(Debug, Clone, Default)]
+pub struct RenderableScene {
+    pub meshes: Vec<ResolvedMesh>,
+    pub placements: Vec<MeshPlacement>,
+    pub lights: Vec<LightInstance>,
+    /// World-space AABB across every brush placement, or `None` if the
+    /// scene has no placements. Stored in the parser's coordinate frame
+    /// (CryEngine Z-up).
+    pub aabb: Option<([f32; 3], [f32; 3])>,
+    /// How many brush placements were dropped because their mesh failed
+    /// to resolve. Reported back to the supervisor so the smoke test can
+    /// surface mesh-load regressions.
+    pub dropped_placements: u32,
+    /// How many unique mesh paths failed to resolve. A unique-mesh failure
+    /// can drop many placements — the two counters are tracked separately.
+    pub failed_mesh_paths: u32,
+    /// How many resolved meshes successfully loaded an MTL file (either via
+    /// the MtlName chunk or the sibling fallback). Surfaced so the
+    /// frontend can show a coverage indicator: when this drops far below
+    /// `meshes.len()`, materials are mostly the neutral default.
+    pub materials_resolved: u32,
+    /// How many resolved meshes have no MTL bound and are using the
+    /// neutral default material (everything in `meshes` minus
+    /// `materials_resolved`).
+    pub materials_default: u32,
+}
+
+/// Result returned by [`emit_glb`]: the GLB byte vector plus a summary
+/// for the caller's manifest / progress UI. Plain fields, easy to copy
+/// into a `serde_json::json!` blob at the Tauri layer.
+#[derive(Debug, Clone)]
+pub struct GlbEmitSummary {
+    pub mesh_count: u32,
+    pub placement_count: u32,
+    /// Lights actually emitted into the GLB. Equal to
+    /// `min(scene.lights.len(), max_lights)`.
+    pub light_count: u32,
+    /// Lights present in the input scene but skipped because the
+    /// importance-sorted top-N cap was reached. Surface this on the UI
+    /// so the user knows lighting is approximate.
+    pub lights_dropped: u32,
+    pub material_count: u32,
+    pub texture_count: u32,
+    pub aabb_min: Option<[f32; 3]>,
+    pub aabb_max: Option<[f32; 3]>,
+}
+
+/// Configuration knobs for [`emit_glb`]. Defaults match the values most
+/// callers want; pass an explicit value when iterating on the cap.
+#[derive(Debug, Clone, Copy)]
+pub struct EmitOptions {
+    /// Maximum number of lights to encode into the GLB. The emitter
+    /// sorts the input lights by descending intensity and keeps the top
+    /// N; the rest are skipped. Forward-rendered three.js shaders
+    /// allocate ~10 fragment uniforms per light, so going above ~64 on
+    /// a 1024-uniform GPU exceeds `MAX_FRAGMENT_UNIFORM_VECTORS` and
+    /// silently fails to compile every lit material in the scene.
+    pub max_lights: usize,
+}
+
+/// Default cap on the number of lights emitted. Conservative: a handful
+/// of GPUs report `MAX_FRAGMENT_UNIFORM_VECTORS = 1024`; at ~10 uniforms
+/// per point light plus the per-material baseline, 64 fits comfortably
+/// inside the cap on all of them. Drop to 32 if a user reports the
+/// shader-compile error on this default.
+pub const DEFAULT_MAX_EMITTED_LIGHTS: usize = 64;
+
+impl Default for EmitOptions {
+    fn default() -> Self {
+        Self {
+            max_lights: DEFAULT_MAX_EMITTED_LIGHTS,
+        }
+    }
+}
+
+// ── Mesh resolution ─────────────────────────────────────────────────────────
+
+/// Resolve every brush placement in `scene` against the p4k, producing a
+/// [`RenderableScene`] ready for emission. Per-mesh failures are logged
+/// at warn level and surface in `RenderableScene::failed_mesh_paths`;
+/// per-placement failures are counted in `dropped_placements` so callers
+/// can spot a sudden regression.
+pub fn resolve_scene(p4k: &MappedP4k, scene: &ComposedScene) -> RenderableScene {
+    resolve_scene_with_progress(p4k, scene, &mut |_, _| {})
+}
+
+/// Like [`resolve_scene`] but reports per-mesh resolution progress
+/// through `on_progress(current, total)`. Callers (e.g. the Tauri
+/// command surface) can throttle and forward these updates as
+/// `scene-load-progress` events.
+pub fn resolve_scene_with_progress<F>(
+    p4k: &MappedP4k,
+    scene: &ComposedScene,
+    on_progress: &mut F,
+) -> RenderableScene
+where
+    F: FnMut(usize, usize),
+{
+    let mut out = RenderableScene::default();
+
+    // First pass: collect unique mesh paths from every zone's brush set.
+    let mut path_to_index: HashMap<String, usize> = HashMap::new();
+    let mut canonical_paths: Vec<String> = Vec::new();
+    let mut original_paths: Vec<String> = Vec::new();
+
+    for zone in &scene.zones {
+        for brush in &zone.brushes {
+            let mesh_path = match zone.mesh_paths.get(brush.mesh_index as usize) {
+                Some(p) => p,
+                None => continue,
+            };
+            let canonical = canonicalize_mesh_path(mesh_path);
+            if !path_to_index.contains_key(&canonical) {
+                path_to_index.insert(canonical.clone(), canonical_paths.len());
+                canonical_paths.push(canonical);
+                original_paths.push(mesh_path.clone());
+            }
+        }
+    }
+
+    // Second pass: try to load each unique mesh. Track which canonical
+    // paths fell through so we can fold their placement-side losses into
+    // `dropped_placements`.
+    let total_unique = canonical_paths.len();
+    let mut canonical_to_resolved: HashMap<String, usize> = HashMap::new();
+    for (i, (canonical, original)) in canonical_paths
+        .iter()
+        .zip(original_paths.iter())
+        .enumerate()
+    {
+        on_progress(i, total_unique);
+        match resolve_one_mesh(p4k, original) {
+            Some(resolved) => {
+                let resolved_index = out.meshes.len();
+                canonical_to_resolved.insert(canonical.clone(), resolved_index);
+                let has_material = resolved.1.is_some();
+                out.meshes.push(ResolvedMesh {
+                    canonical_path: canonical.clone(),
+                    mesh: resolved.0,
+                    material: resolved.1,
+                });
+                if has_material {
+                    out.materials_resolved += 1;
+                } else {
+                    out.materials_default += 1;
+                }
+            }
+            None => {
+                out.failed_mesh_paths += 1;
+            }
+        }
+    }
+    on_progress(total_unique, total_unique);
+
+    // Third pass: emit one placement per brush. Drop placements whose
+    // mesh failed to resolve.
+    let mut global_brush_index: u32 = 0;
+    for zone in &scene.zones {
+        for brush in &zone.brushes {
+            let mesh_path = match zone.mesh_paths.get(brush.mesh_index as usize) {
+                Some(p) => p,
+                None => {
+                    out.dropped_placements += 1;
+                    global_brush_index = global_brush_index.wrapping_add(1);
+                    continue;
+                }
+            };
+            let canonical = canonicalize_mesh_path(mesh_path);
+            let Some(&mesh_index) = canonical_to_resolved.get(&canonical) else {
+                out.dropped_placements += 1;
+                global_brush_index = global_brush_index.wrapping_add(1);
+                continue;
+            };
+            out.placements.push(MeshPlacement {
+                mesh_index,
+                world_transform: brush.world_transform,
+                instance_id: global_brush_index,
+            });
+            update_aabb(&mut out.aabb, &brush.translation);
+            global_brush_index = global_brush_index.wrapping_add(1);
+        }
+    }
+
+    // Fourth pass: lights. We keep every light entity, even ones with no
+    // explicit colour / intensity, and rely on a sane default downstream.
+    for zone in &scene.zones {
+        for entity in &zone.entities {
+            if entity.kind != EntityKind::Light {
+                continue;
+            }
+            out.lights.push(LightInstance {
+                world_transform: entity_world_transform(entity, zone.parent_translation,
+                    zone.parent_rotation),
+                descriptor: light_from_entity(entity),
+            });
+        }
+    }
+
+    out
+}
+
+/// Lower-case + backslash-normalise a mesh path, then strip any leading
+/// `data\` so reuse works across the few different conventions the SOC
+/// data uses.
+fn canonicalize_mesh_path(path: &str) -> String {
+    let lc = path.to_ascii_lowercase().replace('/', "\\");
+    lc.strip_prefix("data\\").map(|s| s.to_string()).unwrap_or(lc)
+}
+
+fn resolve_one_mesh(
+    p4k: &MappedP4k,
+    original_path: &str,
+) -> Option<(Mesh, Option<mtl::MtlFile>)> {
+    let geom_bytes = read_geom_bytes(p4k, original_path)?;
+    let mesh = match parse_skin_with_options(&geom_bytes, false) {
+        Ok(m) => m,
+        Err(err) => {
+            log::warn!("[soc-render] mesh parse failed for {original_path}: {err:?}");
+            return None;
+        }
+    };
+    let metadata = read_metadata_bytes(p4k, original_path);
+    let material = resolve_material_for_mesh(p4k, original_path, metadata.as_deref());
+    Some((mesh, material))
+}
+
+/// Read the geometry payload for a mesh. Most SOC brushes ship as a
+/// `.cgf` + `.cgfm` pair where the `.cgfm` carries the IVO chunks the
+/// parser wants. We try the sibling `.cgfm` first; if absent, the parent
+/// `.cgf` itself is the IVO container.
+fn read_geom_bytes(p4k: &MappedP4k, original_path: &str) -> Option<Vec<u8>> {
+    let primary = p4k_path_for(original_path);
+    let companion = format!("{primary}m");
+    if let Some(entry) = p4k.entry_case_insensitive(&companion)
+        && let Ok(bytes) = p4k.read(entry)
+    {
+        return Some(bytes);
+    }
+    if let Some(entry) = p4k.entry_case_insensitive(&primary)
+        && let Ok(bytes) = p4k.read(entry)
+    {
+        return Some(bytes);
+    }
+    None
+}
+
+/// Read the primary mesh file (the `.cgf` itself) — used as the source of
+/// the `MtlName` chunk for material resolution.
+fn read_metadata_bytes(p4k: &MappedP4k, original_path: &str) -> Option<Vec<u8>> {
+    let primary = p4k_path_for(original_path);
+    let entry = p4k.entry_case_insensitive(&primary)?;
+    p4k.read(entry).ok()
+}
+
+/// Convert a SOC-table mesh path into the canonical `Data\...` form the
+/// p4k library expects.
+fn p4k_path_for(original_path: &str) -> String {
+    let normalised = original_path.replace('/', "\\");
+    if normalised
+        .to_ascii_lowercase()
+        .starts_with("data\\")
+    {
+        normalised
+    } else {
+        format!("Data\\{normalised}")
+    }
+}
+
+/// Resolve a material for a mesh by trying the on-disk `MtlName` chunk
+/// first and falling back to the same-name sibling `.mtl`.
+fn resolve_material_for_mesh(
+    p4k: &MappedP4k,
+    original_path: &str,
+    metadata_bytes: Option<&[u8]>,
+) -> Option<mtl::MtlFile> {
+    let primary = p4k_path_for(original_path);
+
+    if let Some(metadata) = metadata_bytes
+        && let Some(name) = mtl::extract_mtl_name(metadata)
+    {
+        let mtl_path = mtl_path_for(&name, &primary);
+        if let Some(material) = read_mtl(p4k, &mtl_path) {
+            return Some(material);
+        }
+    }
+
+    // Sibling `.mtl` fallback — same stem next to the geometry.
+    let sibling = sibling_mtl_for(&primary);
+    if let Some(material) = read_mtl(p4k, &sibling) {
+        return Some(material);
+    }
+
+    None
+}
+
+fn read_mtl(p4k: &MappedP4k, p4k_path: &str) -> Option<mtl::MtlFile> {
+    let entry = p4k.entry_case_insensitive(p4k_path)?;
+    let data = p4k.read(entry).ok()?;
+    let mut mtl = mtl::parse_mtl(&data).ok()?;
+    mtl.source_path = Some(p4k_path.to_string());
+    Some(mtl)
+}
+
+/// Compose an `MtlName` chunk's value with the mesh path to get the
+/// material's p4k location. Names that contain a path separator are taken
+/// verbatim (rooted under `Data\`); plain names are looked up as a sibling
+/// of the mesh.
+fn mtl_path_for(mtl_name: &str, p4k_geom_path: &str) -> String {
+    if mtl_name.contains('/') || mtl_name.contains('\\') {
+        format!("Data\\{}.mtl", mtl_name.replace('/', "\\"))
+    } else {
+        let dir = p4k_geom_path
+            .rfind('\\')
+            .map(|i| &p4k_geom_path[..i])
+            .unwrap_or(p4k_geom_path);
+        format!("{dir}\\{mtl_name}.mtl")
+    }
+}
+
+fn sibling_mtl_for(p4k_geom_path: &str) -> String {
+    if let Some(dot) = p4k_geom_path.rfind('.') {
+        format!("{}.mtl", &p4k_geom_path[..dot])
+    } else {
+        format!("{p4k_geom_path}.mtl")
+    }
+}
+
+// ── AABB tracking ───────────────────────────────────────────────────────────
+
+fn update_aabb(aabb: &mut Option<([f32; 3], [f32; 3])>, point: &[f32; 3]) {
+    match aabb {
+        None => *aabb = Some((*point, *point)),
+        Some((mn, mx)) => {
+            for i in 0..3 {
+                if point[i] < mn[i] {
+                    mn[i] = point[i];
+                }
+                if point[i] > mx[i] {
+                    mx[i] = point[i];
+                }
+            }
+        }
+    }
+}
+
+// ── Lights ──────────────────────────────────────────────────────────────────
+
+/// Default colour when the entity does not carry a tint. Slightly warm
+/// white to match the engine's neutral lamp setup.
+const LIGHT_DEFAULT_COLOR: [f32; 3] = [1.0, 0.95, 0.88];
+/// Default candela value when the entity does not advertise an intensity.
+const LIGHT_DEFAULT_INTENSITY: f32 = 1.0;
+/// Default range cutoff in metres. Zero tells `KHR_lights_punctual`
+/// consumers to use their own engine default.
+const LIGHT_DEFAULT_RANGE: f32 = 0.0;
+
+/// Build a `LightDescriptor` from one entity. We only have placement +
+/// class on the SOC side; colour / intensity / radius come from
+/// `PropertiesDataCore` records that the renderer or DataCore layer
+/// resolves later. The descriptor encodes sane defaults so the glTF
+/// emitter has a complete record to write.
+fn light_from_entity(entity: &EntityPlacement) -> LightDescriptor {
+    let kind = match entity.entity_class.as_str() {
+        // The SOC stream does not yet split spot vs point — every light
+        // placement is treated as a point light at this layer. Iteration
+        // C can split spotlights once the DataCore-side classifier lands.
+        _ => LightKind::Point,
+    };
+    LightDescriptor {
+        name: if entity.name.is_empty() {
+            entity.entity_class.clone()
+        } else {
+            entity.name.clone()
+        },
+        kind,
+        color: LIGHT_DEFAULT_COLOR,
+        intensity: LIGHT_DEFAULT_INTENSITY,
+        range: LIGHT_DEFAULT_RANGE,
+    }
+}
+
+/// Recover a 3x4 row-major world transform for an entity by composing
+/// its parent QuatTS with its placement. `EntityPlacement` already
+/// stores world-space translation + rotation; we just re-pack into the
+/// emitter's expected layout (column rotation followed by translation).
+fn entity_world_transform(
+    entity: &EntityPlacement,
+    _parent_t: [f64; 3],
+    _parent_r: [f64; 4],
+) -> [[f32; 4]; 3] {
+    let q = DQuat::from_xyzw(
+        entity.rotation[0] as f64,
+        entity.rotation[1] as f64,
+        entity.rotation[2] as f64,
+        entity.rotation[3] as f64,
+    )
+    .normalize();
+    let t = DVec3::new(
+        entity.translation[0] as f64,
+        entity.translation[1] as f64,
+        entity.translation[2] as f64,
+    );
+    let cols = [
+        q * DVec3::X,
+        q * DVec3::Y,
+        q * DVec3::Z,
+    ];
+    [
+        [cols[0].x as f32, cols[1].x as f32, cols[2].x as f32, t.x as f32],
+        [cols[0].y as f32, cols[1].y as f32, cols[2].y as f32, t.y as f32],
+        [cols[0].z as f32, cols[1].z as f32, cols[2].z as f32, t.z as f32],
+    ]
+}
+
+// ── glTF emission ───────────────────────────────────────────────────────────
+
+/// Convert a 3x4 row-major matrix into glTF's flat 16-element column-major
+/// layout (matrices in glTF are column-major).
+fn mat3x4_to_gltf_matrix(m: &[[f32; 4]; 3]) -> [f32; 16] {
+    [
+        m[0][0], m[1][0], m[2][0], 0.0,
+        m[0][1], m[1][1], m[2][1], 0.0,
+        m[0][2], m[1][2], m[2][2], 0.0,
+        m[0][3], m[1][3], m[2][3], 1.0,
+    ]
+}
+
+/// Emit a self-contained `.glb` byte vector for the given
+/// [`RenderableScene`]. The emitted file follows glTF 2.0 spec and uses
+/// `KHR_lights_punctual` for every light entity. Uses
+/// [`EmitOptions::default`].
+pub fn emit_glb(scene: &RenderableScene) -> Result<(Vec<u8>, GlbEmitSummary), String> {
+    emit_glb_with_options(scene, EmitOptions::default())
+}
+
+/// Like [`emit_glb`] but takes an explicit [`EmitOptions`] so callers
+/// can override the light cap.
+pub fn emit_glb_with_options(
+    scene: &RenderableScene,
+    options: EmitOptions,
+) -> Result<(Vec<u8>, GlbEmitSummary), String> {
+    let mut bin: Vec<u8> = Vec::new();
+    let mut buffer_views: Vec<json::buffer::View> = Vec::new();
+    let mut accessors: Vec<json::Accessor> = Vec::new();
+    let images: Vec<json::Image> = Vec::new();
+    let textures: Vec<json::Texture> = Vec::new();
+    let samplers: Vec<json::texture::Sampler> = Vec::new();
+    let mut materials: Vec<json::Material> = Vec::new();
+    let mut meshes: Vec<json::Mesh> = Vec::new();
+    let mut nodes: Vec<json::Node> = Vec::new();
+
+    // Default neutral material returned for meshes that did not resolve a
+    // material. Stays at index 0; per-mesh materials append after it.
+    let default_material_index = materials.len() as u32;
+    materials.push(neutral_material());
+
+    // Per-resolved-mesh: list of glTF material indices, one per submesh.
+    let mut mesh_material_indices: Vec<Vec<u32>> = Vec::with_capacity(scene.meshes.len());
+
+    // ── Pack per-mesh materials ─────────────────────────────────────────
+    for resolved in &scene.meshes {
+        let mut indices = Vec::with_capacity(resolved.mesh.submeshes.len());
+        for submesh in &resolved.mesh.submeshes {
+            let mat_idx = match resolved.material.as_ref() {
+                Some(mtl) => build_glb_material(
+                    mtl,
+                    submesh.material_id as usize,
+                    &mut materials,
+                ),
+                None => default_material_index,
+            };
+            indices.push(mat_idx);
+        }
+        mesh_material_indices.push(indices);
+    }
+
+    // ── Pack per-mesh geometry ──────────────────────────────────────────
+    let mut mesh_indices_by_resolved: Vec<u32> = Vec::with_capacity(scene.meshes.len());
+    for (resolved_idx, resolved) in scene.meshes.iter().enumerate() {
+        let mat_indices = &mesh_material_indices[resolved_idx];
+        let mesh_idx = pack_mesh(
+            &resolved.mesh,
+            &resolved.canonical_path,
+            mat_indices,
+            &mut buffer_views,
+            &mut accessors,
+            &mut meshes,
+            &mut bin,
+        )?;
+        mesh_indices_by_resolved.push(mesh_idx);
+    }
+
+    // ── Emit one node per placement ─────────────────────────────────────
+    let mut scene_nodes: Vec<json::Index<json::Node>> = Vec::new();
+
+    for placement in &scene.placements {
+        let mesh_idx = mesh_indices_by_resolved
+            .get(placement.mesh_index)
+            .copied()
+            .ok_or_else(|| format!("placement references missing mesh {}", placement.mesh_index))?;
+        let matrix = mat3x4_to_gltf_matrix(&placement.world_transform);
+        let identity = is_identity_matrix(&matrix);
+
+        let mut extras_map = serde_json::Map::new();
+        extras_map.insert(
+            "instance_id".into(),
+            serde_json::json!(placement.instance_id),
+        );
+        let extras_string = serde_json::to_string(&serde_json::Value::Object(extras_map))
+            .map_err(|e| format!("instance extras serialize: {e}"))?;
+        let extras = serde_json::value::RawValue::from_string(extras_string)
+            .map_err(|e| format!("instance extras raw value: {e}"))?
+            .into();
+
+        let node_idx = nodes.len() as u32;
+        nodes.push(json::Node {
+            mesh: Some(json::Index::new(mesh_idx)),
+            matrix: if identity { None } else { Some(matrix) },
+            name: Some(format!("brush_{}", placement.instance_id)),
+            extras: Some(extras),
+            ..Default::default()
+        });
+        scene_nodes.push(json::Index::new(node_idx));
+    }
+
+    // ── Cap the light list ─────────────────────────────────────────────
+    // Forward-rendered fragments allocate uniforms per active light, so
+    // an unbounded scene blows past `MAX_FRAGMENT_UNIFORM_VECTORS` and
+    // every lit material in the WebGL pipeline silently fails to
+    // compile. Sort by descending intensity, take the top-N, count the
+    // rest as `lights_dropped`.
+    let total_light_input = scene.lights.len() as u32;
+    let kept_lights = pick_top_lights(&scene.lights, options.max_lights);
+    let lights_dropped = total_light_input.saturating_sub(kept_lights.len() as u32);
+
+    // ── Emit one node per kept light, each carrying a KHR_lights_punctual ref
+    let lights_root = build_lights_root(&kept_lights, &mut nodes, &mut scene_nodes);
+
+    // ── Finalise the glTF root ──────────────────────────────────────────
+    let extensions_used = if kept_lights.is_empty() {
+        Vec::new()
+    } else {
+        vec!["KHR_lights_punctual".to_string()]
+    };
+
+    let scene_root = json::Scene {
+        nodes: scene_nodes,
+        name: Some("soc_scene".to_string()),
+        extensions: None,
+        extras: Default::default(),
+    };
+
+    let aabb_pair = scene.aabb;
+    let summary = GlbEmitSummary {
+        mesh_count: scene.meshes.len() as u32,
+        placement_count: scene.placements.len() as u32,
+        light_count: kept_lights.len() as u32,
+        lights_dropped,
+        material_count: materials.len() as u32,
+        texture_count: textures.len() as u32,
+        aabb_min: aabb_pair.map(|p| p.0),
+        aabb_max: aabb_pair.map(|p| p.1),
+    };
+
+    let asset_extras = build_asset_extras(&summary)?;
+
+    let root = json::Root {
+        asset: json::Asset {
+            generator: Some("starbreaker-soc-scene".into()),
+            version: "2.0".into(),
+            extras: asset_extras,
+            ..Default::default()
+        },
+        buffers: vec![json::Buffer {
+            byte_length: json::validation::USize64(bin.len() as u64),
+            uri: None,
+            name: None,
+            extensions: None,
+            extras: Default::default(),
+        }],
+        buffer_views,
+        accessors,
+        meshes,
+        materials,
+        images,
+        textures,
+        samplers,
+        nodes,
+        scenes: vec![scene_root],
+        scene: Some(json::Index::new(0)),
+        extensions_used,
+        extensions: lights_root,
+        ..Default::default()
+    };
+
+    let glb = serialize_glb(&root, &bin)?;
+    Ok((glb, summary))
+}
+
+fn build_asset_extras(
+    summary: &GlbEmitSummary,
+) -> Result<Option<Box<serde_json::value::RawValue>>, String> {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "soc_emitter_version".into(),
+        serde_json::json!(env!("CARGO_PKG_VERSION")),
+    );
+    map.insert("mesh_count".into(), serde_json::json!(summary.mesh_count));
+    map.insert(
+        "placement_count".into(),
+        serde_json::json!(summary.placement_count),
+    );
+    map.insert("light_count".into(), serde_json::json!(summary.light_count));
+    map.insert(
+        "lights_dropped".into(),
+        serde_json::json!(summary.lights_dropped),
+    );
+    if let (Some(mn), Some(mx)) = (summary.aabb_min, summary.aabb_max) {
+        map.insert("aabb_min".into(), serde_json::json!(mn));
+        map.insert("aabb_max".into(), serde_json::json!(mx));
+    }
+    let s = serde_json::to_string(&serde_json::Value::Object(map))
+        .map_err(|e| format!("asset extras serialize: {e}"))?;
+    Ok(Some(
+        serde_json::value::RawValue::from_string(s)
+            .map_err(|e| format!("asset extras raw value: {e}"))?
+            .into(),
+    ))
+}
+
+fn is_identity_matrix(m: &[f32; 16]) -> bool {
+    let identity = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    for i in 0..16 {
+        if (m[i] - identity[i]).abs() > 1e-6 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Build a glTF material from one submaterial of an `MtlFile`.
+///
+/// We deliberately do NOT bind a `baseColorTexture` here, even when the
+/// MTL points at a diffuse texture. Earlier iterations embedded a 1x1
+/// placeholder PNG and bound every textured material to it; on a scene
+/// with thousands of materials, GLTFLoader's per-image blob URLs (one
+/// per embedded image) and the placeholder texture's GPU upload
+/// lifecycle interacted badly with the texture-resolver substitution
+/// step and produced "Couldn't load texture blob:..." errors at render
+/// time. Skipping the placeholder removes the failure surface entirely
+/// and shrinks the GLB. The downstream loader detects "this material
+/// wants a diffuse texture" by reading the `diffuse_texture_path` extra
+/// and creates a real `THREE.Texture` on the JS side once the DDS
+/// resolves.
+fn build_glb_material(
+    mtl: &mtl::MtlFile,
+    submaterial_id: usize,
+    materials: &mut Vec<json::Material>,
+) -> u32 {
+    let sub = mtl.materials.get(submaterial_id);
+    let (base_rgb, opacity, name, diffuse_tex_path, normal_tex_path) = match sub {
+        Some(s) => (
+            s.diffuse,
+            s.opacity,
+            Some(format!(
+                "{}_{}",
+                mtl.source_path
+                    .as_ref()
+                    .and_then(|p| p.rsplit(['\\', '/']).next())
+                    .map(|f| f.strip_suffix(".mtl").unwrap_or(f))
+                    .unwrap_or("mtl"),
+                if s.name.is_empty() {
+                    format!("submat_{submaterial_id}")
+                } else {
+                    s.name.clone()
+                },
+            )),
+            s.diffuse_tex.clone(),
+            s.normal_tex.clone(),
+        ),
+        None => ([0.8, 0.8, 0.8], 1.0, None, None, None),
+    };
+
+    let mut extras_map = serde_json::Map::new();
+    extras_map.insert(
+        "submat_index".into(),
+        serde_json::json!(submaterial_id),
+    );
+    if let Some(path) = diffuse_tex_path {
+        extras_map.insert("diffuse_texture_path".into(), serde_json::json!(path));
+    }
+    if let Some(path) = normal_tex_path {
+        extras_map.insert("normal_texture_path".into(), serde_json::json!(path));
+    }
+    if let Some(src) = mtl.source_path.as_ref() {
+        extras_map.insert("mtl_source_path".into(), serde_json::json!(src));
+    }
+    let extras_string = serde_json::to_string(&serde_json::Value::Object(extras_map))
+        .ok()
+        .unwrap_or_default();
+    let extras = serde_json::value::RawValue::from_string(extras_string)
+        .ok()
+        .map(|raw| raw.into());
+
+    let material = json::Material {
+        name,
+        pbr_metallic_roughness: json::material::PbrMetallicRoughness {
+            base_color_factor: json::material::PbrBaseColorFactor([
+                base_rgb[0],
+                base_rgb[1],
+                base_rgb[2],
+                opacity,
+            ]),
+            base_color_texture: None,
+            metallic_factor: json::material::StrengthFactor(0.0),
+            roughness_factor: json::material::StrengthFactor(0.8),
+            metallic_roughness_texture: None,
+            extensions: Default::default(),
+            extras: Default::default(),
+        },
+        alpha_mode: Checked::Valid(if opacity < 0.999 {
+            json::material::AlphaMode::Blend
+        } else {
+            json::material::AlphaMode::Opaque
+        }),
+        double_sided: false,
+        extras,
+        ..Default::default()
+    };
+    let idx = materials.len() as u32;
+    materials.push(material);
+    idx
+}
+
+/// Sort the input lights by descending intensity and return at most
+/// `max_lights` of them, preserving the `LightInstance` payloads. When
+/// `max_lights == 0` returns an empty slice. When the input already fits
+/// under the cap, returns it as-is (no clone of the descriptor data
+/// payloads beyond the wrapping vector).
+fn pick_top_lights(lights: &[LightInstance], max_lights: usize) -> Vec<LightInstance> {
+    if max_lights == 0 || lights.is_empty() {
+        return Vec::new();
+    }
+    if lights.len() <= max_lights {
+        return lights.to_vec();
+    }
+    let mut indexed: Vec<(usize, f32)> = lights
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (i, l.descriptor.intensity))
+        .collect();
+    // Descending by intensity. Use partial_cmp + reverse so NaN inputs
+    // sort to the end rather than panicking.
+    indexed.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    indexed.truncate(max_lights);
+    // Restore the original placement order so the kept set still tracks
+    // the level layout — no functional dependency on order, but it
+    // makes diffs stable and debugging easier.
+    indexed.sort_by_key(|(i, _)| *i);
+    indexed
+        .into_iter()
+        .map(|(i, _)| lights[i].clone())
+        .collect()
+}
+
+fn neutral_material() -> json::Material {
+    json::Material {
+        name: Some("soc_default".to_string()),
+        pbr_metallic_roughness: json::material::PbrMetallicRoughness {
+            base_color_factor: json::material::PbrBaseColorFactor([0.7, 0.7, 0.7, 1.0]),
+            base_color_texture: None,
+            metallic_factor: json::material::StrengthFactor(0.0),
+            roughness_factor: json::material::StrengthFactor(0.85),
+            metallic_roughness_texture: None,
+            extensions: Default::default(),
+            extras: Default::default(),
+        },
+        alpha_mode: Checked::Valid(json::material::AlphaMode::Opaque),
+        double_sided: false,
+        ..Default::default()
+    }
+}
+
+fn align_bin_to_4(bin: &mut Vec<u8>) {
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+}
+
+/// Pack one mesh's geometry into the BIN buffer, register accessors, and
+/// emit one glTF Mesh with one primitive per submesh. Returns the glTF
+/// mesh index.
+fn pack_mesh(
+    mesh: &Mesh,
+    canonical_path: &str,
+    submesh_material_indices: &[u32],
+    buffer_views: &mut Vec<json::buffer::View>,
+    accessors: &mut Vec<json::Accessor>,
+    meshes: &mut Vec<json::Mesh>,
+    bin: &mut Vec<u8>,
+) -> Result<u32, String> {
+    align_bin_to_4(bin);
+
+    // Positions.
+    let pos_offset = bin.len();
+    for p in &mesh.positions {
+        bin.extend_from_slice(&p[0].to_le_bytes());
+        bin.extend_from_slice(&p[1].to_le_bytes());
+        bin.extend_from_slice(&p[2].to_le_bytes());
+    }
+    let pos_len = bin.len() - pos_offset;
+    let (pos_min, pos_max) = position_min_max(&mesh.positions);
+
+    let pos_bv = buffer_views.len() as u32;
+    buffer_views.push(json::buffer::View {
+        buffer: json::Index::new(0),
+        byte_offset: Some(json::validation::USize64(pos_offset as u64)),
+        byte_length: json::validation::USize64(pos_len as u64),
+        byte_stride: None,
+        target: Some(Checked::Valid(json::buffer::Target::ArrayBuffer)),
+        name: None,
+        extensions: None,
+        extras: Default::default(),
+    });
+    let pos_acc = accessors.len() as u32;
+    accessors.push(json::Accessor {
+        buffer_view: Some(json::Index::new(pos_bv)),
+        byte_offset: Some(json::validation::USize64(0)),
+        count: json::validation::USize64(mesh.positions.len() as u64),
+        component_type: Checked::Valid(json::accessor::GenericComponentType(
+            json::accessor::ComponentType::F32,
+        )),
+        type_: Checked::Valid(json::accessor::Type::Vec3),
+        min: Some(serde_json::Value::Array(
+            pos_min.iter().map(|&v| serde_json::Value::from(v)).collect(),
+        )),
+        max: Some(serde_json::Value::Array(
+            pos_max.iter().map(|&v| serde_json::Value::from(v)).collect(),
+        )),
+        name: None,
+        normalized: false,
+        sparse: None,
+        extensions: None,
+        extras: Default::default(),
+    });
+
+    // Indices, packed once for the whole mesh; each submesh gets its own
+    // accessor with byte_offset + count for its slice.
+    align_bin_to_4(bin);
+    let idx_offset = bin.len();
+    for &i in &mesh.indices {
+        bin.extend_from_slice(&i.to_le_bytes());
+    }
+    let idx_len = bin.len() - idx_offset;
+    let idx_bv = buffer_views.len() as u32;
+    buffer_views.push(json::buffer::View {
+        buffer: json::Index::new(0),
+        byte_offset: Some(json::validation::USize64(idx_offset as u64)),
+        byte_length: json::validation::USize64(idx_len as u64),
+        byte_stride: None,
+        target: Some(Checked::Valid(json::buffer::Target::ElementArrayBuffer)),
+        name: None,
+        extensions: None,
+        extras: Default::default(),
+    });
+
+    // Optional UVs.
+    let uv_acc = mesh.uvs.as_ref().map(|uvs| {
+        align_bin_to_4(bin);
+        let uv_offset = bin.len();
+        for uv in uvs {
+            bin.extend_from_slice(&uv[0].to_le_bytes());
+            bin.extend_from_slice(&uv[1].to_le_bytes());
+        }
+        let uv_len = bin.len() - uv_offset;
+        let uv_bv = buffer_views.len() as u32;
+        buffer_views.push(json::buffer::View {
+            buffer: json::Index::new(0),
+            byte_offset: Some(json::validation::USize64(uv_offset as u64)),
+            byte_length: json::validation::USize64(uv_len as u64),
+            byte_stride: None,
+            target: Some(Checked::Valid(json::buffer::Target::ArrayBuffer)),
+            name: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        let acc = accessors.len() as u32;
+        accessors.push(json::Accessor {
+            buffer_view: Some(json::Index::new(uv_bv)),
+            byte_offset: Some(json::validation::USize64(0)),
+            count: json::validation::USize64(uvs.len() as u64),
+            component_type: Checked::Valid(json::accessor::GenericComponentType(
+                json::accessor::ComponentType::F32,
+            )),
+            type_: Checked::Valid(json::accessor::Type::Vec2),
+            min: None,
+            max: None,
+            name: None,
+            normalized: false,
+            sparse: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        acc
+    });
+
+    // Optional normals.
+    let normal_acc = mesh.normals.as_ref().map(|norms| {
+        align_bin_to_4(bin);
+        let off = bin.len();
+        for n in norms {
+            bin.extend_from_slice(&n[0].to_le_bytes());
+            bin.extend_from_slice(&n[1].to_le_bytes());
+            bin.extend_from_slice(&n[2].to_le_bytes());
+        }
+        let len = bin.len() - off;
+        let bv = buffer_views.len() as u32;
+        buffer_views.push(json::buffer::View {
+            buffer: json::Index::new(0),
+            byte_offset: Some(json::validation::USize64(off as u64)),
+            byte_length: json::validation::USize64(len as u64),
+            byte_stride: None,
+            target: Some(Checked::Valid(json::buffer::Target::ArrayBuffer)),
+            name: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        let acc = accessors.len() as u32;
+        accessors.push(json::Accessor {
+            buffer_view: Some(json::Index::new(bv)),
+            byte_offset: Some(json::validation::USize64(0)),
+            count: json::validation::USize64(norms.len() as u64),
+            component_type: Checked::Valid(json::accessor::GenericComponentType(
+                json::accessor::ComponentType::F32,
+            )),
+            type_: Checked::Valid(json::accessor::Type::Vec3),
+            min: None,
+            max: None,
+            name: None,
+            normalized: false,
+            sparse: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        acc
+    });
+
+    // Build one primitive per submesh. Each primitive shares the same
+    // POSITION/UV/NORMAL accessors but gets its own index accessor that
+    // points at the submesh's slice of the global index buffer.
+    let mut primitives: Vec<json::mesh::Primitive> =
+        Vec::with_capacity(mesh.submeshes.len().max(1));
+
+    if mesh.submeshes.is_empty() {
+        // Whole-mesh fallback for meshes that ship without explicit submeshes.
+        let idx_acc = accessors.len() as u32;
+        accessors.push(json::Accessor {
+            buffer_view: Some(json::Index::new(idx_bv)),
+            byte_offset: Some(json::validation::USize64(0)),
+            count: json::validation::USize64(mesh.indices.len() as u64),
+            component_type: Checked::Valid(json::accessor::GenericComponentType(
+                json::accessor::ComponentType::U32,
+            )),
+            type_: Checked::Valid(json::accessor::Type::Scalar),
+            min: None,
+            max: None,
+            name: None,
+            normalized: false,
+            sparse: None,
+            extensions: None,
+            extras: Default::default(),
+        });
+        primitives.push(make_primitive(
+            pos_acc,
+            uv_acc,
+            normal_acc,
+            idx_acc,
+            submesh_material_indices.first().copied().unwrap_or(0),
+        ));
+    } else {
+        for (sm_idx, sub) in mesh.submeshes.iter().enumerate() {
+            if sub.num_indices == 0 {
+                continue;
+            }
+            let byte_offset = (sub.first_index as usize) * 4;
+            let idx_acc = accessors.len() as u32;
+            accessors.push(json::Accessor {
+                buffer_view: Some(json::Index::new(idx_bv)),
+                byte_offset: Some(json::validation::USize64(byte_offset as u64)),
+                count: json::validation::USize64(sub.num_indices as u64),
+                component_type: Checked::Valid(json::accessor::GenericComponentType(
+                    json::accessor::ComponentType::U32,
+                )),
+                type_: Checked::Valid(json::accessor::Type::Scalar),
+                min: None,
+                max: None,
+                name: None,
+                normalized: false,
+                sparse: None,
+                extensions: None,
+                extras: Default::default(),
+            });
+            let mat_idx = submesh_material_indices
+                .get(sm_idx)
+                .copied()
+                .unwrap_or(0);
+            primitives.push(make_primitive(pos_acc, uv_acc, normal_acc, idx_acc, mat_idx));
+        }
+    }
+
+    if primitives.is_empty() {
+        return Err(format!("mesh {canonical_path} produced no primitives"));
+    }
+
+    let mesh_idx = meshes.len() as u32;
+    meshes.push(json::Mesh {
+        primitives,
+        name: Some(canonical_path.to_string()),
+        weights: None,
+        extensions: None,
+        extras: Default::default(),
+    });
+    Ok(mesh_idx)
+}
+
+fn make_primitive(
+    pos_acc: u32,
+    uv_acc: Option<u32>,
+    normal_acc: Option<u32>,
+    idx_acc: u32,
+    mat_idx: u32,
+) -> json::mesh::Primitive {
+    use json::mesh::Semantic;
+    let mut attributes = std::collections::BTreeMap::new();
+    attributes.insert(
+        Checked::Valid(Semantic::Positions),
+        json::Index::new(pos_acc),
+    );
+    if let Some(acc) = uv_acc {
+        attributes.insert(
+            Checked::Valid(Semantic::TexCoords(0)),
+            json::Index::new(acc),
+        );
+    }
+    if let Some(acc) = normal_acc {
+        attributes.insert(
+            Checked::Valid(Semantic::Normals),
+            json::Index::new(acc),
+        );
+    }
+    json::mesh::Primitive {
+        attributes,
+        indices: Some(json::Index::new(idx_acc)),
+        material: Some(json::Index::new(mat_idx)),
+        mode: Checked::Valid(json::mesh::Mode::Triangles),
+        targets: None,
+        extensions: None,
+        extras: Default::default(),
+    }
+}
+
+fn position_min_max(positions: &[[f32; 3]]) -> ([f32; 3], [f32; 3]) {
+    if positions.is_empty() {
+        return ([0.0; 3], [0.0; 3]);
+    }
+    let mut mn = positions[0];
+    let mut mx = positions[0];
+    for p in &positions[1..] {
+        for i in 0..3 {
+            if p[i] < mn[i] {
+                mn[i] = p[i];
+            }
+            if p[i] > mx[i] {
+                mx[i] = p[i];
+            }
+        }
+    }
+    (mn, mx)
+}
+
+/// Build the root-level `KHR_lights_punctual` extension and append one
+/// glTF node per light to the scene graph. Returns the
+/// `extensions::root::Root` value to set on the glTF root, or `None`
+/// when there are no lights.
+fn build_lights_root(
+    lights: &[LightInstance],
+    nodes: &mut Vec<json::Node>,
+    scene_nodes: &mut Vec<json::Index<json::Node>>,
+) -> Option<json::extensions::root::Root> {
+    if lights.is_empty() {
+        return None;
+    }
+    use json::extensions::scene::khr_lights_punctual as klp;
+
+    let mut gltf_lights = Vec::with_capacity(lights.len());
+    for (i, light) in lights.iter().enumerate() {
+        let (type_, spot) = match light.descriptor.kind {
+            LightKind::Point => (Checked::Valid(klp::Type::Point), None),
+            LightKind::Directional => (Checked::Valid(klp::Type::Directional), None),
+            LightKind::Spot { inner_cone, outer_cone } => (
+                Checked::Valid(klp::Type::Spot),
+                Some(klp::Spot {
+                    inner_cone_angle: inner_cone,
+                    outer_cone_angle: outer_cone,
+                }),
+            ),
+        };
+        gltf_lights.push(klp::Light {
+            color: light.descriptor.color,
+            intensity: light.descriptor.intensity,
+            name: Some(if light.descriptor.name.is_empty() {
+                format!("light_{i}")
+            } else {
+                light.descriptor.name.clone()
+            }),
+            range: if light.descriptor.range > 0.0 {
+                Some(light.descriptor.range)
+            } else {
+                None
+            },
+            type_,
+            spot,
+            extensions: None,
+            extras: Default::default(),
+        });
+
+        // glTF nodes for lights carry the placement matrix and reference
+        // the light by index through the node-level extension.
+        let matrix = mat3x4_to_gltf_matrix(&light.world_transform);
+        let identity = is_identity_matrix(&matrix);
+        let node_idx = nodes.len() as u32;
+        nodes.push(json::Node {
+            name: Some(if light.descriptor.name.is_empty() {
+                format!("light_{i}")
+            } else {
+                format!("light_{}", light.descriptor.name)
+            }),
+            matrix: if identity { None } else { Some(matrix) },
+            extensions: Some(json::extensions::scene::Node {
+                khr_lights_punctual: Some(klp::KhrLightsPunctual {
+                    light: json::Index::new(i as u32),
+                }),
+            }),
+            ..Default::default()
+        });
+        scene_nodes.push(json::Index::new(node_idx));
+    }
+
+    Some(json::extensions::root::Root {
+        khr_lights_punctual: Some(json::extensions::root::KhrLightsPunctual {
+            lights: gltf_lights,
+        }),
+    })
+}
+
+/// glTF 2.0 binary container layout (12-byte header + JSON chunk + BIN
+/// chunk). Mirrors `crate::gltf::glb_builder::serialize_glb` but stays
+/// independent so the SOC scene emitter does not pull in the
+/// ship-pipeline builder state.
+fn serialize_glb(root: &json::Root, bin: &[u8]) -> Result<Vec<u8>, String> {
+    let json_value = serde_json::to_value(root).map_err(|e| format!("json::to_value: {e}"))?;
+    let json_bytes = serde_json::to_vec(&json_value).map_err(|e| format!("json::to_vec: {e}"))?;
+
+    let json_pad = (4 - json_bytes.len() % 4) % 4;
+    let json_padded_len = json_bytes.len() + json_pad;
+    let bin_pad = (4 - bin.len() % 4) % 4;
+    let bin_padded_len = bin.len() + bin_pad;
+    let total_len = 12 + 8 + json_padded_len + 8 + bin_padded_len;
+
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(b"glTF");
+    out.extend_from_slice(&2u32.to_le_bytes());
+    out.extend_from_slice(&(total_len as u32).to_le_bytes());
+
+    out.extend_from_slice(&(json_padded_len as u32).to_le_bytes());
+    out.extend_from_slice(&0x4E4F534Au32.to_le_bytes()); // 'JSON'
+    out.extend_from_slice(&json_bytes);
+    out.extend(std::iter::repeat_n(b' ', json_pad));
+
+    out.extend_from_slice(&(bin_padded_len as u32).to_le_bytes());
+    out.extend_from_slice(&0x004E4942u32.to_le_bytes()); // 'BIN\0'
+    out.extend_from_slice(bin);
+    out.extend(std::iter::repeat_n(0u8, bin_pad));
+
+    Ok(out)
+}
+
+// Suppress an "unused" warning for the helper used only by the inner
+// glTF builder when a future refactor adds a non-Mat4 path.
+#[allow(dead_code)]
+fn mat4_for_transform(m: &[[f32; 4]; 3]) -> Mat4 {
+    let cols = [
+        glam::Vec4::new(m[0][0], m[1][0], m[2][0], 0.0),
+        glam::Vec4::new(m[0][1], m[1][1], m[2][1], 0.0),
+        glam::Vec4::new(m[0][2], m[1][2], m[2][2], 0.0),
+        glam::Vec4::new(m[0][3], m[1][3], m[2][3], 1.0),
+    ];
+    Mat4::from_cols(cols[0], cols[1], cols[2], cols[3])
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SubMesh;
+
+    fn tri_mesh() -> Mesh {
+        Mesh {
+            positions: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            indices: vec![0, 1, 2],
+            uvs: Some(vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]),
+            secondary_uvs: None,
+            normals: Some(vec![[0.0, 0.0, 1.0]; 3]),
+            tangents: None,
+            colors: None,
+            submeshes: vec![SubMesh {
+                material_name: Some("test".into()),
+                material_id: 0,
+                first_index: 0,
+                num_indices: 3,
+                first_vertex: 0,
+                num_vertices: 3,
+                node_parent_index: 0,
+            }],
+            model_min: [0.0; 3],
+            model_max: [1.0; 3],
+            scaling_min: [0.0; 3],
+            scaling_max: [1.0; 3],
+        }
+    }
+
+    #[test]
+    fn canonicalize_strips_data_prefix_and_normalises_slashes() {
+        assert_eq!(
+            canonicalize_mesh_path("Data/Objects/foo/bar.cgf"),
+            "objects\\foo\\bar.cgf"
+        );
+        assert_eq!(
+            canonicalize_mesh_path("DATA\\objects\\Foo.cgf"),
+            "objects\\foo.cgf"
+        );
+        assert_eq!(
+            canonicalize_mesh_path("objects/foo/bar.cgf"),
+            "objects\\foo\\bar.cgf"
+        );
+    }
+
+    #[test]
+    fn p4k_path_for_adds_data_prefix_when_missing() {
+        assert_eq!(
+            p4k_path_for("objects/foo.cgf"),
+            "Data\\objects\\foo.cgf"
+        );
+        assert_eq!(
+            p4k_path_for("Data\\objects\\foo.cgf"),
+            "Data\\objects\\foo.cgf"
+        );
+    }
+
+    #[test]
+    fn mtl_path_for_uses_mtl_name_when_qualified() {
+        assert_eq!(
+            mtl_path_for(
+                "objects/material/foo",
+                "Data\\objects\\meshes\\bar.cgf"
+            ),
+            "Data\\objects\\material\\foo.mtl"
+        );
+        assert_eq!(
+            mtl_path_for("foo", "Data\\objects\\meshes\\bar.cgf"),
+            "Data\\objects\\meshes\\foo.mtl"
+        );
+    }
+
+    #[test]
+    fn sibling_mtl_for_replaces_extension() {
+        assert_eq!(
+            sibling_mtl_for("Data\\objects\\foo.cgf"),
+            "Data\\objects\\foo.mtl"
+        );
+        assert_eq!(
+            sibling_mtl_for("Data\\objects\\foo"),
+            "Data\\objects\\foo.mtl"
+        );
+    }
+
+    #[test]
+    fn emit_glb_roundtrips_minimal_scene() {
+        let scene = RenderableScene {
+            meshes: vec![ResolvedMesh {
+                canonical_path: "test.cgf".to_string(),
+                mesh: tri_mesh(),
+                material: None,
+            }],
+            placements: vec![MeshPlacement {
+                mesh_index: 0,
+                world_transform: [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ],
+                instance_id: 0,
+            }],
+            lights: Vec::new(),
+            aabb: Some(([0.0; 3], [1.0; 3])),
+            dropped_placements: 0,
+            failed_mesh_paths: 0,
+            materials_resolved: 0,
+            materials_default: 1,
+        };
+        let (bytes, summary) = emit_glb(&scene).expect("emit ok");
+        assert!(bytes.starts_with(b"glTF"), "should start with glTF magic");
+        assert!(summary.mesh_count == 1);
+        assert!(summary.placement_count == 1);
+    }
+
+    #[test]
+    fn emit_glb_with_a_light_uses_extension() {
+        let scene = RenderableScene {
+            meshes: vec![ResolvedMesh {
+                canonical_path: "test.cgf".to_string(),
+                mesh: tri_mesh(),
+                material: None,
+            }],
+            placements: vec![MeshPlacement {
+                mesh_index: 0,
+                world_transform: [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ],
+                instance_id: 0,
+            }],
+            lights: vec![LightInstance {
+                world_transform: [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ],
+                descriptor: LightDescriptor {
+                    name: "test_light".into(),
+                    kind: LightKind::Point,
+                    color: [1.0, 1.0, 1.0],
+                    intensity: 100.0,
+                    range: 5.0,
+                },
+            }],
+            aabb: Some(([0.0; 3], [1.0; 3])),
+            dropped_placements: 0,
+            failed_mesh_paths: 0,
+            materials_resolved: 0,
+            materials_default: 1,
+        };
+        let (bytes, summary) = emit_glb(&scene).expect("emit ok");
+        assert!(summary.light_count == 1);
+        // Find the JSON header magic and verify it mentions the extension.
+        let json_chunk_start = 12 + 8;
+        let json_len_bytes: [u8; 4] = bytes[12..16].try_into().unwrap();
+        let json_len = u32::from_le_bytes(json_len_bytes) as usize;
+        let json_text = std::str::from_utf8(&bytes[json_chunk_start..json_chunk_start + json_len])
+            .unwrap();
+        assert!(
+            json_text.contains("KHR_lights_punctual"),
+            "glTF JSON should declare the lights extension"
+        );
+    }
+
+    #[test]
+    fn canonicalize_collapses_case_and_separators() {
+        // Two zones referring to the same mesh under different casing
+        // must canonicalise to the same key — that is the dedupe-pass
+        // contract.
+        let canonical_a = canonicalize_mesh_path("objects/foo.cgf");
+        let canonical_b = canonicalize_mesh_path("OBJECTS\\Foo.cgf");
+        assert_eq!(canonical_a, canonical_b);
+    }
+
+    fn light_with_intensity(intensity: f32) -> LightInstance {
+        LightInstance {
+            world_transform: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+            descriptor: LightDescriptor {
+                name: format!("light_{intensity}"),
+                kind: LightKind::Point,
+                color: [1.0, 1.0, 1.0],
+                intensity,
+                range: 0.0,
+            },
+        }
+    }
+
+    #[test]
+    fn pick_top_lights_keeps_highest_intensity() {
+        let lights = vec![
+            light_with_intensity(1.0),
+            light_with_intensity(10.0),
+            light_with_intensity(5.0),
+            light_with_intensity(20.0),
+        ];
+        let kept = pick_top_lights(&lights, 2);
+        assert_eq!(kept.len(), 2);
+        let intensities: Vec<f32> = kept.iter().map(|l| l.descriptor.intensity).collect();
+        // Highest two are 20.0 and 10.0, regardless of return order.
+        assert!(intensities.contains(&20.0));
+        assert!(intensities.contains(&10.0));
+        assert!(!intensities.contains(&5.0));
+        assert!(!intensities.contains(&1.0));
+    }
+
+    #[test]
+    fn pick_top_lights_handles_max_zero() {
+        let lights = vec![light_with_intensity(1.0)];
+        assert!(pick_top_lights(&lights, 0).is_empty());
+    }
+
+    #[test]
+    fn pick_top_lights_under_cap_returns_input() {
+        let lights = vec![
+            light_with_intensity(1.0),
+            light_with_intensity(2.0),
+        ];
+        let kept = pick_top_lights(&lights, 64);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn emit_glb_caps_lights_and_reports_dropped_count() {
+        // Build 100 lights with descending intensity. Cap at 16. Verify
+        // the emitter keeps the top 16 by intensity and reports 84 as
+        // dropped.
+        let mut lights = Vec::with_capacity(100);
+        for i in 0..100 {
+            lights.push(light_with_intensity(100.0 - i as f32));
+        }
+        let scene = RenderableScene {
+            meshes: vec![ResolvedMesh {
+                canonical_path: "test.cgf".to_string(),
+                mesh: tri_mesh(),
+                material: None,
+            }],
+            placements: vec![MeshPlacement {
+                mesh_index: 0,
+                world_transform: [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ],
+                instance_id: 0,
+            }],
+            lights,
+            aabb: Some(([0.0; 3], [1.0; 3])),
+            dropped_placements: 0,
+            failed_mesh_paths: 0,
+            materials_resolved: 0,
+            materials_default: 1,
+        };
+        let opts = EmitOptions { max_lights: 16 };
+        let (_bytes, summary) =
+            emit_glb_with_options(&scene, opts).expect("emit ok");
+        assert_eq!(summary.light_count, 16);
+        assert_eq!(summary.lights_dropped, 84);
+    }
+
+    #[test]
+    fn emit_glb_does_not_embed_placeholder_textures() {
+        // The minimal-scene roundtrip uses material=None, so no MTL is
+        // resolved. With the placeholder PNG emission removed, even
+        // textured-material scenes should report zero textures and zero
+        // images; that is verified end-to-end by the Exec Hangar render
+        // smoke test. Here we just confirm the no-material baseline
+        // emits no textures and no baseColorTexture binding.
+        let scene = RenderableScene {
+            meshes: vec![ResolvedMesh {
+                canonical_path: "test.cgf".to_string(),
+                mesh: tri_mesh(),
+                material: None,
+            }],
+            placements: vec![MeshPlacement {
+                mesh_index: 0,
+                world_transform: [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ],
+                instance_id: 0,
+            }],
+            lights: Vec::new(),
+            aabb: Some(([0.0; 3], [1.0; 3])),
+            dropped_placements: 0,
+            failed_mesh_paths: 0,
+            materials_resolved: 0,
+            materials_default: 1,
+        };
+        let (bytes, summary) = emit_glb(&scene).expect("emit ok");
+        assert_eq!(summary.texture_count, 0);
+        let json_chunk_start = 12 + 8;
+        let json_len_bytes: [u8; 4] = bytes[12..16].try_into().unwrap();
+        let json_len = u32::from_le_bytes(json_len_bytes) as usize;
+        let json_text =
+            std::str::from_utf8(&bytes[json_chunk_start..json_chunk_start + json_len]).unwrap();
+        assert!(
+            !json_text.contains("baseColorTexture"),
+            "no material should bind a baseColorTexture (no placeholder)"
+        );
+    }
+}

--- a/crates/starbreaker-3d/src/soc/scene.rs
+++ b/crates/starbreaker-3d/src/soc/scene.rs
@@ -1,0 +1,562 @@
+//! Multi-zone scene composition — gluing many SOCs into one world.
+//!
+//! A single SOC file holds the brushes / entities / visareas for **one**
+//! object container. A real level (an Executive Hangar, a hangar interior,
+//! a station module) is built up by nesting containers: a top-level
+//! "assembly" socpak references zero or more child socpaks with a
+//! per-child `pos` / `rot` attribute, and each of those may in turn
+//! reference its own children. The engine resolves the world transform of
+//! each leaf brush by composing the local-space placement against the chain
+//! of parent transforms — that is the `CZoneSystem::GetTransform` pattern
+//! the Star Citizen rendering pipeline uses.
+//!
+//! The per-child `<Child name="..." pos="..." rot="..."/>` entries inside
+//! a socpak's main XML give a `(socpak_name, parent_pos, parent_rot)`
+//! tuple, and chaining those tuples is exactly the parent QuatTS the
+//! brush parser expects. The XML in a `.socpak` is a CryXmlB blob, so we
+//! pull it out via the in-tree zero-copy reader.
+//!
+//! # What is intentionally not in scope
+//!
+//! - Octree node walks. Brushes are still produced by the byte-level scan
+//!   in [`super::brushes::parse`]. The supervisor task to RE the parent
+//!   `QuatTS` per octree node is still open, and until that lands we apply
+//!   the zone's parent QuatTS uniformly to every brush in the SOC. For
+//!   SOCs whose every brush sits under the same node — which empirically
+//!   covers the assembly/interior containers used by Executive Hangar —
+//!   this matches the engine's own world placement.
+//!
+//! - Mesh decimation, CGF lookup, p4k extraction. Those happen in the
+//!   viewer; this module's job is to produce typed `(world_pos, world_rot,
+//!   mesh_path)` tuples from the SOC data.
+
+use super::brushes::{self, BrushInstance, ParentTransform, SocError};
+use super::entities::{self, EntityKind, EntityPlacement};
+use glam::{DQuat, DVec3};
+use starbreaker_p4k::{MappedP4k, P4kArchive};
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// A single child reference parsed out of a socpak's main XML.
+#[derive(Debug, Clone)]
+pub struct ChildSocpakRef {
+    /// `name` attribute exactly as written in the XML (case-preserving).
+    pub name: String,
+    /// `pos` attribute parsed as world-space position relative to the
+    /// containing socpak.
+    pub pos: [f64; 3],
+    /// `rot` attribute parsed as a unit quaternion.
+    pub rot: [f64; 4], // (x, y, z, w) glam ordering
+}
+
+/// One zone's contribution to a composed scene.
+#[derive(Debug, Clone, Default)]
+pub struct SceneZone {
+    /// Logical zone name, derived from the socpak path (no extension).
+    pub name: String,
+    /// Per-zone parent transform that was applied to every brush /
+    /// entity below.
+    pub parent_translation: [f64; 3],
+    pub parent_rotation: [f64; 4],
+    /// World-space brush placements.
+    pub brushes: Vec<BrushInstance>,
+    /// Mesh paths referenced by `brush.mesh_index`.
+    pub mesh_paths: Vec<String>,
+    /// World-space entity placements (lights, doors, loot, mesh-bearing
+    /// entities).
+    pub entities: Vec<EntityPlacement>,
+}
+
+/// A fully-composed multi-zone scene.
+#[derive(Debug, Clone, Default)]
+pub struct ComposedScene {
+    pub zones: Vec<SceneZone>,
+}
+
+impl ComposedScene {
+    /// Total brush count across every zone.
+    pub fn brush_count(&self) -> usize {
+        self.zones.iter().map(|z| z.brushes.len()).sum()
+    }
+
+    /// Total entity count across every zone.
+    pub fn entity_count(&self) -> usize {
+        self.zones.iter().map(|z| z.entities.len()).sum()
+    }
+
+    /// Total light entity count across every zone.
+    pub fn light_count(&self) -> usize {
+        self.zones
+            .iter()
+            .flat_map(|z| z.entities.iter())
+            .filter(|e| e.kind == EntityKind::Light)
+            .count()
+    }
+
+    /// Compute the AABB across every brush translation, in world space.
+    /// Returns `(min, max)` or `None` if the scene has no brushes.
+    pub fn brush_aabb(&self) -> Option<([f32; 3], [f32; 3])> {
+        let mut iter = self.zones.iter().flat_map(|z| z.brushes.iter());
+        let first = iter.next()?;
+        let mut mn = first.translation;
+        let mut mx = first.translation;
+        for b in iter {
+            let t = b.translation;
+            for i in 0..3 {
+                if t[i] < mn[i] {
+                    mn[i] = t[i];
+                }
+                if t[i] > mx[i] {
+                    mx[i] = t[i];
+                }
+            }
+        }
+        Some((mn, mx))
+    }
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+/// Errors produced while composing a multi-socpak scene.
+#[derive(Debug, thiserror::Error)]
+pub enum SceneError {
+    #[error("socpak entry not found in p4k: {0}")]
+    SocpakNotFound(String),
+
+    #[error("failed to read socpak '{path}': {message}")]
+    ReadSocpak { path: String, message: String },
+
+    #[error("socpak '{0}' is not a valid zip archive")]
+    InvalidSocpak(String),
+
+    #[error("socpak '{0}' has no main XML")]
+    MissingMainXml(String),
+
+    #[error("socpak '{0}' has no .soc payload")]
+    MissingSoc(String),
+
+    #[error(transparent)]
+    Soc(#[from] SocError),
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Compose a scene from one root socpak, recursively expanding child
+/// socpak references. Each zone is the SOC inside one socpak; child
+/// transforms accumulate down the tree.
+///
+/// `max_depth` bounds the recursion. Two is sufficient for the standard
+/// "assembly -> interior -> module" hierarchy used by Executive Hangar
+/// and similar dungeons; pass a larger value if a level is known to nest
+/// deeper.
+pub fn compose_from_root(
+    p4k: &MappedP4k,
+    root_socpak_path: &str,
+    max_depth: u32,
+) -> Result<ComposedScene, SceneError> {
+    let mut scene = ComposedScene::default();
+    walk_socpak(
+        p4k,
+        root_socpak_path,
+        &ParentTransform::identity(),
+        max_depth,
+        &mut scene,
+    )?;
+    Ok(scene)
+}
+
+/// Compose a scene from an explicit list of socpak paths to load at the
+/// world origin (parent = identity). Useful for "load these N modules with
+/// no parent transform" — the tests use this when they don't have a
+/// top-level XML to walk.
+pub fn compose_from_flat_list(
+    p4k: &MappedP4k,
+    socpak_paths: &[&str],
+) -> Result<ComposedScene, SceneError> {
+    let mut scene = ComposedScene::default();
+    for path in socpak_paths {
+        load_one_socpak_into_scene(p4k, path, &ParentTransform::identity(), &mut scene)?;
+    }
+    Ok(scene)
+}
+
+/// Parse a socpak's child-socpak references from its main XML, without
+/// recursing. Exposed so callers can drive their own walk strategy.
+pub fn read_child_refs_from_socpak(
+    p4k: &MappedP4k,
+    socpak_path: &str,
+) -> Result<Vec<ChildSocpakRef>, SceneError> {
+    let socpak_data = read_socpak_bytes(p4k, socpak_path)?;
+    let inner = P4kArchive::from_bytes(&socpak_data)
+        .map_err(|_| SceneError::InvalidSocpak(socpak_path.to_string()))?;
+
+    let xml_bytes = read_main_xml(&inner)
+        .ok_or_else(|| SceneError::MissingMainXml(socpak_path.to_string()))?;
+
+    Ok(parse_child_refs(&xml_bytes))
+}
+
+// ── Recursive walker ────────────────────────────────────────────────────────
+
+fn walk_socpak(
+    p4k: &MappedP4k,
+    socpak_path: &str,
+    parent: &ParentTransform,
+    depth_remaining: u32,
+    scene: &mut ComposedScene,
+) -> Result<(), SceneError> {
+    // Always parse this socpak's own SOC payload.
+    load_one_socpak_into_scene(p4k, socpak_path, parent, scene)?;
+
+    if depth_remaining == 0 {
+        return Ok(());
+    }
+
+    // Read its main XML and recurse into children.
+    let socpak_data = match read_socpak_bytes(p4k, socpak_path) {
+        Ok(d) => d,
+        Err(SceneError::SocpakNotFound(_)) => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    let inner = match P4kArchive::from_bytes(&socpak_data) {
+        Ok(z) => z,
+        Err(_) => return Ok(()),
+    };
+    let Some(xml_bytes) = read_main_xml(&inner) else {
+        return Ok(());
+    };
+
+    let children = parse_child_refs(&xml_bytes);
+    for child in &children {
+        let child_parent = compose_parents(parent, &child.pos, &child.rot);
+        // Resolve the child socpak path. The XML uses paths relative to
+        // the p4k root (typically `Data/...`).
+        let child_path = normalize_p4k_path(&child.name);
+        match walk_socpak(p4k, &child_path, &child_parent, depth_remaining - 1, scene) {
+            Ok(()) => {}
+            Err(SceneError::SocpakNotFound(_)) => continue,
+            Err(SceneError::MissingSoc(_)) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+fn load_one_socpak_into_scene(
+    p4k: &MappedP4k,
+    socpak_path: &str,
+    parent: &ParentTransform,
+    scene: &mut ComposedScene,
+) -> Result<(), SceneError> {
+    let socpak_data = read_socpak_bytes(p4k, socpak_path)?;
+    let inner = P4kArchive::from_bytes(&socpak_data)
+        .map_err(|_| SceneError::InvalidSocpak(socpak_path.to_string()))?;
+
+    let soc_bytes = match read_first_soc(&inner) {
+        Some(b) => b,
+        None => return Err(SceneError::MissingSoc(socpak_path.to_string())),
+    };
+
+    let zone_name = socpak_path
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(socpak_path)
+        .strip_suffix(".socpak")
+        .unwrap_or(socpak_path)
+        .to_string();
+
+    // Brushes — soft-fail on every SOC error. Some socpaks carry SOC
+    // payloads that do not have a StatObj chunk at all (parent / assembly
+    // containers), and earlier-build SOC files may use a non-v15 brush
+    // record format. In both cases the right thing for a multi-zone walk
+    // is to skip the brushes from that zone, not abort the walk.
+    let brushes = match brushes::parse(&soc_bytes, parent) {
+        Ok(b) => b,
+        Err(_) => brushes::SocBrushes::default(),
+    };
+
+    // Entities — soft-fail on parse errors, lights are best-effort.
+    let entity_payload = match entities::parse(&soc_bytes, parent) {
+        Ok(e) => e,
+        Err(_) => entities::SocEntities::default(),
+    };
+
+    scene.zones.push(SceneZone {
+        name: zone_name,
+        parent_translation: parent.translation.into(),
+        parent_rotation: [
+            parent.rotation.x,
+            parent.rotation.y,
+            parent.rotation.z,
+            parent.rotation.w,
+        ],
+        brushes: brushes.brushes,
+        mesh_paths: brushes.mesh_paths,
+        entities: entity_payload.entities,
+    });
+
+    Ok(())
+}
+
+// ── socpak / xml helpers ────────────────────────────────────────────────────
+
+fn read_socpak_bytes(p4k: &MappedP4k, socpak_path: &str) -> Result<Vec<u8>, SceneError> {
+    let normalized = normalize_p4k_path(socpak_path);
+    let entry = p4k
+        .entry_case_insensitive(&normalized)
+        .ok_or_else(|| SceneError::SocpakNotFound(normalized.clone()))?;
+    p4k.read(entry).map_err(|e| SceneError::ReadSocpak {
+        path: normalized,
+        message: e.to_string(),
+    })
+}
+
+fn normalize_p4k_path(path: &str) -> String {
+    let normalized = path.replace('/', "\\");
+    if normalized
+        .to_ascii_lowercase()
+        .starts_with("data\\")
+    {
+        normalized
+    } else {
+        format!("Data\\{normalized}")
+    }
+}
+
+/// Find the main XML inside a socpak. The convention from the reference
+/// parser: pick the first `.xml` at the socpak root that is not the
+/// `*.entxml`, editor metadata, or entity-data sidecar.
+fn read_main_xml(inner: &P4kArchive<'_>) -> Option<Vec<u8>> {
+    let mut candidate = None;
+    for entry in inner.entries() {
+        let name_lc = entry.name.to_ascii_lowercase();
+        if !name_lc.ends_with(".xml") {
+            continue;
+        }
+        if name_lc.contains("editor")
+            || name_lc.contains("metadata")
+            || name_lc.contains("entdata")
+            || name_lc.contains("entxml")
+        {
+            continue;
+        }
+        candidate = Some(entry);
+        break;
+    }
+    let entry = candidate?;
+    inner.read(entry).ok()
+}
+
+fn read_first_soc(inner: &P4kArchive<'_>) -> Option<Vec<u8>> {
+    for entry in inner.entries() {
+        if entry.name.to_ascii_lowercase().ends_with(".soc") {
+            if let Ok(bytes) = inner.read(entry) {
+                return Some(bytes);
+            }
+        }
+    }
+    None
+}
+
+/// Parse `<Child name="..." pos="x,y,z" rot="w,x,y,z"/>` references out
+/// of a socpak XML. Supports both CryXmlB binary XML and the plain-text
+/// XML that some socpaks carry (the reference build_exec_hangar.py treats
+/// them with a regex; we use a 1-pass scanner that handles either).
+fn parse_child_refs(xml_bytes: &[u8]) -> Vec<ChildSocpakRef> {
+    if starbreaker_cryxml::is_cryxmlb(xml_bytes) {
+        return parse_child_refs_cryxml(xml_bytes);
+    }
+    parse_child_refs_text(xml_bytes)
+}
+
+fn parse_child_refs_cryxml(xml_bytes: &[u8]) -> Vec<ChildSocpakRef> {
+    let xml = match starbreaker_cryxml::from_bytes(xml_bytes) {
+        Ok(x) => x,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    let root = xml.root();
+    walk_cryxml_for_children(&xml, root, &mut out, 0, 16);
+    out
+}
+
+fn walk_cryxml_for_children(
+    xml: &starbreaker_cryxml::CryXml,
+    node: &starbreaker_cryxml::CryXmlNode,
+    out: &mut Vec<ChildSocpakRef>,
+    depth: u32,
+    max_depth: u32,
+) {
+    if depth > max_depth {
+        return;
+    }
+    let tag = xml.node_tag(node);
+    if tag == "Child" {
+        let attrs: std::collections::HashMap<&str, &str> =
+            xml.node_attributes(node).collect();
+        if let Some(name) = attrs.get("name").copied()
+            && let Some(pos_s) = attrs.get("pos").copied()
+            && let Some(rot_s) = attrs.get("rot").copied()
+            && name.to_ascii_lowercase().ends_with(".socpak")
+            && let Some(pos) = parse_csv3(pos_s)
+            && let Some(rot) = parse_csv4_w_first(rot_s)
+        {
+            out.push(ChildSocpakRef {
+                name: name.to_string(),
+                pos,
+                rot,
+            });
+        }
+    }
+
+    for child in xml.node_children(node) {
+        walk_cryxml_for_children(xml, child, out, depth + 1, max_depth);
+    }
+}
+
+fn parse_child_refs_text(xml_bytes: &[u8]) -> Vec<ChildSocpakRef> {
+    let Ok(text) = std::str::from_utf8(xml_bytes) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    // Conservative scan: each `<Child ... name="...socpak" ... pos="..." ... rot="..." ... />`
+    // We don't need a full XML parser — we only consume well-formed
+    // attribute strings that we know the engine writes verbatim.
+    for chunk in text.split("<Child").skip(1) {
+        let Some(end) = chunk.find('>') else { continue };
+        let block = &chunk[..end];
+
+        let Some(name) = extract_attr(block, "name") else {
+            continue;
+        };
+        if !name.to_ascii_lowercase().ends_with(".socpak") {
+            continue;
+        }
+        let Some(pos_s) = extract_attr(block, "pos") else {
+            continue;
+        };
+        let Some(rot_s) = extract_attr(block, "rot") else {
+            continue;
+        };
+        let Some(pos) = parse_csv3(&pos_s) else { continue };
+        let Some(rot) = parse_csv4_w_first(&rot_s) else {
+            continue;
+        };
+        out.push(ChildSocpakRef {
+            name,
+            pos,
+            rot,
+        });
+    }
+    out
+}
+
+fn extract_attr(block: &str, key: &str) -> Option<String> {
+    // Find ` key="..."` (with the leading space to avoid prefix matches like
+    // `pos` matching the start of `position`).
+    let needle = format!(" {key}=\"");
+    let start = block.find(&needle)? + needle.len();
+    let rest = &block[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn parse_csv3(s: &str) -> Option<[f64; 3]> {
+    let mut iter = s.split(',').map(str::trim);
+    let x = iter.next()?.parse::<f64>().ok()?;
+    let y = iter.next()?.parse::<f64>().ok()?;
+    let z = iter.next()?.parse::<f64>().ok()?;
+    Some([x, y, z])
+}
+
+/// Parse a CryEngine 4-tuple stored as `w,x,y,z` (scalar first) and return
+/// it in glam's `(x, y, z, w)` order.
+fn parse_csv4_w_first(s: &str) -> Option<[f64; 4]> {
+    let mut iter = s.split(',').map(str::trim);
+    let w = iter.next()?.parse::<f64>().ok()?;
+    let x = iter.next()?.parse::<f64>().ok()?;
+    let y = iter.next()?.parse::<f64>().ok()?;
+    let z = iter.next()?.parse::<f64>().ok()?;
+    Some([x, y, z, w])
+}
+
+// ── Transform composition ───────────────────────────────────────────────────
+
+/// Compose a child's local-space `(pos, rot)` with the parent's QuatTS to
+/// produce the child's world-space QuatTS. Uses the standard rigid-body
+/// composition: `world_t = parent_t + parent_q * child_t`, `world_q =
+/// parent_q * child_q`.
+fn compose_parents(parent: &ParentTransform, child_pos: &[f64; 3], child_rot: &[f64; 4]) -> ParentTransform {
+    let child_q = DQuat::from_xyzw(child_rot[0], child_rot[1], child_rot[2], child_rot[3])
+        .normalize();
+    let child_t = DVec3::new(child_pos[0], child_pos[1], child_pos[2]);
+
+    let world_t = parent.translation + parent.rotation * child_t;
+    let world_q = (parent.rotation * child_q).normalize();
+
+    ParentTransform {
+        rotation: world_q,
+        translation: world_t,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_csv3_handles_simple_input() {
+        assert_eq!(parse_csv3("1, 2, 3"), Some([1.0, 2.0, 3.0]));
+        assert_eq!(parse_csv3("1,2"), None);
+        assert_eq!(parse_csv3("a,b,c"), None);
+    }
+
+    #[test]
+    fn parse_csv4_reorders_w_first_to_glam() {
+        // CryEngine identity quaternion is "1,0,0,0" (w,x,y,z).
+        let q = parse_csv4_w_first("1,0,0,0").unwrap();
+        assert_eq!(q, [0.0, 0.0, 0.0, 1.0]); // glam (x,y,z,w)
+    }
+
+    #[test]
+    fn extract_attr_finds_quoted_value() {
+        let block = " name=\"foo.socpak\" pos=\"1,2,3\" rot=\"1,0,0,0\"";
+        assert_eq!(extract_attr(block, "name"), Some("foo.socpak".to_string()));
+        assert_eq!(extract_attr(block, "pos"), Some("1,2,3".to_string()));
+        assert_eq!(extract_attr(block, "rot"), Some("1,0,0,0".to_string()));
+        assert_eq!(extract_attr(block, "missing"), None);
+    }
+
+    #[test]
+    fn parse_child_refs_text_reads_one_child() {
+        let xml = br#"<root><Child name="a/b/foo.socpak" pos="1,2,3" rot="1,0,0,0"/></root>"#;
+        let refs = parse_child_refs_text(xml);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "a/b/foo.socpak");
+        assert_eq!(refs[0].pos, [1.0, 2.0, 3.0]);
+        // Glam (x,y,z,w) order — w-first input "1,0,0,0" -> identity.
+        assert_eq!(refs[0].rot, [0.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn compose_parents_is_associative_for_translation() {
+        let parent = ParentTransform {
+            rotation: DQuat::IDENTITY,
+            translation: DVec3::new(10.0, 0.0, 0.0),
+        };
+        let composed = compose_parents(&parent, &[5.0, 0.0, 0.0], &[0.0, 0.0, 0.0, 1.0]);
+        assert!((composed.translation.x - 15.0).abs() < 1e-9);
+        assert_eq!(composed.translation.y, 0.0);
+        assert_eq!(composed.translation.z, 0.0);
+    }
+
+    #[test]
+    fn brush_aabb_returns_none_when_empty() {
+        let scene = ComposedScene::default();
+        assert!(scene.brush_aabb().is_none());
+    }
+}

--- a/crates/starbreaker-3d/src/soc/visarea.rs
+++ b/crates/starbreaker-3d/src/soc/visarea.rs
@@ -1,0 +1,295 @@
+//! Visibility-area / portal data parsed from chunk 0x000E.
+//!
+//! Each VisArea chunk in a `.soc` file describes the rooms and the portals
+//! that connect them. The viewer does not (yet) cull on this data, but having
+//! it parsed unblocks future portal-based culling and is also useful for
+//! diagnostics ("how many rooms in this scene?").
+//!
+//! # Layout
+//!
+//! Each chunk starts with a 20-byte `SVisAreaManChunkHeader`:
+//!
+//! | Offset | Field                                     |
+//! |--------|-------------------------------------------|
+//! | +0x00  | `nVersion` (u8) — 5/6/7/8 across builds  |
+//! | +0x01  | `nDummy`   (u8)                           |
+//! | +0x02  | `nFlags`   (u8)                           |
+//! | +0x03  | `nFlags2`  (u8)                           |
+//! | +0x04  | `nChunkSize` (u32)                        |
+//! | +0x08  | `visAreaCount` (u32)                      |
+//! | +0x0C  | `portalCount` (u32)                       |
+//! | +0x10  | `occlAreaCount` (u32)                     |
+//!
+//! After the header are `visAreaCount + portalCount + occlAreaCount`
+//! variable-length entries. In the SC v15 layout each entry begins with a
+//! `nChunkVersion` u32 (`= 15`) followed by a 32-byte ASCII name and a body
+//! whose total size we recover by scanning forward to the next entry marker.
+//!
+//! For the renderer we surface the per-area name, vertex polygon (when
+//! present), portal connection list, and (when recoverable) the AABB. The
+//! detailed flags and per-area fields are passed through opaquely; nothing
+//! in the viewer consumes them yet.
+
+use super::brushes::SocError;
+use super::common::{
+    CHUNK_TYPE_VISAREA, ChunkEntry, chunk_slice, parse_chunk_table, parse_crch_header,
+    read_f32, read_u32,
+};
+
+const VISAREA_HEADER_SIZE: usize = 20;
+const ENTRY_NAME_LEN: usize = 32;
+const ENTRY_V15_VERSION: u32 = 15;
+const MAX_VERTICES: usize = 200; // matches reference parser ceiling
+
+// Field offsets inside one v15 entry, relative to the entry start.
+const ENTRY_OFF_NAME: usize = 4;
+const ENTRY_OFF_PORTAL_BLENDING: usize = 44;
+const ENTRY_OFF_VIEW_DIST_RATIO: usize = 48;
+const ENTRY_OFF_HEIGHT_PRIMARY: usize = 80;
+const ENTRY_OFF_HEIGHT_FALLBACK: usize = 228;
+const ENTRY_OFF_CONNECTIONS: usize = 124;
+const CONNECTION_COUNT: usize = 8;
+const ENTRY_OFF_VERTEX_FLAG: usize = 264;
+const ENTRY_OFF_POINT_COUNT: usize = 268;
+const ENTRY_OFF_VERTICES: usize = 272;
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// One visibility area, portal, or occluder area.
+#[derive(Debug, Clone)]
+pub struct VisAreaRecord {
+    pub name: String,
+    /// Source role: a room, a portal, or an occluder area.
+    pub role: VisAreaRole,
+    /// View-distance scaling factor.
+    pub view_dist_ratio: f32,
+    /// Portal blend factor (0 for non-portal records).
+    pub portal_blending: f32,
+    /// Height extent (vertical extrusion of the floor polygon).
+    pub height: f32,
+    /// Connection indices into the same `VisAreaSet` (negative entries
+    /// stripped). For portals these point at the two rooms they connect.
+    pub connections: Vec<i32>,
+    /// Floor polygon vertices in entry-local coordinates, when present.
+    /// VisAreas without an explicit polygon (the engine derives them from
+    /// the AABB) yield an empty list.
+    pub vertices: Vec<[f32; 3]>,
+}
+
+/// Whether the record came from the visAreas / portals / occluders block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisAreaRole {
+    VisArea,
+    Portal,
+    OcclArea,
+}
+
+/// All the records read from a single SOC's chunk 0x000E.
+#[derive(Debug, Clone, Default)]
+pub struct SocVisAreas {
+    pub vis_areas: Vec<VisAreaRecord>,
+    pub portals: Vec<VisAreaRecord>,
+    pub occl_areas: Vec<VisAreaRecord>,
+}
+
+impl SocVisAreas {
+    pub fn total(&self) -> usize {
+        self.vis_areas.len() + self.portals.len() + self.occl_areas.len()
+    }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Parse VisArea data from a SOC. Containers without a 0x000E chunk produce
+/// an empty result rather than an error.
+pub fn parse(data: &[u8]) -> Result<SocVisAreas, SocError> {
+    let header = parse_crch_header(data).ok_or(SocError::BadMagic)?;
+    let chunks = parse_chunk_table(data, &header).ok_or(SocError::BadChunkTable)?;
+
+    let mut out = SocVisAreas::default();
+    for chunk in chunks.iter().filter(|c| c.chunk_type == CHUNK_TYPE_VISAREA) {
+        parse_one_chunk(data, chunk, &mut out);
+    }
+    Ok(out)
+}
+
+// ── Chunk walker ────────────────────────────────────────────────────────────
+
+fn parse_one_chunk(data: &[u8], chunk: &ChunkEntry, out: &mut SocVisAreas) {
+    let body = chunk_slice(data, chunk);
+    if body.len() < VISAREA_HEADER_SIZE {
+        return;
+    }
+
+    let _version = body[0];
+    // header[1] = nDummy, header[2] = nFlags, header[3] = nFlags2 (unused)
+    let _chunk_size = read_u32(body, 4);
+    let vis_count = read_u32(body, 8) as usize;
+    let portal_count = read_u32(body, 12) as usize;
+    let occl_count = read_u32(body, 16) as usize;
+    let total = vis_count + portal_count + occl_count;
+
+    if total == 0 {
+        return;
+    }
+
+    let entry_offsets = locate_v15_entry_offsets(body);
+    if entry_offsets.is_empty() {
+        return;
+    }
+
+    for (idx, &start) in entry_offsets.iter().enumerate() {
+        let end = entry_offsets
+            .get(idx + 1)
+            .copied()
+            .unwrap_or(body.len());
+        let role = if idx < vis_count {
+            VisAreaRole::VisArea
+        } else if idx < vis_count + portal_count {
+            VisAreaRole::Portal
+        } else {
+            VisAreaRole::OcclArea
+        };
+
+        if let Some(record) = decode_entry_v15(body, start, end, role) {
+            match role {
+                VisAreaRole::VisArea => out.vis_areas.push(record),
+                VisAreaRole::Portal => out.portals.push(record),
+                VisAreaRole::OcclArea => out.occl_areas.push(record),
+            }
+        }
+    }
+}
+
+/// Walk the chunk body looking for v15 entry markers (`u32 == 15` followed
+/// by an ASCII name). Mirrors the reference parser's heuristic.
+fn locate_v15_entry_offsets(body: &[u8]) -> Vec<usize> {
+    let mut offsets = Vec::new();
+    if body.len() < VISAREA_HEADER_SIZE + 36 {
+        return offsets;
+    }
+
+    let mut pos = VISAREA_HEADER_SIZE;
+    while pos + 36 <= body.len() {
+        let cv = read_u32(body, pos);
+        if cv == ENTRY_V15_VERSION
+            && let Some(name) = ascii_name_at(body, pos + ENTRY_OFF_NAME, ENTRY_NAME_LEN)
+            && name.len() >= 2
+            && name.chars().take(5).any(|c| c.is_ascii_alphabetic())
+        {
+            offsets.push(pos);
+            pos += 1; // proceed byte-by-byte; entries can be tightly packed
+            continue;
+        }
+        pos += 1;
+    }
+
+    offsets
+}
+
+fn ascii_name_at(body: &[u8], off: usize, len: usize) -> Option<String> {
+    if off + len > body.len() {
+        return None;
+    }
+    let raw = &body[off..off + len];
+    let nul = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+    let s = std::str::from_utf8(&raw[..nul]).ok()?;
+    if s.chars().any(|c| !c.is_ascii_graphic() && !c.is_ascii_whitespace()) {
+        return None;
+    }
+    Some(s.trim().to_string())
+}
+
+fn decode_entry_v15(
+    body: &[u8],
+    start: usize,
+    end: usize,
+    _role: VisAreaRole,
+) -> Option<VisAreaRecord> {
+    if start + ENTRY_OFF_VERTICES > body.len() {
+        return None;
+    }
+    let entry_end = end.min(body.len());
+
+    let name = ascii_name_at(body, start + ENTRY_OFF_NAME, ENTRY_NAME_LEN).unwrap_or_default();
+    let portal_blending = read_f32(body, start + ENTRY_OFF_PORTAL_BLENDING);
+    let view_dist_ratio = read_f32(body, start + ENTRY_OFF_VIEW_DIST_RATIO);
+
+    let height_primary = read_f32(body, start + ENTRY_OFF_HEIGHT_PRIMARY);
+    let height_fallback = read_f32(body, start + ENTRY_OFF_HEIGHT_FALLBACK);
+    let height = if height_primary.abs() > 0.01 {
+        height_primary
+    } else {
+        height_fallback
+    };
+
+    let mut connections = Vec::with_capacity(CONNECTION_COUNT);
+    for j in 0..CONNECTION_COUNT {
+        let off = start + ENTRY_OFF_CONNECTIONS + j * 4;
+        if off + 4 > body.len() {
+            break;
+        }
+        let raw = read_u32(body, off) as i32;
+        if raw >= 0 {
+            connections.push(raw);
+        }
+    }
+
+    let vertex_flag = read_u32(body, start + ENTRY_OFF_VERTEX_FLAG);
+    let mut vertices = Vec::new();
+    if vertex_flag != 0 && start + ENTRY_OFF_VERTICES <= body.len() {
+        let pts_count = read_u32(body, start + ENTRY_OFF_POINT_COUNT) as usize;
+        if pts_count > 0 && pts_count <= MAX_VERTICES {
+            for v in 0..pts_count {
+                let voff = start + ENTRY_OFF_VERTICES + v * 12;
+                if voff + 12 > entry_end {
+                    break;
+                }
+                vertices.push([
+                    read_f32(body, voff),
+                    read_f32(body, voff + 4),
+                    read_f32(body, voff + 8),
+                ]);
+            }
+        }
+    }
+
+    Some(VisAreaRecord {
+        name,
+        role: _role,
+        view_dist_ratio,
+        portal_blending,
+        height,
+        connections,
+        vertices,
+    })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_chunk_returns_empty_visareas() {
+        let data = build_minimal_crch_no_visarea();
+        let parsed = parse(&data).expect("parse ok");
+        assert_eq!(parsed.total(), 0);
+    }
+
+    fn build_minimal_crch_no_visarea() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"CrCh");
+        data.extend_from_slice(&0x0746u32.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes()); // chunk_count
+        data.extend_from_slice(&16u32.to_le_bytes()); // chunk_table_offset
+        data
+    }
+
+    #[test]
+    fn rejects_non_crch_input() {
+        let data = vec![0u8; 16];
+        assert!(matches!(parse(&data), Err(SocError::BadMagic)));
+    }
+}

--- a/crates/starbreaker-3d/src/types.rs
+++ b/crates/starbreaker-3d/src/types.rs
@@ -510,6 +510,16 @@ pub struct EntityPayload {
     pub detach_direction: [f32; 3],
     /// Raw item port flags from SItemPortDef (e.g. "invisible uneditable").
     pub port_flags: String,
+    /// Unique per-export instance id for this child placement. The root
+    /// entity is reserved id 0; every distinct child placement gets a
+    /// fresh monotonic id even when several share the same `entity_name`
+    /// (e.g. paired weapon mounts on a hardpoint pair). Lets downstream
+    /// consumers disambiguate sibling placements that the authored
+    /// entity name alone cannot.
+    pub instance_id: u32,
+    /// Instance id of the parent placement this child attaches to.
+    /// Always populated for children (the root has no parent).
+    pub parent_instance_id: u32,
 }
 
 /// A light extracted from a CryXMLB entity in a .soc file.

--- a/crates/starbreaker-3d/src/types.rs
+++ b/crates/starbreaker-3d/src/types.rs
@@ -513,7 +513,7 @@ pub struct EntityPayload {
     /// Unique per-export instance id for this child placement. The root
     /// entity is reserved id 0; every distinct child placement gets a
     /// fresh monotonic id even when several share the same `entity_name`
-    /// (e.g. paired weapon mounts on a hardpoint pair). Lets downstream
+    /// (e.g. two Mount_Gimbal_S1_NoSafety mounts on a Nox). Lets downstream
     /// consumers disambiguate sibling placements that the authored
     /// entity name alone cannot.
     pub instance_id: u32,

--- a/crates/starbreaker-3d/tests/exec_hangar_render_smoke.rs
+++ b/crates/starbreaker-3d/tests/exec_hangar_render_smoke.rs
@@ -1,0 +1,327 @@
+//! End-to-end render smoke test: walk Executive Hangar's socpak graph,
+//! resolve every brush mesh against the installed `Data.p4k`, emit a
+//! `.glb`, and re-open it through a glTF parser to assert the contract.
+//!
+//! Marked `#[ignore]` because it depends on a Star Citizen install at a
+//! fixed path. Run manually with:
+//!
+//! ```text
+//! cargo test --manifest-path <repo>/Cargo.toml -p starbreaker-3d \
+//!   --test exec_hangar_render_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use starbreaker_3d::soc::{self, SceneError};
+use starbreaker_p4k::MappedP4k;
+
+const EXEC_HANGAR_ROOT_SOCPAK: &str =
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_final_set\\\
+     ab_pyro_final_set_dungeon_executive-001.socpak";
+
+const FALLBACK_FLAT_SOCPAKS: &[&str] = &[
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_assembled\\\
+     ab_pyro_asmbl_01_dung_exec_001a.socpak",
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\int\\ab_int_dungeon\\\
+     ab_pyro_int_dung_exec_001.socpak",
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_ext\\\
+     ab_pyro_hangar_dungeon_exec_001.socpak",
+];
+
+const P4K_CANDIDATES: &[&str] = &[
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\HOTFIX\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\TECH-PREVIEW\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\LIVE\Data.p4k",
+];
+
+const MIN_EXPECTED_BRUSHES: usize = 200;
+const MIN_UNIQUE_MESHES: u32 = 100;
+const MIN_NODES: u32 = 1_000;
+const MIN_AABB_AXIS_EXTENT: f32 = 5.0;
+
+#[test]
+#[ignore = "depends on local SC install; run manually with --ignored"]
+fn smoke_executive_hangar_render() {
+    let p4k_path = locate_p4k().expect("no Star Citizen install with Data.p4k found");
+    eprintln!("opening p4k: {}", p4k_path.display());
+    let p4k = MappedP4k::open(&p4k_path).expect("MappedP4k::open");
+
+    let mut composed = match soc::compose_from_root(&p4k, EXEC_HANGAR_ROOT_SOCPAK, 4) {
+        Ok(scene) if scene.brush_count() >= MIN_EXPECTED_BRUSHES => scene,
+        Ok(_) => compose_flat_list_or_skip(&p4k),
+        Err(SceneError::SocpakNotFound(_)) => compose_flat_list_or_skip(&p4k),
+        Err(other) => panic!("compose_from_root failed: {other}"),
+    };
+    if composed.brush_count() < MIN_EXPECTED_BRUSHES {
+        let flat = compose_flat_list_or_skip(&p4k);
+        for zone in flat.zones {
+            composed.zones.push(zone);
+        }
+    }
+    eprintln!(
+        "composed: zones={} brushes={} entities={} lights={}",
+        composed.zones.len(),
+        composed.brush_count(),
+        composed.entity_count(),
+        composed.light_count(),
+    );
+
+    eprintln!("resolving meshes...");
+    let renderable = soc::resolve_scene(&p4k, &composed);
+    eprintln!(
+        "resolve summary: meshes={} placements={} lights={} \
+         dropped_placements={} failed_mesh_paths={}",
+        renderable.meshes.len(),
+        renderable.placements.len(),
+        renderable.lights.len(),
+        renderable.dropped_placements,
+        renderable.failed_mesh_paths,
+    );
+
+    eprintln!("emitting GLB...");
+    let (glb_bytes, summary) = soc::emit_glb(&renderable).expect("emit ok");
+    eprintln!(
+        "emit summary: mesh_count={} placement_count={} light_count={} \
+         lights_dropped={} material_count={} texture_count={} glb_bytes={}",
+        summary.mesh_count,
+        summary.placement_count,
+        summary.light_count,
+        summary.lights_dropped,
+        summary.material_count,
+        summary.texture_count,
+        glb_bytes.len(),
+    );
+
+    // Write GLB next to the JSON summary so a human can spot-check it
+    // through any glTF viewer.
+    let target_dir = locate_target_dir();
+    std::fs::create_dir_all(&target_dir).ok();
+    let glb_path = target_dir.join("exec-hangar-render-smoke.glb");
+    std::fs::write(&glb_path, &glb_bytes).expect("write glb");
+    eprintln!("glb written to {} ({} bytes)", glb_path.display(), glb_bytes.len());
+
+    // Inspect the emitted glTF JSON header by parsing the bytes back.
+    // We do not depend on the `gltf` crate here — we just decode the
+    // 12-byte header + JSON chunk, then deserialise the JSON with
+    // `serde_json` to check counts.
+    let parsed = parse_glb_json(&glb_bytes).expect("re-open glb");
+    let mesh_array = parsed
+        .get("meshes")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0);
+    let node_array = parsed
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0);
+    let mat_array = parsed
+        .get("materials")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0);
+    let tex_array = parsed
+        .get("textures")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0);
+    let extensions_used = parsed
+        .get("extensionsUsed")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let lights_in_extension = parsed
+        .get("extensions")
+        .and_then(|v| v.get("KHR_lights_punctual"))
+        .and_then(|v| v.get("lights"))
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0);
+
+    let aabb = renderable
+        .aabb
+        .expect("at least one placement should produce an AABB");
+    let extent = [
+        aabb.1[0] - aabb.0[0],
+        aabb.1[1] - aabb.0[1],
+        aabb.1[2] - aabb.0[2],
+    ];
+    let axes_with_extent = extent
+        .iter()
+        .filter(|e| **e > MIN_AABB_AXIS_EXTENT)
+        .count();
+
+    // Verify at least one material carries the `diffuse_texture_path`
+    // extra. The emitter does NOT embed a placeholder PNG / bind a
+    // `baseColorTexture` (that produced thousands of shared blob URLs
+    // and triggered "Couldn't load texture blob:" errors at render
+    // time); instead it leaves `material.map = null` in the GLB and
+    // surfaces the texture path through `extras` so the JS-side
+    // resolver can substitute the real DDS bytes.
+    let materials_with_diffuse_path = parsed
+        .get("materials")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|m| {
+                    m.get("extras")
+                        .and_then(|e| e.get("diffuse_texture_path"))
+                        .is_some()
+                })
+                .count() as u32
+        })
+        .unwrap_or(0);
+
+    eprintln!(
+        "json summary: meshes={mesh_array} nodes={node_array} \
+         materials={mat_array} textures={tex_array} lights_ext={lights_in_extension} \
+         materials_with_diffuse_path={materials_with_diffuse_path} \
+         extensionsUsed={extensions_used:?}"
+    );
+    eprintln!(
+        "AABB: min=({:.2}, {:.2}, {:.2}) max=({:.2}, {:.2}, {:.2}) extent=({:.2}, {:.2}, {:.2})",
+        aabb.0[0], aabb.0[1], aabb.0[2], aabb.1[0], aabb.1[1], aabb.1[2],
+        extent[0], extent[1], extent[2],
+    );
+
+    assert!(
+        mesh_array >= MIN_UNIQUE_MESHES,
+        "expected at least {MIN_UNIQUE_MESHES} unique meshes; got {mesh_array}"
+    );
+    assert!(
+        node_array >= MIN_NODES,
+        "expected at least {MIN_NODES} nodes; got {node_array}"
+    );
+    // The emitted GLB caps lights to a renderer-friendly budget. We
+    // still expect *some* lights to make it through for the hangar.
+    assert!(
+        lights_in_extension >= 1,
+        "expected at least 1 light in the emitted GLB; got {lights_in_extension}"
+    );
+    assert!(
+        lights_in_extension <= starbreaker_3d::soc::DEFAULT_MAX_EMITTED_LIGHTS as u32,
+        "emitted GLB exceeded the default light cap: \
+         got {lights_in_extension}, cap is {}",
+        starbreaker_3d::soc::DEFAULT_MAX_EMITTED_LIGHTS,
+    );
+    // Source SOC scene contains far more lights than the cap; verify
+    // the cap is doing real work rather than running on a tiny scene.
+    if (renderable.lights.len() as u32) > starbreaker_3d::soc::DEFAULT_MAX_EMITTED_LIGHTS as u32 {
+        assert!(
+            summary.lights_dropped > 0,
+            "scene has {} input lights but lights_dropped is 0",
+            renderable.lights.len(),
+        );
+    }
+    assert!(
+        axes_with_extent >= 2,
+        "AABB should have non-zero extent in at least two axes; got {extent:?}"
+    );
+    assert!(
+        materials_with_diffuse_path >= 1,
+        "expected at least one material carrying a diffuse_texture_path extra; \
+         got {materials_with_diffuse_path}"
+    );
+
+    let summary_json = serde_json::json!({
+        "p4k": p4k_path.display().to_string(),
+        "input": {
+            "zones": composed.zones.len(),
+            "brushes": composed.brush_count(),
+            "entities": composed.entity_count(),
+            "lights": composed.light_count(),
+        },
+        "resolve": {
+            "unique_meshes": renderable.meshes.len(),
+            "placements": renderable.placements.len(),
+            "lights": renderable.lights.len(),
+            "dropped_placements": renderable.dropped_placements,
+            "failed_mesh_paths": renderable.failed_mesh_paths,
+        },
+        "emit": {
+            "mesh_count": summary.mesh_count,
+            "placement_count": summary.placement_count,
+            "light_count": summary.light_count,
+            "lights_dropped": summary.lights_dropped,
+            "material_count": summary.material_count,
+            "texture_count": summary.texture_count,
+            "glb_bytes": glb_bytes.len(),
+        },
+        "gltf_json": {
+            "meshes": mesh_array,
+            "nodes": node_array,
+            "materials": mat_array,
+            "textures": tex_array,
+            "lights_in_extension": lights_in_extension,
+            "materials_with_diffuse_path": materials_with_diffuse_path,
+            "extensions_used": extensions_used,
+        },
+        "aabb": {
+            "min": [aabb.0[0], aabb.0[1], aabb.0[2]],
+            "max": [aabb.1[0], aabb.1[1], aabb.1[2]],
+            "extent": [extent[0], extent[1], extent[2]],
+        },
+        "glb_path": glb_path.display().to_string(),
+    });
+    let summary_path = target_dir.join("exec-hangar-render-smoke.json");
+    std::fs::write(
+        &summary_path,
+        serde_json::to_string_pretty(&summary_json).expect("json"),
+    )
+    .expect("write summary");
+    eprintln!("summary written to {}", summary_path.display());
+}
+
+fn compose_flat_list_or_skip(p4k: &MappedP4k) -> soc::ComposedScene {
+    let any_present = FALLBACK_FLAT_SOCPAKS
+        .iter()
+        .any(|p| p4k.entry_case_insensitive(p).is_some());
+    assert!(
+        any_present,
+        "no Executive Hangar socpaks resolved in the installed Data.p4k — \
+         the test cannot run on this build"
+    );
+    soc::compose_from_flat_list(p4k, FALLBACK_FLAT_SOCPAKS).expect("compose_from_flat_list")
+}
+
+fn locate_p4k() -> Option<PathBuf> {
+    for cand in P4K_CANDIDATES {
+        let p = PathBuf::from(cand);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn locate_target_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."));
+    let workspace_root = manifest
+        .ancestors()
+        .nth(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest.clone());
+    workspace_root.join("target")
+}
+
+/// Decode the JSON chunk out of a glTF binary container. Skips
+/// validation — we trust our own emitter and only need to inspect a
+/// handful of array lengths for the smoke assertions.
+fn parse_glb_json(bytes: &[u8]) -> Option<serde_json::Value> {
+    if bytes.len() < 12 + 8 || &bytes[0..4] != b"glTF" {
+        return None;
+    }
+    let json_len = u32::from_le_bytes(bytes[12..16].try_into().ok()?) as usize;
+    let json_type = u32::from_le_bytes(bytes[16..20].try_into().ok()?);
+    if json_type != 0x4E4F534A {
+        return None;
+    }
+    let json_start: usize = 20;
+    let json_end = json_start.checked_add(json_len)?;
+    if json_end > bytes.len() {
+        return None;
+    }
+    serde_json::from_slice(&bytes[json_start..json_end]).ok()
+}

--- a/crates/starbreaker-3d/tests/exec_hangar_smoke.rs
+++ b/crates/starbreaker-3d/tests/exec_hangar_smoke.rs
@@ -1,0 +1,233 @@
+//! End-to-end smoke test: parse the Executive Hangar SOC payload from a
+//! real installed `Data.p4k` and assert basic sanity on the result.
+//!
+//! Marked `#[ignore]` because it depends on a Star Citizen install being
+//! present at a fixed path. Run manually with:
+//!
+//! ```text
+//! cargo test --manifest-path <repo>/Cargo.toml -p starbreaker-3d \
+//!   --test exec_hangar_smoke -- --ignored --nocapture
+//! ```
+//!
+//! The test writes a JSON summary of brush / entity / visarea counts and the
+//! brush-translation AABB to `target/exec-hangar-smoke.json` so a supervisor
+//! can spot-check changes between iterations.
+
+use std::path::PathBuf;
+
+use starbreaker_3d::soc::{self, SceneError};
+use starbreaker_p4k::MappedP4k;
+
+// Top-level Executive Hangar socpaks observed in `Data/ObjectContainers/PU/
+// loc/mod/pyro/asteroid_base/`. The "final_set" socpak is the master that
+// nests the interior + hangar containers; we walk it recursively so the
+// composer pulls in every child zone.
+const EXEC_HANGAR_ROOT_SOCPAK: &str =
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_final_set\\\
+     ab_pyro_final_set_dungeon_executive-001.socpak";
+
+const FALLBACK_FLAT_SOCPAKS: &[&str] = &[
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_assembled\\\
+     ab_pyro_asmbl_01_dung_exec_001a.socpak",
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\int\\ab_int_dungeon\\\
+     ab_pyro_int_dung_exec_001.socpak",
+    "Data\\ObjectContainers\\PU\\loc\\mod\\pyro\\asteroid_base\\ext\\ab_ext\\\
+     ab_pyro_hangar_dungeon_exec_001.socpak",
+];
+
+const P4K_CANDIDATES: &[&str] = &[
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\HOTFIX\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\TECH-PREVIEW\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\LIVE\Data.p4k",
+];
+
+const MIN_EXPECTED_BRUSHES: usize = 200;
+const MIN_AABB_AXIS_EXTENT: f32 = 5.0;
+
+#[test]
+#[ignore = "depends on local SC install; run manually with --ignored"]
+fn smoke_executive_hangar_from_p4k() {
+    let p4k_path = locate_p4k().expect("no Star Citizen install with Data.p4k found");
+    eprintln!("opening p4k: {}", p4k_path.display());
+    let p4k = MappedP4k::open(&p4k_path).expect("MappedP4k::open");
+
+    // First try walking the master socpak so transforms cascade naturally.
+    // If the master can't be reached (different build, renamed layout) fall
+    // back to loading the three known top-level socpaks at world origin —
+    // that still produces a usable scene for the smoke assertions.
+    let mut scene = match soc::compose_from_root(&p4k, EXEC_HANGAR_ROOT_SOCPAK, 4) {
+        Ok(scene) if scene.brush_count() >= MIN_EXPECTED_BRUSHES => scene,
+        Ok(weak) => {
+            eprintln!(
+                "compose_from_root yielded only {} brushes; falling back to flat-list mode",
+                weak.brush_count()
+            );
+            compose_flat_list_or_skip(&p4k)
+        }
+        Err(SceneError::SocpakNotFound(_)) => compose_flat_list_or_skip(&p4k),
+        Err(other) => panic!("compose_from_root failed: {other}"),
+    };
+
+    if scene.brush_count() < MIN_EXPECTED_BRUSHES {
+        // Augment with the flat list — picks up any zone the recursive
+        // walk missed because of XML-level differences.
+        let flat = compose_flat_list_or_skip(&p4k);
+        for zone in flat.zones {
+            scene.zones.push(zone);
+        }
+    }
+
+    let brush_count = scene.brush_count();
+    let entity_count = scene.entity_count();
+    let light_count = scene.light_count();
+    let zone_count = scene.zones.len();
+
+    let aabb = scene
+        .brush_aabb()
+        .expect("at least one brush should produce an AABB");
+    let extent = [
+        aabb.1[0] - aabb.0[0],
+        aabb.1[1] - aabb.0[1],
+        aabb.1[2] - aabb.0[2],
+    ];
+    let axes_with_extent = extent
+        .iter()
+        .filter(|e| **e > MIN_AABB_AXIS_EXTENT)
+        .count();
+
+    let visarea_count: usize = scene
+        .zones
+        .iter()
+        .filter_map(|z| {
+            // Re-parse the SOC for visarea data: the composer doesn't track
+            // it because the renderer doesn't consume it yet, but the smoke
+            // test wants a count for the JSON summary.
+            // Cheap because the bytes are usually still in the OS page
+            // cache after the brush walk.
+            let socpak_path = guess_socpak_path_for_zone(&z.name)?;
+            let socpak_bytes = match read_socpak(&p4k, &socpak_path) {
+                Some(b) => b,
+                None => return None,
+            };
+            let inner = starbreaker_p4k::P4kArchive::from_bytes(&socpak_bytes).ok()?;
+            for e in inner.entries() {
+                if e.name.to_ascii_lowercase().ends_with(".soc") {
+                    let bytes = inner.read(e).ok()?;
+                    if let Ok(va) = soc::visarea::parse(&bytes) {
+                        return Some(va.total());
+                    }
+                }
+            }
+            None
+        })
+        .sum();
+
+    eprintln!(
+        "exec-hangar smoke: zones={zone_count} brushes={brush_count} \
+         entities={entity_count} lights={light_count} visareas={visarea_count}"
+    );
+    eprintln!(
+        "AABB: min=({:.2}, {:.2}, {:.2}) max=({:.2}, {:.2}, {:.2}) extent=({:.2}, {:.2}, {:.2})",
+        aabb.0[0], aabb.0[1], aabb.0[2], aabb.1[0], aabb.1[1], aabb.1[2],
+        extent[0], extent[1], extent[2],
+    );
+
+    assert!(
+        brush_count >= MIN_EXPECTED_BRUSHES,
+        "expected at least {MIN_EXPECTED_BRUSHES} brushes; got {brush_count}"
+    );
+    assert!(
+        light_count >= 1,
+        "expected at least one light entity; got {light_count} (entity_count={entity_count})"
+    );
+    assert!(
+        axes_with_extent >= 2,
+        "AABB should have non-zero extent in at least two axes; got {extent:?}"
+    );
+
+    // Dump JSON summary so the supervisor can compare iterations.
+    let summary = serde_json::json!({
+        "zones": zone_count,
+        "brushes": brush_count,
+        "entities": entity_count,
+        "lights": light_count,
+        "visareas": visarea_count,
+        "aabb": {
+            "min": [aabb.0[0], aabb.0[1], aabb.0[2]],
+            "max": [aabb.1[0], aabb.1[1], aabb.1[2]],
+            "extent": [extent[0], extent[1], extent[2]],
+        },
+        "p4k": p4k_path.display().to_string(),
+    });
+
+    let target_dir = locate_target_dir();
+    let summary_path = target_dir.join("exec-hangar-smoke.json");
+    if let Some(parent) = summary_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let body = serde_json::to_string_pretty(&summary).expect("json");
+    std::fs::write(&summary_path, body).expect("write summary");
+    eprintln!("summary written to {}", summary_path.display());
+}
+
+fn compose_flat_list_or_skip(p4k: &MappedP4k) -> soc::ComposedScene {
+    let any_present = FALLBACK_FLAT_SOCPAKS
+        .iter()
+        .any(|p| p4k.entry_case_insensitive(p).is_some());
+    assert!(
+        any_present,
+        "no Executive Hangar socpaks resolved in the installed Data.p4k — \
+         the test cannot run on this build"
+    );
+
+    soc::compose_from_flat_list(p4k, FALLBACK_FLAT_SOCPAKS).expect("compose_from_flat_list")
+}
+
+fn locate_p4k() -> Option<PathBuf> {
+    for cand in P4K_CANDIDATES {
+        let p = PathBuf::from(cand);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn locate_target_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at the crate dir; target sits at workspace
+    // root, two levels up.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."));
+    let workspace_root = manifest
+        .ancestors()
+        .nth(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest.clone());
+    workspace_root.join("target")
+}
+
+fn guess_socpak_path_for_zone(zone_name: &str) -> Option<String> {
+    // The composer's zone name is the socpak file stem. Map back to its
+    // p4k path using the known Executive Hangar layout. Returning `None`
+    // simply skips visarea counting for that zone, which is acceptable for
+    // a smoke test.
+    let lc = zone_name.to_ascii_lowercase();
+    let path = if lc.contains("final_set") {
+        EXEC_HANGAR_ROOT_SOCPAK
+    } else if lc.contains("asmbl_01_dung_exec_001a") {
+        FALLBACK_FLAT_SOCPAKS[0]
+    } else if lc.contains("int_dung_exec_001") {
+        FALLBACK_FLAT_SOCPAKS[1]
+    } else if lc.contains("hangar_dungeon_exec_001") {
+        FALLBACK_FLAT_SOCPAKS[2]
+    } else {
+        return None;
+    };
+    Some(path.to_string())
+}
+
+fn read_socpak(p4k: &MappedP4k, path: &str) -> Option<Vec<u8>> {
+    let entry = p4k.entry_case_insensitive(path)?;
+    p4k.read(entry).ok()
+}

--- a/crates/starbreaker-3d/tests/scene_catalog_smoke.rs
+++ b/crates/starbreaker-3d/tests/scene_catalog_smoke.rs
@@ -1,0 +1,156 @@
+//! End-to-end smoke test for the scene catalog enumerator.
+//!
+//! Loads the installed HOTFIX (or fallback channel) `Data.p4k`, runs
+//! `enumerate_scene_roots` against `Data/ObjectContainers/`, and asserts
+//! sanity on the result. Dumps the full catalog JSON to
+//! `target/scene_catalog_smoke.json` so the supervisor can inspect what
+//! came out.
+//!
+//! Marked `#[ignore]` because it depends on a Star Citizen install at a
+//! fixed path. Run manually with:
+//!
+//! ```text
+//! cargo test --manifest-path <repo>/Cargo.toml -p starbreaker-3d \
+//!   --test scene_catalog_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use starbreaker_3d::soc::{self, SceneCatalogEntry};
+use starbreaker_p4k::MappedP4k;
+
+const P4K_CANDIDATES: &[&str] = &[
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\HOTFIX\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\TECH-PREVIEW\Data.p4k",
+    r"C:\Program Files\Roberts Space Industries\StarCitizen\LIVE\Data.p4k",
+];
+
+const SEARCH_ROOTS: &[&str] = &["Data/ObjectContainers/"];
+
+/// Sanity floor: a real p4k always carries at least dozens of scene
+/// roots (asteroid bases, hangars, modular outposts, ship interiors).
+const MIN_EXPECTED_COUNT: usize = 10;
+
+/// Sanity ceiling: if the enumerator returns more than this, the
+/// graph is broken (every socpak became a "root") and the filter
+/// needs revisiting before we ship the list to the user.
+const MAX_EXPECTED_COUNT: usize = 5000;
+
+/// Path tails the catalog must surface so the smoke test stays
+/// anchored to the iteration-A reference scene. The Executive Hangar
+/// socpak (`ab_pyro_final_set_dungeon_executive-001.socpak`) turns
+/// out NOT to be a graph root in the live HOTFIX p4k -- a parent
+/// `ab_final_set` aggregator references it, putting it at in-degree
+/// 1. The user picks the parent, the composer recurses into the
+/// executive variant.
+///
+/// We assert that at least one of these well-known asteroid-base
+/// hangar / dungeon roots survives the filter. Different builds
+/// rename the parent aggregator; a substring match is more durable
+/// than pinning a specific filename.
+const REQUIRED_PATH_SUBSTRINGS: &[&str] = &[
+    "ab_pyro_final_set_dungeon",
+    "ab_collector_hangar",
+    "asteroid_base",
+];
+
+#[test]
+#[ignore = "depends on local SC install; run manually with --ignored"]
+fn smoke_scene_catalog_from_p4k() {
+    let p4k_path = locate_p4k().expect("no Star Citizen install with Data.p4k found");
+    eprintln!("opening p4k: {}", p4k_path.display());
+    let p4k = MappedP4k::open(&p4k_path).expect("MappedP4k::open");
+
+    let entries =
+        soc::enumerate_scene_roots(&p4k, SEARCH_ROOTS).expect("enumerate_scene_roots");
+
+    let total = entries.len();
+    eprintln!("scene catalog: {total} root socpaks");
+    if total > 0 {
+        eprintln!("first: {} ({})", entries[0].display_name, entries[0].path);
+        eprintln!(
+            "last:  {} ({})",
+            entries[total - 1].display_name,
+            entries[total - 1].path
+        );
+    }
+
+    // Dump JSON dump so the supervisor can scan the list. Done before
+    // assertions so even an assertion failure leaves a debuggable
+    // artefact behind.
+    let target_dir = locate_target_dir();
+    let summary_path = target_dir.join("scene_catalog_smoke.json");
+    if let Some(parent) = summary_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let body = serde_json::to_string_pretty(&entries_to_json(&entries)).expect("json");
+    std::fs::write(&summary_path, body).expect("write summary");
+    eprintln!("summary written to {}", summary_path.display());
+
+    assert!(
+        total >= MIN_EXPECTED_COUNT,
+        "expected at least {MIN_EXPECTED_COUNT} scene roots; got {total}"
+    );
+    assert!(
+        total <= MAX_EXPECTED_COUNT,
+        "expected at most {MAX_EXPECTED_COUNT} scene roots; got {total} -- the graph or filter is probably broken"
+    );
+
+    for needle in REQUIRED_PATH_SUBSTRINGS {
+        let present = entries
+            .iter()
+            .any(|e| e.path.to_ascii_lowercase().contains(needle));
+        assert!(
+            present,
+            "expected at least one root whose path contains {needle:?}"
+        );
+    }
+
+    for e in &entries {
+        assert!(
+            !e.display_name.trim().is_empty(),
+            "every entry should have a non-empty display name; got {:?}",
+            e
+        );
+    }
+}
+
+fn entries_to_json(entries: &[SceneCatalogEntry]) -> serde_json::Value {
+    let arr: Vec<serde_json::Value> = entries
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "path": e.path,
+                "display_name": e.display_name,
+                "sub_zone_count": e.sub_zone_count,
+                "source_kind": e.source_kind.as_snake_case(),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "count": arr.len(),
+        "entries": arr,
+    })
+}
+
+fn locate_p4k() -> Option<PathBuf> {
+    for cand in P4K_CANDIDATES {
+        let p = PathBuf::from(cand);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn locate_target_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."));
+    let workspace_root = manifest
+        .ancestors()
+        .nth(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest.clone());
+    workspace_root.join("target")
+}

--- a/crates/starbreaker-common/src/discover.rs
+++ b/crates/starbreaker-common/src/discover.rs
@@ -26,7 +26,12 @@
 use std::path::PathBuf;
 
 /// Known Star Citizen channel names, in preference order.
-pub const CHANNELS: &[&str] = &["LIVE", "PTU", "EPTU", "TECH-PREVIEW"];
+///
+/// HOTFIX is a transient channel CIG spins up to ship emergency fixes
+/// outside the normal LIVE/PTU/EPTU cadence. TECH-PREVIEW is used for
+/// limited-access feature previews. Both appear in the launcher and ship
+/// a full Data.p4k, so they belong in discovery.
+pub const CHANNELS: &[&str] = &["LIVE", "PTU", "EPTU", "HOTFIX", "TECH-PREVIEW"];
 
 /// Default install root on Windows.
 pub const DEFAULT_ROOT: &str = r"C:\Program Files\Roberts Space Industries\StarCitizen";

--- a/docs/decomposed-export-contract.md
+++ b/docs/decomposed-export-contract.md
@@ -18,10 +18,62 @@ Within that export root:
 - the package directory path under `Packages/<package name>`
 - root entity metadata and asset references
 - child attachment relationships via `parent_entity_name`, `parent_node_name`, `offset_position`, `offset_rotation`, `no_rotation`, and `port_flags`
+- a unique per-export `instance_id` on the root and every child, plus `parent_instance_id` on every child, so consumers can disambiguate sibling placements that share the same `entity_name` (see "Instance Identity" below)
 - interior container transforms, placement records, and exported light data
 - material sidecar and palette references for every scene instance
 
 `port_flags` is the raw source `SItemPortDef.Flags` string for the item port that attached a child. Importers can use this to preserve source visibility semantics; for example, Blender hides attachments by default when the source port includes `invisible` while keeping the objects present for inspection.
+
+## Instance Identity
+
+Authored `entity_name` values are not unique across a scene. A ship can mount
+the same entity at several hardpoints (paired weapon mounts, paired
+countermeasure launchers, paired turrets), and every instance shares one name.
+Children that record `parent_entity_name = "Mount_Gimbal_S1_NoSafety"` therefore
+cannot tell which physical mount they hang off when more than one exists.
+
+To disambiguate, every scene instance now carries a unique `instance_id`:
+
+- the root entity is reserved id `0`
+- every distinct child placement gets a fresh monotonic `u32` from a counter
+  scoped to a single export run
+- every child also carries `parent_instance_id` referencing the actual
+  scene-graph parent (root or another child)
+
+Consumers should key any parent-attach registry on `instance_id` rather than
+`entity_name`, and resolve a child's parent via `parent_instance_id` rather
+than `parent_entity_name`. The name fields remain in the JSON for
+human-readable debugging.
+
+```json
+"children": [
+  {
+    "entity_name": "Mount_Gimbal_S1_NoSafety",
+    "instance_id": 23,
+    "parent_entity_name": "EntityClassDefinition.XIAN_Nox",
+    "parent_instance_id": 0,
+    "parent_node_name": "hardpoint_weapon_right"
+  },
+  {
+    "entity_name": "Mount_Gimbal_S1_NoSafety",
+    "instance_id": 25,
+    "parent_entity_name": "EntityClassDefinition.XIAN_Nox",
+    "parent_instance_id": 0,
+    "parent_node_name": "hardpoint_weapon_left"
+  }
+]
+```
+
+`instance_id` is unique only within one export. It is not stable across
+re-exports of the same entity (the counter walks the loadout in order, so
+order-preserving changes will keep ids stable, but adding or removing a child
+can shift later ids). Consumers should therefore not persist instance ids
+across export runs.
+
+Backward compatibility: older sidecars without `instance_id` /
+`parent_instance_id` remain valid. Loaders should fall back to
+`entity_name` / `parent_entity_name` matching with a warning so the operator
+knows disambiguation is best-effort until the export is regenerated.
 
 ## Light Records
 
@@ -153,6 +205,61 @@ Each `*.materials.json` sidecar preserves:
 - material-set identity and palette-routing metadata
 - resolved paint-override selectors when equipped paints choose a palette or material through `SubGeometry` tag matching
 - variant-membership hints for palette-routed and layered materials
+- per-submaterial `tint_palette` block with the resolved TintPaletteTree colors when the submaterial belongs to a palette-driven family (currently HardSurface)
+
+### Tint Palette Block
+
+HardSurface ship hulls render as a palette color modulated by a shared
+tiling texture: `final_diffuse = entry.tint_color * (tiling / 255)`.
+The exporter resolves the entity's TintPaletteTree once via
+`Components[SGeometryResourceParams].Geometry.Geometry.Palette.RootRecord`
+and bakes the resolved entry colors into every HardSurface submaterial in
+the sidecar so consumers do not need DataCore access at render time.
+
+The sidecar also carries the shared palette identifier on the parent
+`palette_contract.resolved_palette_id`, which matches the same id stored
+in `palettes.json` and on every scene instance in `scene.json`. Consumers
+that prefer the shared manifest can ignore the per-submaterial entries
+and resolve via that lookup instead.
+
+`assigned_channel` is filled from the MTL's authored `PaletteTint`
+attribute when set (`1=entryA`, `2=entryB`, `3=entryC`). When that
+attribute is absent the exporter falls back to the
+`Paint_Primary` / `Paint_Secondary` / `Paint_Tertiary` submaterial-name
+prefix. Submaterials that match neither leave `assigned_channel` null
+but still receive the full `entries` array so consumers can apply their
+own routing rule.
+
+`tint_color` and `spec_color` are linear RGB in `[0,1]`, sRGB-decoded
+from the authored 0-255 source values. `glossiness` is the authored
+scalar, or `null` when the entry omits it.
+
+```json
+"submaterials": [
+  {
+    "submaterial_name": "metal_a",
+    "shader_family": "HardSurface",
+    "tint_palette": {
+      "palette_id": "palette/rsi_polaris_default",
+      "palette_source_name": "rsi_polaris_default",
+      "assigned_channel": "entryA",
+      "entries": [
+        {
+          "channel": "entryA",
+          "tint_color": [0.10, 0.20, 0.30],
+          "spec_color": [0.9, 0.9, 0.9],
+          "glossiness": 0.55
+        },
+        { "channel": "entryB", "tint_color": [0.30, 0.20, 0.10], "spec_color": [0.5, 0.5, 0.5], "glossiness": 0.42 },
+        { "channel": "entryC", "tint_color": [0.40, 0.50, 0.60], "spec_color": [0.2, 0.2, 0.2], "glossiness": 0.30 }
+      ]
+    }
+  }
+]
+```
+
+The block is omitted (`null`) for non-HardSurface submaterials and for
+entities that have no resolved TintPaletteTree.
 
 The current sidecar contract is now substantially closer to the raw `.mtl` XML surface, but it is still intentionally split into two layers:
 


### PR DESCRIPTION

# Add 3D Scene Viewer with material fidelity and platform fixes

Adds a Tauri-side 3D scene viewer that renders decomposed exports directly, plus the supporting backend changes that let the viewer produce somewhat visually-correct results without a Blender round-trip. There are more iterations needed to get the visual quality on par with Blender and in-game renders.

## What this adds:

* 3D Viewer mode in the Tauri app (sidebar entry "3D Viewer"). Loads a decomposed export package, walks scene.json, builds Three.js objects for every scene instance and interior placement, and presents an interactive PBR scene with OrbitControls, IBL via PMREMGenerator + RoomEnvironment, sRGB output, and ACES filmic tonemapping.
* Tauri command surface (`decomposed_commands.rs`) for cache management, on-demand exports, package enumeration, and scene/sidecar/texture reads. The viewer can either consume an on-disk package or trigger a fresh decomposed export from DataCore.

## Engine-fidelity backend fixes:

* `mtl::extract_mtl_name` now handles legacy CrCh chunk files in addition to IVO. CrCh meshes were silently falling through to the DataCore-supplied path and binding the wrong MTL.
* `pipeline::resolve_material` now prefers the MtlName chunk declared by the mesh's metadata over the DataCore-supplied path. The runtime resolves a CGF's MTL the same way, so component meshes whose loadout entry points at a generic interior-master MTL now bind to the asset-specific MTL the mesh itself declares.
* `glb_builder::build_material` emits `extras.submat_index` on every GLB material. Downstream loaders (Blender importer, Three.js viewer) can bind GLB materials to sidecar submaterial entries by index instead of name-matching across MTL-source / Blender-semantic naming spaces.
* `decomposed.rs` adds `cols_to_rows_4x4` for the row-major JSON contract and routes `interior_container_json::container_transform` and per-placement transforms through it; the previous serializer treated column-major glTF matrices as row-major and emitted transposed transforms.
* Interior cache key now includes `effective_palette_id`. Without it, an interior loaded under paint variant A returned a stale sidecar for paint variant B.
* New `instance_id` / `parent_instance_id` system on every `EntityPayload` and scene-instance record. A monotonic per-export counter assigns a unique id to every child placement, so sibling placements that share `entity_name` (paired weapon mounts, paired turrets) can be disambiguated by downstream consumers. The root entity is reserved id 0; both fields are documented in `decomposed-export-contract.md` with a backward-compatibility note.
* `decomposed::CONTRACT_VERSION` bumped to 2 (re-exported from the crate root as `DECOMPOSED_CONTRACT_VERSION`) and stamped into scene.json so consumers can detect schema changes.

## Installation / platform fixes:

* `discover::CHANNELS` adds `HOTFIX`. CIG ships emergency patches through HOTFIX with a full Data.p4k; auto-discovery should pick it up.
* `main.tsx` replaces `attachConsole()` with a `forwardConsole()` shim. `attachConsole` routes Rust logs back into the JS console, where `tauri-plugin-log`'s Webview target re-captures them, creating an infinite loop. The shim forwards browser console writes to Rust log without the Webview target, breaking the cycle.
* `main.rs` drops the Webview log target accordingly, adds Stdout + LogDir targets with file rotation.

## What it doesn't do:

* Material accuracy is iterative. ClearCoat is bound to a conservative default (0.5 when present, 0 otherwise); the proper PublicParams ClearCoatBlend port is a follow-up. IBL uses Three.js's RoomEnvironment as a placeholder; HDRI and EnvProbe baking are follow-ups. Layer wear blending uses the first-layer diffuse as a fallback; multi-layer LayerBlend with edge-wear masks is a follow-up.
* No animation playback, no shadows, no parallax-occlusion offline baking. The viewer is intended for visual inspection of decomposed exports, not as a final-quality render.

Co-authored with Claude Code Opus 4.7, who would lead you believe it did all the work.