### PR TITLE
Improve tree view for P4K and DCB views

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -35,6 +35,13 @@ pub enum DirEntryDto {
     Directory { name: String },
 }
 
+/// A matching file returned by P4k path search.
+#[derive(Serialize)]
+pub struct P4kSearchResultDto {
+    pub path: String,
+    pub uncompressed_size: u64,
+}
+
 /// Info returned after opening a P4k.
 #[derive(Serialize)]
 pub struct P4kInfo {
@@ -208,6 +215,38 @@ pub fn list_dir(state: State<'_, AppState>, path: String) -> Result<Vec<DirEntry
         .collect();
 
     Ok(dtos)
+}
+
+/// Search file paths from the loaded P4k archive.
+#[tauri::command]
+pub fn p4k_search(
+    state: State<'_, AppState>,
+    query: String,
+) -> Result<Vec<P4kSearchResultDto>, AppError> {
+    let guard = state.p4k.lock();
+    let p4k = guard
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("P4k not loaded".into()))?;
+
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut results: Vec<_> = p4k
+        .entries()
+        .iter()
+        .filter(|entry| entry.name.to_ascii_lowercase().contains(&query))
+        .map(|entry| P4kSearchResultDto {
+            path: entry.name.clone(),
+            uncompressed_size: entry.uncompressed_size,
+        })
+        .collect();
+
+    results.sort_by(|a, b| a.path.len().cmp(&b.path.len()).then_with(|| a.path.cmp(&b.path)));
+    results.truncate(500);
+
+    Ok(results)
 }
 
 // ── DataCore / Export DTOs ──────────────────────────────────────────

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -216,6 +216,7 @@ fn main() {
             commands::discover_p4k,
             commands::open_p4k,
             commands::list_dir,
+            commands::p4k_search,
             commands::list_subdirs,
             commands::scan_categories,
             commands::start_export,

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -20,6 +20,11 @@ export interface DirectoryDirEntry {
 
 export type DirEntry = FileDirEntry | DirectoryDirEntry;
 
+export interface P4kSearchResult {
+  path: string;
+  uncompressed_size: number;
+}
+
 export interface LoadProgress {
   fraction: number;
   message: string;
@@ -67,6 +72,11 @@ export async function openP4k(path: string): Promise<P4kInfo> {
 /** List directory contents from the loaded P4k. */
 export async function listDir(path: string): Promise<DirEntry[]> {
   return invoke<DirEntry[]>("list_dir", { path });
+}
+
+/** Search file paths from the loaded P4k. */
+export async function p4kSearch(query: string): Promise<P4kSearchResult[]> {
+  return invoke<P4kSearchResult[]>("p4k_search", { query });
 }
 
 /** List only subdirectory names under a path (fast). */

--- a/app/src/views/datacore-browser.tsx
+++ b/app/src/views/datacore-browser.tsx
@@ -59,8 +59,8 @@ function NavPanel({ width, onExtractStart, onExtractEnd }: {
   const hasSearch = searchQuery.trim().length > 0;
 
   return (
-    <div className="flex flex-col border-r border-border overflow-hidden shrink-0" style={{ width }}>
-      <div className={hasSearch ? "hidden" : "flex-1 overflow-hidden"}>
+    <div className="flex flex-col border-r border-border overflow-hidden shrink-0 min-h-0" style={{ width }}>
+      <div className={hasSearch ? "hidden" : "flex-1 min-h-0 overflow-hidden"}>
         <TreePanel onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />
       </div>
       {hasSearch && <SearchResults onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />}
@@ -174,11 +174,11 @@ function SearchResults({ onExtractStart, onExtractEnd }: {
   }, [searchQuery, doSearch]);
 
   return (
-    <>
+    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
       <div className="px-2.5 py-1 text-[11px] text-text-dim">
         {searching ? "Searching..." : `${searchResults.length} results`}
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {searchTree.map((node) => (
           <SearchTreeItem
             key={node.kind === "folder" ? `f:${node.path}` : `r:${node.id}`}
@@ -189,7 +189,7 @@ function SearchResults({ onExtractStart, onExtractEnd }: {
           />
         ))}
       </div>
-    </>
+    </div>
   );
 }
 
@@ -246,7 +246,7 @@ function TreePanel({ onExtractStart, onExtractEnd }: {
   onExtractEnd: () => void;
 }) {
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="h-full min-h-0 overflow-y-auto">
       <TreeLevel path="" depth={0} onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />
     </div>
   );

--- a/app/src/views/datacore-browser.tsx
+++ b/app/src/views/datacore-browser.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Download } from "lucide-react";
 import { useDataCoreStore } from "../stores/datacore-store";
 import { ResizeHandle } from "../components/resize-handle";
@@ -60,20 +60,99 @@ function NavPanel({ width, onExtractStart, onExtractEnd }: {
 
   return (
     <div className="flex flex-col border-r border-border overflow-hidden shrink-0" style={{ width }}>
-      {hasSearch ? <SearchResults /> : <TreePanel onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />}
+      <div className={hasSearch ? "hidden" : "flex-1 overflow-hidden"}>
+        <TreePanel onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />
+      </div>
+      {hasSearch && <SearchResults onExtractStart={onExtractStart} onExtractEnd={onExtractEnd} />}
     </div>
   );
 }
 
-// ── Search results (flat list when typing) ──────────────────────────────────
+// ── Search results (hierarchical while typing) ───────────────────────────────
 
-function SearchResults() {
+interface SearchTreeFolder {
+  kind: "folder";
+  name: string;
+  path: string;
+  children: SearchTreeNode[];
+}
+
+interface SearchTreeRecord {
+  kind: "record";
+  name: string;
+  path: string;
+  structType: string;
+  id: string;
+}
+
+type SearchTreeNode = SearchTreeFolder | SearchTreeRecord;
+
+function searchResultsToTree(results: SearchResultDto[]): SearchTreeNode[] {
+  const root: SearchTreeNode[] = [];
+
+  for (const result of results) {
+    const segments = result.path.split("/").filter(Boolean);
+    const folderSegments = segments.length > 1 ? segments.slice(0, -1) : [];
+    let siblings = root;
+    let currentPath = "";
+
+    for (const segment of folderSegments) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let folder = siblings.find(
+        (node): node is SearchTreeFolder =>
+          node.kind === "folder" && node.path === currentPath,
+      );
+
+      if (!folder) {
+        folder = {
+          kind: "folder",
+          name: segment,
+          path: currentPath,
+          children: [],
+        };
+        siblings.push(folder);
+      }
+
+      siblings = folder.children;
+    }
+
+    siblings.push({
+      kind: "record",
+      name: result.name,
+      path: result.path,
+      structType: result.struct_type,
+      id: result.id,
+    });
+  }
+
+  const sortNodes = (nodes: SearchTreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const node of nodes) {
+      if (node.kind === "folder") sortNodes(node.children);
+    }
+  };
+
+  sortNodes(root);
+  return root;
+}
+
+function SearchResults({ onExtractStart, onExtractEnd }: {
+  onExtractStart: () => void;
+  onExtractEnd: () => void;
+}) {
   const searchQuery = useDataCoreStore((s) => s.searchQuery);
   const searchResults = useDataCoreStore((s) => s.searchResults);
   const setSearchResults = useDataCoreStore((s) => s.setSearchResults);
   const searching = useDataCoreStore((s) => s.searching);
   const setSearching = useDataCoreStore((s) => s.setSearching);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const searchTree = useMemo(
+    () => searchResultsToTree(searchResults),
+    [searchResults],
+  );
 
   const doSearch = useCallback(
     (query: string) => {
@@ -100,28 +179,62 @@ function SearchResults() {
         {searching ? "Searching..." : `${searchResults.length} results`}
       </div>
       <div className="flex-1 overflow-y-auto">
-        {searchResults.map((result) => (
-          <SearchResultRow key={result.id} result={result} />
+        {searchTree.map((node) => (
+          <SearchTreeItem
+            key={node.kind === "folder" ? `f:${node.path}` : `r:${node.id}`}
+            node={node}
+            depth={0}
+            onExtractStart={onExtractStart}
+            onExtractEnd={onExtractEnd}
+          />
         ))}
       </div>
     </>
   );
 }
 
-function SearchResultRow({ result }: { result: SearchResultDto }) {
+function SearchTreeItem({ node, depth, onExtractStart, onExtractEnd }: {
+  node: SearchTreeNode;
+  depth: number;
+  onExtractStart: () => void;
+  onExtractEnd: () => void;
+}) {
   const selectRecord = useSelectRecord();
+
+  if (node.kind === "folder") {
+    return (
+      <div>
+        <FolderRow
+          name={node.name}
+          path={node.path}
+          depth={depth}
+          expanded={true}
+          onToggle={() => undefined}
+          onExtractStart={onExtractStart}
+          onExtractEnd={onExtractEnd}
+        />
+        {node.children.map((child) => (
+          <SearchTreeItem
+            key={child.kind === "folder" ? `f:${child.path}` : `r:${child.id}`}
+            node={child}
+            depth={depth + 1}
+            onExtractStart={onExtractStart}
+            onExtractEnd={onExtractEnd}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <button
       type="button"
-      onClick={() => selectRecord(result.id)}
-      className="w-full text-left px-2.5 py-1 hover:bg-surface transition-colors"
+      onClick={() => selectRecord(node.id)}
+      className="w-full text-left flex items-center h-6 hover:bg-surface transition-colors group"
+      style={{ paddingLeft: depth * 16 + 22 }}
     >
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[13px] text-text truncate">{result.name}</span>
-        <span className="text-[10px] text-primary shrink-0">{result.struct_type}</span>
-      </div>
-      <div className="text-[11px] text-text-dim truncate">{result.path}</div>
+      <span className="text-[13px] text-text-sub truncate flex-1">{node.name}</span>
+      <span className="text-[10px] text-text-faint pr-2 shrink-0">{node.structType}</span>
     </button>
   );
 }

--- a/app/src/views/datacore-browser.tsx
+++ b/app/src/views/datacore-browser.tsx
@@ -200,6 +200,7 @@ function SearchTreeItem({ node, depth, onExtractStart, onExtractEnd }: {
   onExtractEnd: () => void;
 }) {
   const selectRecord = useSelectRecord();
+  const [expanded, setExpanded] = useState(true);
 
   if (node.kind === "folder") {
     return (
@@ -208,12 +209,12 @@ function SearchTreeItem({ node, depth, onExtractStart, onExtractEnd }: {
           name={node.name}
           path={node.path}
           depth={depth}
-          expanded={true}
-          onToggle={() => undefined}
+          expanded={expanded}
+          onToggle={() => setExpanded((e) => !e)}
           onExtractStart={onExtractStart}
           onExtractEnd={onExtractEnd}
         />
-        {node.children.map((child) => (
+        {expanded && node.children.map((child) => (
           <SearchTreeItem
             key={child.kind === "folder" ? `f:${child.path}` : `r:${child.id}`}
             node={child}

--- a/app/src/views/p4k-browser.tsx
+++ b/app/src/views/p4k-browser.tsx
@@ -1,6 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Download } from "lucide-react";
-import { listDir, extractP4kFolder, extractP4kFile, type DirEntry } from "../lib/commands";
+import {
+  listDir,
+  p4kSearch,
+  extractP4kFolder,
+  extractP4kFile,
+  type DirEntry,
+  type P4kSearchResult,
+} from "../lib/commands";
 import { ExtractProgress } from "../components/extract-progress";
 import { useAppStore } from "../stores/app-store";
 import { ResizeHandle } from "../components/resize-handle";
@@ -248,12 +255,75 @@ function entriesToNodes(parentPath: string, entries: DirEntry[]): TreeNode[] {
   return [...dirs, ...files];
 }
 
+function p4kSearchResultsToNodes(results: P4kSearchResult[]): TreeNode[] {
+  const root: TreeNode[] = [];
+
+  for (const result of results) {
+    const segments = result.path.split("\\").filter(Boolean);
+    let siblings = root;
+    let currentPath = "";
+
+    segments.forEach((segment, index) => {
+      const isFile = index === segments.length - 1;
+      currentPath = currentPath ? `${currentPath}\\${segment}` : segment;
+
+      if (isFile) {
+        siblings.push({
+          name: segment,
+          path: currentPath,
+          isDir: false,
+          size: result.uncompressed_size,
+          loaded: true,
+          expanded: false,
+          loading: false,
+        });
+        return;
+      }
+
+      let folder = siblings.find((node) => node.isDir && node.path === currentPath);
+      if (!folder) {
+        folder = {
+          name: segment,
+          path: currentPath,
+          isDir: true,
+          loaded: true,
+          expanded: true,
+          loading: false,
+          children: [],
+        };
+        siblings.push(folder);
+      }
+
+      folder.children ??= [];
+      siblings = folder.children;
+    });
+  }
+
+  const sortNodes = (nodes: TreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const node of nodes) {
+      if (node.children) sortNodes(node.children);
+    }
+  };
+
+  sortNodes(root);
+  return root;
+}
+
 export function P4kBrowser() {
   const hasData = useAppStore((s) => s.hasData);
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [selectedPath, setSelectedPath] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<P4kSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
   const [treeWidth, setTreeWidth] = useState(360);
+  const [extracting, setExtracting] = useState(false);
+  const [extractFilter, setExtractFilter] = useState("");
+  const searchSeqRef = useRef(0);
 
   // Load root entries on mount
   useEffect(() => {
@@ -262,6 +332,45 @@ export function P4kBrowser() {
       setTree(entriesToNodes("", entries));
     });
   }, [hasData]);
+
+  useEffect(() => {
+    const query = searchQuery.trim();
+    searchSeqRef.current += 1;
+    const seq = searchSeqRef.current;
+
+    if (!hasData || query.length === 0) {
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+
+    setSearching(true);
+    const timeout = setTimeout(() => {
+      p4kSearch(query)
+        .then((results) => {
+          if (searchSeqRef.current === seq) {
+            setSearchResults(results);
+            setSearching(false);
+          }
+        })
+        .catch((err) => {
+          if (searchSeqRef.current === seq) {
+            console.error("P4k search failed:", err);
+            setSearchResults([]);
+            setSearching(false);
+          }
+        });
+    }, 150);
+
+    return () => clearTimeout(timeout);
+  }, [hasData, searchQuery]);
+
+  const searchTree = useMemo(
+    () => p4kSearchResultsToNodes(searchResults),
+    [searchResults],
+  );
+  const hasSearch = searchQuery.trim().length > 0;
+  const displayedTree = hasSearch ? searchTree : tree;
 
   const handleToggle = useCallback(
     async (path: string) => {
@@ -328,9 +437,6 @@ export function P4kBrowser() {
     );
   }
 
-  const [extracting, setExtracting] = useState(false);
-  const [extractFilter, setExtractFilter] = useState("");
-
   return (
     <div className="flex-1 flex flex-col overflow-hidden relative">
       <ExtractProgress active={extracting} onDone={() => setExtracting(false)} />
@@ -343,6 +449,11 @@ export function P4kBrowser() {
           onChange={(e) => setSearchQuery(e.target.value)}
           className="flex-1 bg-surface rounded-md px-3 py-1.5 text-sm text-text placeholder:text-text-faint outline-none focus:ring-1 focus:ring-ring"
         />
+        {hasSearch && (
+          <span className="text-xs text-text-dim shrink-0">
+            {searching ? "Searching..." : `${searchResults.length} results`}
+          </span>
+        )}
         <input
           type="text"
           placeholder="Extract filter (e.g. mtl,xml)"
@@ -357,12 +468,12 @@ export function P4kBrowser() {
       {/* Tree panel */}
       <div className="border-r border-border overflow-y-auto shrink-0" style={{ width: treeWidth }}>
         <div className="py-1">
-          {tree.map((node) => (
+          {displayedTree.map((node) => (
             <TreeItem
               key={node.path}
               node={node}
               depth={0}
-              onToggle={handleToggle}
+              onToggle={hasSearch ? () => undefined : handleToggle}
               selectedPath={selectedPath}
               onSelect={setSelectedPath}
               extractFilter={extractFilter}

--- a/app/src/views/p4k-browser.tsx
+++ b/app/src/views/p4k-browser.tsx
@@ -337,6 +337,7 @@ export function P4kBrowser() {
     const query = searchQuery.trim();
     searchSeqRef.current += 1;
     const seq = searchSeqRef.current;
+    setCollapsedSearchPaths(new Set());
 
     if (!hasData || query.length === 0) {
       setSearchResults([]);
@@ -369,8 +370,30 @@ export function P4kBrowser() {
     () => p4kSearchResultsToNodes(searchResults),
     [searchResults],
   );
+  const [collapsedSearchPaths, setCollapsedSearchPaths] = useState<Set<string>>(new Set());
   const hasSearch = searchQuery.trim().length > 0;
-  const displayedTree = hasSearch ? searchTree : tree;
+  const displayedTree = useMemo(() => {
+    if (!hasSearch) return tree;
+    const applyCollapsed = (nodes: TreeNode[]): TreeNode[] =>
+      nodes.map((node) => ({
+        ...node,
+        expanded: node.isDir ? !collapsedSearchPaths.has(node.path) : node.expanded,
+        ...(node.children ? { children: applyCollapsed(node.children) } : {}),
+      }));
+    return applyCollapsed(searchTree);
+  }, [hasSearch, tree, searchTree, collapsedSearchPaths]);
+
+  const handleSearchToggle = useCallback((path: string) => {
+    setCollapsedSearchPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
 
   const handleToggle = useCallback(
     async (path: string) => {
@@ -473,7 +496,7 @@ export function P4kBrowser() {
               key={node.path}
               node={node}
               depth={0}
-              onToggle={hasSearch ? () => undefined : handleToggle}
+              onToggle={hasSearch ? handleSearchToggle : handleToggle}
               selectedPath={selectedPath}
               onSelect={setSelectedPath}
               extractFilter={extractFilter}


### PR DESCRIPTION
* Fixes P4K Browser search function
<img width="1279" height="822" alt="image" src="https://github.com/user-attachments/assets/676e9121-8e0a-4d08-abb0-9e011a4946d5" />

* Adds hierarchical search results to P4K Browser and Datacore Views
<img width="1275" height="821" alt="image" src="https://github.com/user-attachments/assets/f932a225-3af3-4743-9bf6-9f069e025541" />


I wanted to implement an expand/collapse all feature but it drastically slows down the initial load times. Because starbreaker doesn't load every entry on load as opposed to starfab, so expanding all requires a crawl when done dynamically.

I opted to revert those changes until I find a better solution.
Current changes fix the search and keep the hierarchy upon search.

### What I want to work on

I want to allow xml view of datacore entries with ctrl+f search support (similar capabilities to starfab). 

I also wanted to "remember" which entry is open on the tree view and keep that branch expanded even if the search is closed, but had issues with it so I also reverted that.