### PR TITLE
[WIP] Diffing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -179,6 +179,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -499,6 +505,20 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -928,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1033,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -5166,7 +5201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5350,6 +5385,7 @@ dependencies = [
  "starbreaker-cryxml",
  "starbreaker-datacore",
  "starbreaker-dds",
+ "starbreaker-diff",
  "starbreaker-p4k",
  "starbreaker-wem",
  "starbreaker-wwise",
@@ -5395,6 +5431,7 @@ dependencies = [
  "starbreaker-cryxml",
  "starbreaker-datacore",
  "starbreaker-dds",
+ "starbreaker-diff",
  "starbreaker-p4k",
  "starbreaker-wem",
  "starbreaker-wwise",
@@ -5484,6 +5521,19 @@ dependencies = [
  "starbreaker-common",
  "thiserror 2.0.18",
  "zerocopy",
+]
+
+[[package]]
+name = "starbreaker-diff"
+version = "0.2.2"
+dependencies = [
+ "blake3",
+ "serde",
+ "serde_json",
+ "starbreaker-datacore",
+ "starbreaker-p4k",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "starbreaker-app",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.24",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-log": "^2.8.0",
@@ -1250,6 +1251,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ starbreaker-wwise = { path = "../../crates/starbreaker-wwise" }
 starbreaker-wem = { path = "../../crates/starbreaker-wem" }
 starbreaker-cryxml = { path = "../../crates/starbreaker-cryxml" }
 starbreaker-dds = { path = "../../crates/starbreaker-dds" }
+starbreaker-diff = { path = "../../crates/starbreaker-diff" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 tokio = { version = "1", features = ["rt"] }
 rayon = "1"

--- a/app/src-tauri/src/diff_commands.rs
+++ b/app/src-tauri/src/diff_commands.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
@@ -5,7 +6,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
 use crate::error::AppError;
-use crate::state::AppState;
+use crate::state::{AppState, DiffSession};
 
 #[derive(Clone, Serialize)]
 pub struct DiffInventoryProgress {
@@ -183,26 +184,70 @@ pub fn diff_query_report_page(
     offset: usize,
     limit: usize,
 ) -> Result<starbreaker_diff::DiffPage, AppError> {
-    let inventories = state.diff_inventories.lock();
-    let old = inventories
-        .get(&old_id)
-        .ok_or_else(|| AppError::Internal(format!("old inventory not found: {old_id}")))?;
-    let new = inventories
-        .get(&new_id)
-        .ok_or_else(|| AppError::Internal(format!("new inventory not found: {new_id}")))?;
+    let session_id = diff_session_id(&old_id, &new_id, filter.include_unchanged);
+    ensure_diff_session(&state, &session_id, &old_id, &new_id, filter.include_unchanged)?;
     log::info!(
-        "diff page query started: old_id={} old_label={} new_id={} new_label={} filter={:?} offset={} limit={}",
+        "diff page query started: session_id={} old_id={} new_id={} filter={:?} offset={} limit={}",
+        session_id,
         old_id,
-        old.source.label,
         new_id,
-        new.source.label,
         filter,
         offset,
         limit
     );
-    let page = starbreaker_diff::compare_report_page(old, new, &filter, offset, limit);
+    let mut sessions = state.diff_sessions.lock();
+    let session = sessions
+        .get_mut(&session_id)
+        .ok_or_else(|| AppError::Internal(format!("diff session not found: {session_id}")))?;
+    let filter_key = serde_json::to_string(&filter)
+        .map_err(|e| AppError::Internal(format!("filter serialization failed: {e}")))?;
+    if !session.filter_indexes.contains_key(&filter_key) {
+        let indexes: Vec<_> = session
+            .report
+            .items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, item)| {
+                if starbreaker_diff::diff_item_matches_filter(item, &filter) {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if session.filter_indexes.len() >= 8
+            && let Some(remove_key) = session.filter_indexes.keys().next().cloned()
+        {
+            session.filter_indexes.remove(&remove_key);
+        }
+        session.filter_indexes.insert(filter_key.clone(), indexes);
+    }
+    let indexes = session
+        .filter_indexes
+        .get(&filter_key)
+        .ok_or_else(|| AppError::Internal("diff filter index missing".to_string()))?;
+    let limit = limit.max(1);
+    let items = indexes
+        .iter()
+        .skip(offset)
+        .take(limit)
+        .map(|index| session.report.items[*index].clone())
+        .collect();
+    let page = starbreaker_diff::DiffPage {
+        schema_version: session.report.schema_version,
+        old_label: session.report.old_label.clone(),
+        new_label: session.report.new_label.clone(),
+        old_inventory_hash: session.report.old_inventory_hash.clone(),
+        new_inventory_hash: session.report.new_inventory_hash.clone(),
+        summary: session.report.summary.clone(),
+        total_matching: indexes.len(),
+        offset,
+        limit,
+        items,
+    };
     log::info!(
-        "diff page query finished: old_id={} new_id={} total_matching={} returned_items={} summary_added={} summary_removed={} summary_modified={} summary_metadata={} summary_unchanged={}",
+        "diff page query finished: session_id={} old_id={} new_id={} total_matching={} returned_items={} summary_added={} summary_removed={} summary_modified={} summary_metadata={} summary_unchanged={}",
+        session_id,
         old_id,
         new_id,
         page.total_matching,
@@ -231,6 +276,53 @@ fn new_inventory_id() -> String {
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
     format!("inv-{nanos}")
+}
+
+fn diff_session_id(old_id: &str, new_id: &str, include_unchanged: bool) -> String {
+    format!("{old_id}:{new_id}:{include_unchanged}")
+}
+
+fn ensure_diff_session(
+    state: &State<'_, AppState>,
+    session_id: &str,
+    old_id: &str,
+    new_id: &str,
+    include_unchanged: bool,
+) -> Result<(), AppError> {
+    if state.diff_sessions.lock().contains_key(session_id) {
+        return Ok(());
+    }
+    let inventories = state.diff_inventories.lock();
+    let old = inventories
+        .get(old_id)
+        .ok_or_else(|| AppError::Internal(format!("old inventory not found: {old_id}")))?;
+    let new = inventories
+        .get(new_id)
+        .ok_or_else(|| AppError::Internal(format!("new inventory not found: {new_id}")))?;
+    log::info!(
+        "diff session build started: session_id={} old_label={} new_label={} include_unchanged={}",
+        session_id,
+        old.source.label,
+        new.source.label,
+        include_unchanged
+    );
+    let report = starbreaker_diff::compare_reports(old, new, include_unchanged);
+    drop(inventories);
+    let mut sessions = state.diff_sessions.lock();
+    if sessions.len() >= 4
+        && let Some(remove_key) = sessions.keys().next().cloned()
+    {
+        sessions.remove(&remove_key);
+    }
+    sessions.insert(
+        session_id.to_string(),
+        DiffSession {
+            report,
+            filter_indexes: HashMap::new(),
+        },
+    );
+    log::info!("diff session build finished: session_id={}", session_id);
+    Ok(())
 }
 
 fn inventory_handle(id: &str, report: &starbreaker_diff::InventoryReport) -> DiffInventoryHandle {

--- a/app/src-tauri/src/diff_commands.rs
+++ b/app/src-tauri/src/diff_commands.rs
@@ -1,0 +1,209 @@
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+#[derive(Clone, Serialize)]
+pub struct DiffInventoryProgress {
+    pub job_id: String,
+    pub phase: String,
+    pub current: Option<usize>,
+    pub total: Option<usize>,
+    pub message: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct DiffInventoryHandle {
+    pub id: String,
+    pub label: String,
+    pub mode: starbreaker_diff::InventoryMode,
+    pub path_hint: Option<String>,
+    pub archive_count: usize,
+    pub datacore_count: usize,
+    pub inventory_hash: String,
+    pub warnings: Vec<String>,
+}
+
+#[tauri::command]
+pub async fn diff_generate_inventory(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    path: String,
+    skip_datacore: bool,
+    label: Option<String>,
+    job_id: String,
+) -> Result<DiffInventoryHandle, AppError> {
+    state.diff_cancel.store(false, Ordering::Relaxed);
+    let cancel = state.diff_cancel.clone();
+    let app_clone = app.clone();
+    let options = starbreaker_diff::InventoryOptions {
+        skip_datacore,
+        label,
+        ..Default::default()
+    };
+    let report = tokio::task::spawn_blocking(move || {
+        let mut progress = |event: starbreaker_diff::ProgressEvent| {
+            let _ = app_clone.emit("diff-inventory-progress", DiffInventoryProgress {
+                job_id: job_id.clone(),
+                phase: format!("{:?}", event.phase),
+                current: event.current,
+                total: event.total,
+                message: event.message,
+            });
+        };
+        starbreaker_diff::generate_inventory_from_p4k_with_progress(
+            PathBuf::from(path),
+            &options,
+            Some(&mut progress),
+            Some(cancel.as_ref()),
+        )
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("task join error: {e}")))?
+    .map_err(AppError::from)?;
+    let id = new_inventory_id();
+    let handle = inventory_handle(&id, &report);
+    log::info!(
+        "diff inventory ready: id={} label={} mode={:?} archive_count={} datacore_count={} hash={}",
+        handle.id,
+        handle.label,
+        handle.mode,
+        handle.archive_count,
+        handle.datacore_count,
+        handle.inventory_hash
+    );
+    state.diff_inventories.lock().insert(id, report);
+    Ok(handle)
+}
+
+#[tauri::command]
+pub fn diff_cancel_inventory(state: State<'_, AppState>) {
+    state.diff_cancel.store(true, Ordering::Relaxed);
+}
+
+#[tauri::command]
+pub fn diff_load_inventory_report(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<DiffInventoryHandle, AppError> {
+    let report = starbreaker_diff::report::read_inventory_report(path)?;
+    let id = new_inventory_id();
+    let handle = inventory_handle(&id, &report);
+    log::info!(
+        "diff inventory loaded: id={} label={} mode={:?} archive_count={} datacore_count={} hash={}",
+        handle.id,
+        handle.label,
+        handle.mode,
+        handle.archive_count,
+        handle.datacore_count,
+        handle.inventory_hash
+    );
+    state.diff_inventories.lock().insert(id, report);
+    Ok(handle)
+}
+
+#[tauri::command]
+pub fn diff_save_inventory_report(
+    state: State<'_, AppState>,
+    path: String,
+    id: String,
+) -> Result<(), AppError> {
+    let inventories = state.diff_inventories.lock();
+    let report = inventories
+        .get(&id)
+        .ok_or_else(|| AppError::Internal(format!("inventory not found: {id}")))?;
+    Ok(starbreaker_diff::report::write_inventory_report(path, report)?)
+}
+
+#[tauri::command]
+pub fn diff_compare_reports(
+    state: State<'_, AppState>,
+    old_id: String,
+    new_id: String,
+    include_unchanged: bool,
+    filter: Option<starbreaker_diff::DiffFilter>,
+    max_items: Option<usize>,
+) -> Result<starbreaker_diff::DiffReport, AppError> {
+    let inventories = state.diff_inventories.lock();
+    let old = inventories
+        .get(&old_id)
+        .ok_or_else(|| AppError::Internal(format!("old inventory not found: {old_id}")))?;
+    let new = inventories
+        .get(&new_id)
+        .ok_or_else(|| AppError::Internal(format!("new inventory not found: {new_id}")))?;
+    log::info!(
+        "diff compare started: old_id={} old_label={} new_id={} new_label={} include_unchanged={} filter={:?} max_items={:?}",
+        old_id,
+        old.source.label,
+        new_id,
+        new.source.label,
+        include_unchanged,
+        filter,
+        max_items
+    );
+    let mut report = starbreaker_diff::compare_reports(old, new, include_unchanged);
+    let unfiltered_items = report.items.len();
+    if let Some(filter) = filter {
+        report.items = starbreaker_diff::filter_diff_items(&report.items, &filter)
+            .into_iter()
+            .cloned()
+            .collect();
+    }
+    let filtered_items = report.items.len();
+    let max_items = max_items.unwrap_or(5000);
+    if report.items.len() > max_items {
+        report.items.truncate(max_items);
+    }
+    log::info!(
+        "diff compare finished: old_id={} new_id={} summary_added={} summary_removed={} summary_modified={} summary_metadata={} summary_unchanged={} unfiltered_items={} filtered_items={} returned_items={}",
+        old_id,
+        new_id,
+        report.summary.added,
+        report.summary.removed,
+        report.summary.modified,
+        report.summary.metadata_changed,
+        report.summary.unchanged,
+        unfiltered_items,
+        filtered_items,
+        report.items.len()
+    );
+    Ok(report)
+}
+
+#[tauri::command]
+pub fn diff_save_diff_report(
+    path: String,
+    report: starbreaker_diff::DiffReport,
+) -> Result<(), AppError> {
+    Ok(starbreaker_diff::report::write_diff_report(path, &report)?)
+}
+
+fn new_inventory_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("inv-{nanos}")
+}
+
+fn inventory_handle(id: &str, report: &starbreaker_diff::InventoryReport) -> DiffInventoryHandle {
+    DiffInventoryHandle {
+        id: id.to_string(),
+        label: report.source.label.clone(),
+        mode: report.mode,
+        path_hint: report
+            .source
+            .source_file
+            .as_ref()
+            .map(|source| source.path_hint.clone()),
+        archive_count: report.archive.len(),
+        datacore_count: report.datacore.status.records().len(),
+        inventory_hash: report.inventory_hash.clone(),
+        warnings: report.source.warnings.clone(),
+    }
+}

--- a/app/src-tauri/src/diff_commands.rs
+++ b/app/src-tauri/src/diff_commands.rs
@@ -175,6 +175,48 @@ pub fn diff_compare_reports(
 }
 
 #[tauri::command]
+pub fn diff_query_report_page(
+    state: State<'_, AppState>,
+    old_id: String,
+    new_id: String,
+    filter: starbreaker_diff::DiffFilter,
+    offset: usize,
+    limit: usize,
+) -> Result<starbreaker_diff::DiffPage, AppError> {
+    let inventories = state.diff_inventories.lock();
+    let old = inventories
+        .get(&old_id)
+        .ok_or_else(|| AppError::Internal(format!("old inventory not found: {old_id}")))?;
+    let new = inventories
+        .get(&new_id)
+        .ok_or_else(|| AppError::Internal(format!("new inventory not found: {new_id}")))?;
+    log::info!(
+        "diff page query started: old_id={} old_label={} new_id={} new_label={} filter={:?} offset={} limit={}",
+        old_id,
+        old.source.label,
+        new_id,
+        new.source.label,
+        filter,
+        offset,
+        limit
+    );
+    let page = starbreaker_diff::compare_report_page(old, new, &filter, offset, limit);
+    log::info!(
+        "diff page query finished: old_id={} new_id={} total_matching={} returned_items={} summary_added={} summary_removed={} summary_modified={} summary_metadata={} summary_unchanged={}",
+        old_id,
+        new_id,
+        page.total_matching,
+        page.items.len(),
+        page.summary.added,
+        page.summary.removed,
+        page.summary.modified,
+        page.summary.metadata_changed,
+        page.summary.unchanged
+    );
+    Ok(page)
+}
+
+#[tauri::command]
 pub fn diff_save_diff_report(
     path: String,
     report: starbreaker_diff::DiffReport,

--- a/app/src-tauri/src/error.rs
+++ b/app/src-tauri/src/error.rs
@@ -31,6 +31,8 @@ pub enum AppError {
     CryXml(#[from] starbreaker_cryxml::CryXmlError),
     #[error(transparent)]
     Dds(#[from] starbreaker_dds::DdsError),
+    #[error(transparent)]
+    Diff(#[from] starbreaker_diff::DiffError),
 
     #[error("{0}")]
     Internal(String),

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod audio_commands;
 mod commands;
 mod datacore_commands;
+mod diff_commands;
 mod error;
 mod state;
 mod ui_sink;
@@ -227,6 +228,12 @@ fn main() {
             datacore_commands::dc_export_xml,
             datacore_commands::dc_get_backlinks,
             datacore_commands::dc_export_folder,
+            diff_commands::diff_generate_inventory,
+            diff_commands::diff_cancel_inventory,
+            diff_commands::diff_load_inventory_report,
+            diff_commands::diff_save_inventory_report,
+            diff_commands::diff_compare_reports,
+            diff_commands::diff_save_diff_report,
             audio_commands::audio_init,
             audio_commands::audio_search_entities,
             audio_commands::audio_search_triggers,

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -233,6 +233,7 @@ fn main() {
             diff_commands::diff_load_inventory_report,
             diff_commands::diff_save_inventory_report,
             diff_commands::diff_compare_reports,
+            diff_commands::diff_query_report_page,
             diff_commands::diff_save_diff_report,
             audio_commands::audio_init,
             audio_commands::audio_search_entities,

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -12,6 +12,8 @@ pub struct AppState {
     pub p4k: Mutex<Option<Arc<MappedP4k>>>,
     pub dcb_bytes: Mutex<Option<Vec<u8>>>,
     pub export_cancel: Arc<AtomicBool>,
+    pub diff_cancel: Arc<AtomicBool>,
+    pub diff_inventories: Mutex<HashMap<String, starbreaker_diff::InventoryReport>>,
     /// Localization strings from Data\Localization\english\global.ini.
     /// Keys are lowercase for case-insensitive lookup.
     pub localization: Mutex<HashMap<String, String>>,
@@ -31,6 +33,8 @@ impl AppState {
             p4k: Mutex::new(None),
             dcb_bytes: Mutex::new(None),
             export_cancel: Arc::new(AtomicBool::new(false)),
+            diff_cancel: Arc::new(AtomicBool::new(false)),
+            diff_inventories: Mutex::new(HashMap::new()),
             localization: Mutex::new(HashMap::new()),
             record_index: Mutex::new(None),
             atl_index: Mutex::new(None),

--- a/app/src-tauri/src/state.rs
+++ b/app/src-tauri/src/state.rs
@@ -14,6 +14,7 @@ pub struct AppState {
     pub export_cancel: Arc<AtomicBool>,
     pub diff_cancel: Arc<AtomicBool>,
     pub diff_inventories: Mutex<HashMap<String, starbreaker_diff::InventoryReport>>,
+    pub diff_sessions: Mutex<HashMap<String, DiffSession>>,
     /// Localization strings from Data\Localization\english\global.ini.
     /// Keys are lowercase for case-insensitive lookup.
     pub localization: Mutex<HashMap<String, String>>,
@@ -35,6 +36,7 @@ impl AppState {
             export_cancel: Arc::new(AtomicBool::new(false)),
             diff_cancel: Arc::new(AtomicBool::new(false)),
             diff_inventories: Mutex::new(HashMap::new()),
+            diff_sessions: Mutex::new(HashMap::new()),
             localization: Mutex::new(HashMap::new()),
             record_index: Mutex::new(None),
             atl_index: Mutex::new(None),
@@ -42,6 +44,11 @@ impl AppState {
             wwise_paths: Mutex::new(HashMap::new()),
         }
     }
+}
+
+pub struct DiffSession {
+    pub report: starbreaker_diff::DiffReport,
+    pub filter_indexes: HashMap<String, Vec<usize>>,
 }
 
 /// Parse a global.ini localization file into a key→value map.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { P4kBrowser } from "./views/p4k-browser";
 import { DataCoreBrowser } from "./views/datacore-browser";
 import { ExportView } from "./views/export-view";
 import { AudioView } from "./views/audio-view";
+import { DiffView } from "./views/diff-view";
 import { getSystemTheme, onSystemThemeChanged } from "./lib/commands";
 import { applySystemTheme } from "./lib/theme";
 
@@ -21,7 +22,7 @@ function App() {
     return () => { unlisten.then((f) => f()); };
   }, []);
 
-  if (!hasData) {
+  if (!hasData && mode !== "diff") {
     return <StartupScreen />;
   }
 
@@ -35,6 +36,7 @@ function App() {
           {mode === "datacore" && <DataCoreBrowser />}
           {mode === "export" && <ExportView />}
           {mode === "audio" && <AudioView />}
+          {mode === "diff" && <DiffView />}
         </main>
       </div>
     </div>

--- a/app/src/components/sidebar.tsx
+++ b/app/src/components/sidebar.tsx
@@ -1,4 +1,4 @@
-import { Archive, Database, Box, Volume2, type LucideIcon } from "lucide-react";
+import { Archive, Database, Box, Volume2, GitCompare, type LucideIcon } from "lucide-react";
 import { useAppStore, type AppMode } from "../stores/app-store";
 
 interface ModeButton {
@@ -20,6 +20,7 @@ const modes: ModeButton[] = [
   { id: "datacore", label: "DataCore", icon: Database },
   { id: "export", label: "3D Export", icon: Box },
   { id: "audio", label: "Audio", icon: Volume2 },
+  { id: "diff", label: "Diff", icon: GitCompare },
 ];
 
 export function Sidebar() {
@@ -51,7 +52,7 @@ export function Sidebar() {
           <button
             key={m.id}
             onClick={() => setMode(m.id)}
-            disabled={!hasData}
+            disabled={!hasData && m.id !== "diff"}
             className={`
               flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium
               transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed

--- a/app/src/components/startup-dialog.tsx
+++ b/app/src/components/startup-dialog.tsx
@@ -16,6 +16,7 @@ export function StartupScreen() {
   const clearError = useAppStore((s) => s.clearError);
   const recentCustomPaths = useAppStore((s) => s.recentCustomPaths);
   const addRecentCustomPath = useAppStore((s) => s.addRecentCustomPath);
+  const setMode = useAppStore((s) => s.setMode);
 
   const hasDiscovered = useRef(false);
 
@@ -160,6 +161,14 @@ export function StartupScreen() {
                          hover:bg-primary/5 transition-colors cursor-pointer"
             >
               Browse for Data.p4k...
+            </button>
+            <button
+              onClick={() => setMode("diff")}
+              className="flex items-center justify-center gap-2 p-3 border border-border
+                         rounded-lg text-sm text-text-sub hover:text-text hover:border-info/50
+                         hover:bg-info/5 transition-colors cursor-pointer"
+            >
+              Open Diff Viewer
             </button>
           </div>
         )}

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -537,6 +537,12 @@ export interface DiffReport {
   items: DiffItem[];
 }
 
+export interface DiffPage extends DiffReport {
+  total_matching: number;
+  offset: number;
+  limit: number;
+}
+
 export interface DiffFilter {
   search?: string | null;
   tiers: DiffTier[];
@@ -640,6 +646,22 @@ export async function diffCompareReports(
     includeUnchanged,
     filter: filter ?? null,
     maxItems,
+  });
+}
+
+export async function diffQueryReportPage(
+  oldId: string,
+  newId: string,
+  filter: DiffFilter,
+  offset: number,
+  limit: number,
+): Promise<DiffPage> {
+  return invoke<DiffPage>("diff_query_report_page", {
+    oldId,
+    newId,
+    filter,
+    offset,
+    limit,
   });
 }
 

--- a/app/src/lib/commands.ts
+++ b/app/src/lib/commands.ts
@@ -437,3 +437,212 @@ export async function extractP4kFile(
 ): Promise<void> {
   return invoke<void>("extract_p4k_file", { path, outputPath });
 }
+
+// ── Diff types ──
+
+export interface ArchiveEntryInventory {
+  path: string;
+  normalized_path: string;
+  crc32: number;
+  compressed_size: number;
+  uncompressed_size: number;
+  compression_method: number;
+  encrypted: boolean;
+  last_modified: number;
+}
+
+export interface DataCoreRecordInventory {
+  id: string;
+  record_type: string;
+  name: string;
+  path: string;
+  content_hash: string;
+}
+
+export type DataCoreInventory =
+  | { source_path: string | null; status: "present"; records: DataCoreRecordInventory[] }
+  | { source_path: string | null; status: "skipped" };
+
+export interface InventoryReport {
+  schema_version: number;
+  mode: "full" | "p4k_only";
+  generated_by: string;
+  generated_at_unix: number;
+  source: {
+    label: string;
+    source_file: {
+      path_hint: string;
+      size: number | null;
+      modified_unix: number | null;
+      entry_count: number;
+    } | null;
+    build_manifest?: {
+      branch: string | null;
+      version: string | null;
+      requested_p4_change_num: number | null;
+      channel_hint: string | null;
+    };
+    warnings: string[];
+  };
+  archive: ArchiveEntryInventory[];
+  datacore: DataCoreInventory;
+  inventory_hash: string;
+}
+
+export interface DiffInventoryHandle {
+  id: string;
+  label: string;
+  mode: "full" | "p4k_only";
+  path_hint: string | null;
+  archive_count: number;
+  datacore_count: number;
+  inventory_hash: string;
+  warnings: string[];
+}
+
+export type DiffStatus = "added" | "removed" | "modified" | "metadata_changed" | "unchanged";
+export type DiffTier = "p4k" | "data_core";
+
+export type DiffSide =
+  | { archive: ArchiveEntryInventory }
+  | { data_core: DataCoreRecordInventory };
+
+export interface DiffItem {
+  tier: DiffTier;
+  status: DiffStatus;
+  key: string;
+  display: string;
+  old: DiffSide | null;
+  new: DiffSide | null;
+  reasons: string[];
+}
+
+export interface DiffSummary {
+  added: number;
+  removed: number;
+  modified: number;
+  metadata_changed: number;
+  unchanged: number;
+  p4k_items: number;
+  datacore_items: number;
+}
+
+export interface DiffReport {
+  schema_version: number;
+  old_label: string;
+  new_label: string;
+  old_inventory_hash: string;
+  new_inventory_hash: string;
+  summary: DiffSummary;
+  items: DiffItem[];
+}
+
+export interface DiffFilter {
+  search?: string | null;
+  tiers: DiffTier[];
+  statuses: DiffStatus[];
+  extensions: string[];
+  record_types: string[];
+  path_prefixes: string[];
+  include_unchanged: boolean;
+}
+
+export interface DiffInventoryProgress {
+  job_id: string;
+  phase: string;
+  current: number | null;
+  total: number | null;
+  message: string;
+}
+
+export async function browseDiffSource(): Promise<string | null> {
+  const { open } = await import("@tauri-apps/plugin-dialog");
+  const result = await open({
+    title: "Select P4k or inventory report",
+    filters: [
+      { name: "Diff sources", extensions: ["p4k", "json"] },
+      { name: "P4k archive", extensions: ["p4k"] },
+      { name: "Inventory report", extensions: ["json"] },
+    ],
+    multiple: false,
+    directory: false,
+  });
+  return result ?? null;
+}
+
+export async function browseInventorySavePath(defaultPath?: string): Promise<string | null> {
+  const { save } = await import("@tauri-apps/plugin-dialog");
+  const result = await save({
+    title: "Save inventory report",
+    defaultPath,
+    filters: [{ name: "Inventory report", extensions: ["json"] }],
+  });
+  return result ?? null;
+}
+
+export async function browseDiffSavePath(defaultPath?: string): Promise<string | null> {
+  const { save } = await import("@tauri-apps/plugin-dialog");
+  const result = await save({
+    title: "Save diff report",
+    defaultPath,
+    filters: [{ name: "Diff report", extensions: ["json"] }],
+  });
+  return result ?? null;
+}
+
+export function onDiffInventoryProgress(
+  callback: (progress: DiffInventoryProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<DiffInventoryProgress>("diff-inventory-progress", (event) => {
+    callback(event.payload);
+  });
+}
+
+export async function diffGenerateInventory(
+  path: string,
+  skipDatacore: boolean,
+  jobId: string,
+  label?: string,
+): Promise<DiffInventoryHandle> {
+  return invoke<DiffInventoryHandle>("diff_generate_inventory", {
+    path,
+    skipDatacore,
+    label: label ?? null,
+    jobId,
+  });
+}
+
+export async function diffCancelInventory(): Promise<void> {
+  return invoke<void>("diff_cancel_inventory");
+}
+
+export async function diffLoadInventoryReport(path: string): Promise<DiffInventoryHandle> {
+  return invoke<DiffInventoryHandle>("diff_load_inventory_report", { path });
+}
+
+export async function diffSaveInventoryReport(
+  path: string,
+  id: string,
+): Promise<void> {
+  return invoke<void>("diff_save_inventory_report", { path, id });
+}
+
+export async function diffCompareReports(
+  oldId: string,
+  newId: string,
+  includeUnchanged: boolean,
+  filter?: DiffFilter,
+  maxItems = 5000,
+): Promise<DiffReport> {
+  return invoke<DiffReport>("diff_compare_reports", {
+    oldId,
+    newId,
+    includeUnchanged,
+    filter: filter ?? null,
+    maxItems,
+  });
+}
+
+export async function diffSaveDiffReport(path: string, report: DiffReport): Promise<void> {
+  return invoke<void>("diff_save_diff_report", { path, report });
+}

--- a/app/src/stores/app-store.ts
+++ b/app/src/stores/app-store.ts
@@ -3,7 +3,7 @@ import { persist } from "zustand/middleware";
 import type { DiscoverResult } from "../lib/commands";
 import { tauriStorage } from "../lib/tauri-storage";
 
-export type AppMode = "p4k" | "datacore" | "export" | "audio";
+export type AppMode = "p4k" | "datacore" | "export" | "audio" | "diff";
 
 interface AppState {
   mode: AppMode;

--- a/app/src/stores/diff-store.ts
+++ b/app/src/stores/diff-store.ts
@@ -1,0 +1,135 @@
+import { create } from "zustand";
+import type {
+  DiffFilter,
+  DiffInventoryHandle,
+  DiffInventoryProgress,
+  DiffPage,
+  DiffStatus,
+  DiffTier,
+} from "../lib/commands";
+
+export type SlotId = "old" | "new";
+export type StatusFilter = DiffStatus | "all";
+export type TierFilter = DiffTier | "all";
+
+export interface SourceSlot {
+  path: string | null;
+  report: DiffInventoryHandle | null;
+  loading: boolean;
+  error: string | null;
+  progress: DiffInventoryProgress | null;
+}
+
+export const emptySlot: SourceSlot = {
+  path: null,
+  report: null,
+  loading: false,
+  error: null,
+  progress: null,
+};
+
+interface DiffState {
+  oldSlot: SourceSlot;
+  newSlot: SourceSlot;
+  diff: DiffPage | null;
+  compareIds: { oldId: string; newId: string } | null;
+  selectedKey: string | null;
+  error: string | null;
+  includeUnchanged: boolean;
+  search: string;
+  tier: TierFilter;
+  status: StatusFilter;
+  extension: string;
+  recordType: string;
+  pathPrefix: string;
+  scrollTop: number;
+  currentOffset: number;
+  queryKey: string;
+
+  setSlot: (slot: SlotId, next: SourceSlot) => void;
+  updateSlot: (slot: SlotId, update: (current: SourceSlot) => SourceSlot) => void;
+  setDiff: (diff: DiffPage | null) => void;
+  setCompareIds: (compareIds: { oldId: string; newId: string } | null) => void;
+  setSelectedKey: (selectedKey: string | null) => void;
+  setError: (error: string | null) => void;
+  setIncludeUnchanged: (includeUnchanged: boolean) => void;
+  setSearch: (search: string) => void;
+  setTier: (tier: TierFilter) => void;
+  setStatus: (status: StatusFilter) => void;
+  setExtension: (extension: string) => void;
+  setRecordType: (recordType: string) => void;
+  setPathPrefix: (pathPrefix: string) => void;
+  setScrollTop: (scrollTop: number) => void;
+  setCurrentOffset: (currentOffset: number) => void;
+  setQueryKey: (queryKey: string) => void;
+  resetComparison: () => void;
+}
+
+export const useDiffStore = create<DiffState>((set) => ({
+  oldSlot: emptySlot,
+  newSlot: emptySlot,
+  diff: null,
+  compareIds: null,
+  selectedKey: null,
+  error: null,
+  includeUnchanged: false,
+  search: "",
+  tier: "all",
+  status: "all",
+  extension: "",
+  recordType: "",
+  pathPrefix: "",
+  scrollTop: 0,
+  currentOffset: 0,
+  queryKey: "",
+
+  setSlot: (slot, next) => set(slot === "old" ? { oldSlot: next } : { newSlot: next }),
+  updateSlot: (slot, update) =>
+    set((state) => (
+      slot === "old"
+        ? { oldSlot: update(state.oldSlot) }
+        : { newSlot: update(state.newSlot) }
+    )),
+  setDiff: (diff) => set({ diff }),
+  setCompareIds: (compareIds) => set({ compareIds }),
+  setSelectedKey: (selectedKey) => set({ selectedKey }),
+  setError: (error) => set({ error }),
+  setIncludeUnchanged: (includeUnchanged) => set({ includeUnchanged }),
+  setSearch: (search) => set({ search }),
+  setTier: (tier) => set({ tier }),
+  setStatus: (status) => set({ status }),
+  setExtension: (extension) => set({ extension }),
+  setRecordType: (recordType) => set({ recordType }),
+  setPathPrefix: (pathPrefix) => set({ pathPrefix }),
+  setScrollTop: (scrollTop) => set({ scrollTop }),
+  setCurrentOffset: (currentOffset) => set({ currentOffset }),
+  setQueryKey: (queryKey) => set({ queryKey }),
+  resetComparison: () => set({
+    diff: null,
+    compareIds: null,
+    selectedKey: null,
+    scrollTop: 0,
+    currentOffset: 0,
+    queryKey: "",
+  }),
+}));
+
+export function buildBackendFilter(input: {
+  search: string;
+  tier: TierFilter;
+  status: StatusFilter;
+  extension: string;
+  recordType: string;
+  pathPrefix: string;
+  includeUnchanged: boolean;
+}): DiffFilter {
+  return {
+    search: input.search.trim() || null,
+    tiers: input.tier === "all" ? [] : [input.tier],
+    statuses: input.status === "all" ? [] : [input.status],
+    extensions: input.extension.trim() ? [input.extension.trim()] : [],
+    record_types: input.recordType.trim() ? [input.recordType.trim()] : [],
+    path_prefixes: input.pathPrefix.trim() ? [input.pathPrefix.trim()] : [],
+    include_unchanged: input.includeUnchanged,
+  };
+}

--- a/app/src/views/diff-view.tsx
+++ b/app/src/views/diff-view.tsx
@@ -1,0 +1,568 @@
+import { useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Download,
+  FileJson,
+  GitCompare,
+  Loader2,
+  Save,
+  Search,
+  X,
+} from "lucide-react";
+import {
+  browseDiffSavePath,
+  browseDiffSource,
+  browseInventorySavePath,
+  diffCancelInventory,
+  diffCompareReports,
+  diffGenerateInventory,
+  diffLoadInventoryReport,
+  diffSaveDiffReport,
+  diffSaveInventoryReport,
+  onDiffInventoryProgress,
+  type DiffInventoryProgress,
+  type DiffFilter,
+  type DiffItem,
+  type DiffReport,
+  type DiffStatus,
+  type DiffTier,
+  type DiffInventoryHandle,
+} from "../lib/commands";
+
+type SlotId = "old" | "new";
+
+interface SourceSlot {
+  path: string | null;
+  report: DiffInventoryHandle | null;
+  loading: boolean;
+  error: string | null;
+  progress: DiffInventoryProgress | null;
+}
+
+type StatusFilter = DiffStatus | "all";
+type TierFilter = DiffTier | "all";
+
+const emptySlot: SourceSlot = {
+  path: null,
+  report: null,
+  loading: false,
+  error: null,
+  progress: null,
+};
+
+function isInventoryPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".starbreaker-inventory.json");
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+function statusLabel(status: DiffStatus): string {
+  switch (status) {
+    case "metadata_changed": return "metadata";
+    default: return status;
+  }
+}
+
+function tierLabel(tier: DiffTier): string {
+  return tier === "data_core" ? "DataCore" : "P4k";
+}
+
+function itemPath(item: DiffItem): string {
+  const side = item.new ?? item.old;
+  if (!side) return item.display;
+  if ("archive" in side) return side.archive.path;
+  return side.data_core.path;
+}
+
+function itemType(item: DiffItem): string {
+  const side = item.new ?? item.old;
+  if (!side) return "";
+  if ("archive" in side) {
+    const match = side.archive.path.match(/\.([^.\\/]+)$/);
+    return match ? `.${match[1].toLowerCase()}` : "";
+  }
+  return side.data_core.record_type;
+}
+
+export function DiffView() {
+  const [oldSlot, setOldSlot] = useState<SourceSlot>(emptySlot);
+  const [newSlot, setNewSlot] = useState<SourceSlot>(emptySlot);
+  const [diff, setDiff] = useState<DiffReport | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [includeUnchanged, setIncludeUnchanged] = useState(false);
+  const [search, setSearch] = useState("");
+  const [tier, setTier] = useState<TierFilter>("all");
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [extension, setExtension] = useState("");
+  const [recordType, setRecordType] = useState("");
+  const [pathPrefix, setPathPrefix] = useState("");
+  const [scrollTop, setScrollTop] = useState(0);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const setSlot = (slot: SlotId, next: SourceSlot) => {
+    if (slot === "old") setOldSlot(next);
+    else setNewSlot(next);
+  };
+
+  const updateSlot = (slot: SlotId, update: (current: SourceSlot) => SourceSlot) => {
+    if (slot === "old") setOldSlot(update);
+    else setNewSlot(update);
+  };
+
+  const loadSource = async (slot: SlotId) => {
+    const path = await browseDiffSource();
+    if (!path) return;
+    setError(null);
+    setDiff(null);
+    setSelectedKey(null);
+
+    if (isInventoryPath(path)) {
+      setSlot(slot, { ...emptySlot, path, loading: true });
+      try {
+        const report = await diffLoadInventoryReport(path);
+        setSlot(slot, { ...emptySlot, path, report });
+      } catch (err) {
+        setSlot(slot, { ...emptySlot, path, error: String(err) });
+      }
+      return;
+    }
+
+    setSlot(slot, { ...emptySlot, path, loading: true });
+    const jobId = `${slot}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const unlisten = await onDiffInventoryProgress((progress) => {
+      if (progress.job_id !== jobId) return;
+      updateSlot(slot, (current) => ({ ...current, loading: true, progress }));
+    });
+    try {
+      const report = await diffGenerateInventory(path, false, jobId);
+      setSlot(slot, { ...emptySlot, path, report });
+    } catch (err) {
+      setSlot(slot, { ...emptySlot, path, error: String(err) });
+    } finally {
+      unlisten();
+    }
+  };
+
+  const compare = async () => {
+    if (!oldSlot.report || !newSlot.report) return;
+    setError(null);
+    try {
+      const filter = buildBackendFilter({
+        search,
+        tier,
+        status,
+        extension,
+        recordType,
+        pathPrefix,
+      });
+      console.info("diff compare request", {
+        oldId: oldSlot.report.id,
+        oldLabel: oldSlot.report.label,
+        newId: newSlot.report.id,
+        newLabel: newSlot.report.label,
+        filter,
+        maxItems: 5000,
+      });
+      const next = await diffCompareReports(oldSlot.report.id, newSlot.report.id, false, filter, 5000);
+      console.info("diff compare response", {
+        summary: next.summary,
+        returnedItems: next.items.length,
+      });
+      setDiff(next);
+      setSelectedKey(next.items[0]?.key ?? null);
+      setScrollTop(0);
+      if (scrollRef.current) scrollRef.current.scrollTop = 0;
+    } catch (err) {
+      console.error("diff compare failed", err);
+      setError(String(err));
+    }
+  };
+
+  const saveInventory = async (slot: SourceSlot) => {
+    if (!slot.report) return;
+    const safeLabel = slot.report.label.replace(/[\\/:*?"<>|]/g, "_");
+    const path = await browseInventorySavePath(`${safeLabel}.starbreaker-inventory.json`);
+    if (path) await diffSaveInventoryReport(path, slot.report.id);
+  };
+
+  const saveDiff = async () => {
+    if (!diff) return;
+    const path = await browseDiffSavePath(`${diff.old_label}-to-${diff.new_label}.starbreaker-diff.json`);
+    if (path) await diffSaveDiffReport(path, diff);
+  };
+
+  const filteredItems = useMemo(() => {
+    if (!diff) return [];
+    const text = search.trim().toLowerCase();
+    const ext = extension.trim().toLowerCase();
+    const recType = recordType.trim().toLowerCase();
+    const prefix = pathPrefix.trim().replaceAll("\\", "/").toLowerCase();
+    return diff.items.filter((item) => {
+      if (tier !== "all" && item.tier !== tier) return false;
+      if (status !== "all" && item.status !== status) return false;
+      if (ext && (item.tier !== "p4k" || itemType(item) !== (ext.startsWith(".") ? ext : `.${ext}`))) {
+        return false;
+      }
+      if (recType && (item.tier !== "data_core" || !itemType(item).toLowerCase().includes(recType))) {
+        return false;
+      }
+      if (prefix && !itemPath(item).replaceAll("\\", "/").toLowerCase().startsWith(prefix)) {
+        return false;
+      }
+      if (!text) return true;
+      const fields = [
+        item.display,
+        item.key,
+        itemPath(item),
+        itemType(item),
+        item.reasons.join(" "),
+      ].join(" ").toLowerCase();
+      return fields.includes(text);
+    });
+  }, [diff, extension, includeUnchanged, pathPrefix, recordType, search, status, tier]);
+
+  const selected = filteredItems.find((item) => item.key === selectedKey) ?? filteredItems[0] ?? null;
+  const totalChanged = diff
+    ? diff.summary.added + diff.summary.removed + diff.summary.modified + diff.summary.metadata_changed
+    : 0;
+  const rowHeight = 34;
+  const viewportHeight = 560;
+  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - 6);
+  const visibleCount = Math.ceil(viewportHeight / rowHeight) + 12;
+  const visibleItems = filteredItems.slice(start, start + visibleCount);
+
+  return (
+    <div className="flex flex-col h-full bg-bg overflow-hidden">
+      <header className="h-[var(--toolbar-height)] border-b border-border px-4 flex items-center justify-between bg-bg-alt">
+        <div className="flex items-center gap-2">
+          <GitCompare size={18} className="text-primary" />
+          <h1 className="font-semibold text-sm">Diff Viewer</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-2 text-xs text-text-sub">
+            <input
+              type="checkbox"
+              checked={includeUnchanged}
+              disabled
+              onChange={(event) => setIncludeUnchanged(event.target.checked)}
+            />
+            Unchanged counted in summary
+          </label>
+          <button
+            onClick={compare}
+            disabled={!oldSlot.report || !newSlot.report}
+            className="px-3 py-1.5 rounded-md bg-primary/15 text-text text-xs disabled:opacity-40"
+          >
+            Compare
+          </button>
+          <button
+            onClick={saveDiff}
+            disabled={!diff}
+            title="Export diff"
+            className="p-1.5 rounded-md hover:bg-surface disabled:opacity-40"
+          >
+            <Download size={15} />
+          </button>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 p-3 border-b border-border">
+        <SourcePanel slotId="old" slot={oldSlot} onLoad={() => loadSource("old")} onSave={() => saveInventory(oldSlot)} />
+        <SourcePanel slotId="new" slot={newSlot} onLoad={() => loadSource("new")} onSave={() => saveInventory(newSlot)} />
+      </section>
+
+      {error && (
+        <div className="mx-3 mt-3 p-2 border border-danger/30 bg-danger/10 text-danger text-xs rounded-md">
+          {error}
+        </div>
+      )}
+
+      {diff && (
+        <section className="px-3 py-2 border-b border-border">
+          <div className="grid grid-cols-5 gap-2">
+            <SummaryCell label="Added" value={diff.summary.added} tone="text-success" />
+            <SummaryCell label="Removed" value={diff.summary.removed} tone="text-danger" />
+            <SummaryCell label="Modified" value={diff.summary.modified} tone="text-warning" />
+            <SummaryCell label="Metadata" value={diff.summary.metadata_changed} tone="text-info" />
+            <SummaryCell label="Unchanged" value={diff.summary.unchanged} tone="text-text-dim" />
+          </div>
+          {diff.items.length < totalChanged && (
+            <p className="mt-2 text-xs text-text-dim">
+              Showing {formatCount(diff.items.length)} rows. Narrow filters and compare again for a focused result set.
+            </p>
+          )}
+        </section>
+      )}
+
+      <div className="flex flex-1 min-h-0">
+        <aside className="w-[240px] border-r border-border p-3 flex flex-col gap-3 bg-bg-alt/40">
+          <div className="relative">
+            <Search size={14} className="absolute left-2 top-2.5 text-text-dim" />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search"
+              className="w-full pl-7 pr-2 py-2 bg-surface border border-border rounded-md text-sm outline-none focus:border-primary"
+            />
+          </div>
+          <FilterSelect label="Tier" value={tier} onChange={(value) => setTier(value as TierFilter)} options={[
+            ["all", "All"],
+            ["p4k", "P4k files"],
+            ["data_core", "DataCore"],
+          ]} />
+          <FilterSelect label="Status" value={status} onChange={(value) => setStatus(value as StatusFilter)} options={[
+            ["all", "All"],
+            ["added", "Added"],
+            ["removed", "Removed"],
+            ["modified", "Modified"],
+            ["metadata_changed", "Metadata"],
+            ["unchanged", "Unchanged"],
+          ]} />
+          <TextFilter label="Extension" value={extension} onChange={setExtension} placeholder=".dds" />
+          <TextFilter label="Record type" value={recordType} onChange={setRecordType} placeholder="EntityClassDefinition" />
+          <TextFilter label="Path prefix" value={pathPrefix} onChange={setPathPrefix} placeholder="Data/Objects" />
+        </aside>
+
+        <main className="flex-1 min-w-0 flex flex-col">
+          <div className="grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 px-3 py-2 text-[11px] uppercase tracking-wide text-text-dim border-b border-border">
+            <span>Status</span>
+            <span>Tier</span>
+            <span>Name</span>
+            <span>Type</span>
+            <span>Reasons</span>
+          </div>
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-auto"
+            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+          >
+            <div style={{ height: filteredItems.length * rowHeight, position: "relative" }}>
+              <div style={{ transform: `translateY(${start * rowHeight}px)` }}>
+                {visibleItems.map((item) => (
+                  <button
+                    key={`${item.tier}:${item.key}`}
+                    onClick={() => setSelectedKey(item.key)}
+                    className={`grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 w-full px-3 text-left text-xs border-b border-border/60 hover:bg-surface/60 ${
+                      selected?.key === item.key ? "bg-primary/10" : ""
+                    }`}
+                    style={{ height: rowHeight }}
+                  >
+                    <span className={`self-center ${statusTone(item.status)}`}>{statusLabel(item.status)}</span>
+                    <span className="self-center text-text-sub">{tierLabel(item.tier)}</span>
+                    <span className="self-center truncate" title={item.display}>{item.display}</span>
+                    <span className="self-center truncate text-text-sub" title={itemType(item)}>{itemType(item)}</span>
+                    <span className="self-center truncate text-text-dim" title={item.reasons.join(", ")}>{item.reasons.join(", ")}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </main>
+
+        <aside className="w-[320px] border-l border-border p-3 bg-bg-alt/40 overflow-auto">
+          <DetailPanel item={selected} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function buildBackendFilter(input: {
+  search: string;
+  tier: TierFilter;
+  status: StatusFilter;
+  extension: string;
+  recordType: string;
+  pathPrefix: string;
+}): DiffFilter {
+  return {
+    search: input.search.trim() || null,
+    tiers: input.tier === "all" ? [] : [input.tier],
+    statuses: input.status === "all" ? [] : [input.status],
+    extensions: input.extension.trim() ? [input.extension.trim()] : [],
+    record_types: input.recordType.trim() ? [input.recordType.trim()] : [],
+    path_prefixes: input.pathPrefix.trim() ? [input.pathPrefix.trim()] : [],
+    include_unchanged: false,
+  };
+}
+
+function SourcePanel({ slotId, slot, onLoad, onSave }: {
+  slotId: SlotId;
+  slot: SourceSlot;
+  onLoad: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <div className="border border-border rounded-md bg-bg-alt p-3 min-w-0">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-wide text-text-dim">{slotId === "old" ? "Old" : "New"}</p>
+          <p className="text-sm font-medium truncate">{slot.report?.label ?? "No source selected"}</p>
+        </div>
+        <div className="flex items-center gap-1">
+          {slot.loading && (
+            <button onClick={() => diffCancelInventory()} title="Cancel" className="p-1.5 rounded-md hover:bg-surface">
+              <X size={14} />
+            </button>
+          )}
+          <button onClick={onSave} disabled={!slot.report} title="Save inventory" className="p-1.5 rounded-md hover:bg-surface disabled:opacity-40">
+            <Save size={14} />
+          </button>
+          <button onClick={onLoad} title="Load source" className="p-1.5 rounded-md hover:bg-surface">
+            <FileJson size={14} />
+          </button>
+        </div>
+      </div>
+      {slot.path && <p className="mt-2 text-xs text-text-dim truncate" title={slot.path}>{slot.path}</p>}
+      {slot.loading && (
+        <div className="mt-3 grid grid-cols-[16px_minmax(0,1fr)_96px] items-center gap-2 text-xs text-text-sub">
+          <Loader2 size={14} className="animate-spin" />
+          <span className="truncate">{slot.progress?.message ?? "Generating inventory"}</span>
+          {slot.progress?.total != null && (
+            <span className="text-text-dim text-right tabular-nums">
+              {formatCount(slot.progress.current ?? 0)}/{formatCount(slot.progress.total)}
+            </span>
+          )}
+        </div>
+      )}
+      {slot.report && (
+        <p className="mt-2 text-xs text-text-dim">
+          {formatCount(slot.report.archive_count)} files · {formatCount(slot.report.datacore_count)} records
+        </p>
+      )}
+      {slot.error && (
+        <div className="mt-2 flex gap-2 text-xs text-danger">
+          <AlertTriangle size={14} />
+          <span>{slot.error}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCell({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="bg-bg-alt border border-border rounded-md px-3 py-2">
+      <p className="text-[11px] uppercase tracking-wide text-text-dim">{label}</p>
+      <p className={`text-lg font-semibold ${tone}`}>{formatCount(value)}</p>
+    </div>
+  );
+}
+
+function FilterSelect({ label, value, onChange, options }: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<[string, string]>;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-text-dim">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="bg-surface border border-border rounded-md px-2 py-2 text-sm text-text outline-none focus:border-primary"
+      >
+        {options.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function TextFilter({ label, value, onChange, placeholder }: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-text-dim">
+      {label}
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="bg-surface border border-border rounded-md px-2 py-2 text-sm text-text outline-none focus:border-primary"
+      />
+    </label>
+  );
+}
+
+function DetailPanel({ item }: { item: DiffItem | null }) {
+  if (!item) {
+    return <p className="text-sm text-text-dim">Select a changed item.</p>;
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <p className="text-[11px] uppercase tracking-wide text-text-dim">{tierLabel(item.tier)}</p>
+        <h2 className="text-sm font-semibold break-words">{item.display}</h2>
+      </div>
+      <DetailRow label="Status" value={statusLabel(item.status)} />
+      <DetailRow label="Key" value={item.key} />
+      <DetailRow label="Path" value={itemPath(item)} />
+      <DetailRow label="Type" value={itemType(item)} />
+      <div>
+        <p className="text-[11px] uppercase tracking-wide text-text-dim mb-1">Reasons</p>
+        {item.reasons.length === 0 ? (
+          <p className="text-xs text-text-dim">No change reasons.</p>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {item.reasons.map((reason) => (
+              <span key={reason} className="px-2 py-1 bg-surface border border-border rounded text-xs">
+                {reason}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <SideBlock title="Old" side={item.old} />
+      <SideBlock title="New" side={item.new} />
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-wide text-text-dim">{label}</p>
+      <p className="text-xs break-words">{value || "n/a"}</p>
+    </div>
+  );
+}
+
+function SideBlock({ title, side }: { title: string; side: DiffItem["old"] }) {
+  if (!side) return <DetailRow label={title} value="missing" />;
+  if ("archive" in side) {
+    const entry = side.archive;
+    return (
+      <div className="border border-border rounded-md p-2">
+        <p className="text-[11px] uppercase tracking-wide text-text-dim mb-1">{title}</p>
+        <p className="text-xs break-words">{entry.path}</p>
+        <p className="text-xs text-text-dim mt-1">CRC32 {entry.crc32} · {formatCount(entry.uncompressed_size)} bytes</p>
+      </div>
+    );
+  }
+  const record = side.data_core;
+  return (
+    <div className="border border-border rounded-md p-2">
+      <p className="text-[11px] uppercase tracking-wide text-text-dim mb-1">{title}</p>
+      <p className="text-xs break-words">{record.name}</p>
+      <p className="text-xs text-text-dim mt-1">{record.record_type}</p>
+      <p className="text-xs text-text-dim break-words mt-1">{record.content_hash}</p>
+    </div>
+  );
+}
+
+function statusTone(status: DiffStatus): string {
+  switch (status) {
+    case "added": return "text-success";
+    case "removed": return "text-danger";
+    case "modified": return "text-warning";
+    case "metadata_changed": return "text-info";
+    case "unchanged": return "text-text-dim";
+  }
+}

--- a/app/src/views/diff-view.tsx
+++ b/app/src/views/diff-view.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import {
   AlertTriangle,
   Download,
@@ -102,7 +103,6 @@ export function DiffView() {
   const [extension, setExtension] = useState("");
   const [recordType, setRecordType] = useState("");
   const [pathPrefix, setPathPrefix] = useState("");
-  const [scrollTop, setScrollTop] = useState(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const cacheRef = useRef<Map<number, DiffPage>>(new Map());
   const inFlightRef = useRef<Map<number, Promise<DiffPage>>>(new Map());
@@ -112,9 +112,15 @@ export function DiffView() {
   const lastScrollTopRef = useRef(0);
   const scrollDirectionRef = useRef<"up" | "down">("down");
   const rowHeight = 34;
-  const viewportHeight = 560;
   const pageSize = 1000;
   const pageCacheLimit = 7;
+  const rowVirtualizer = useVirtualizer({
+    count: diff?.total_matching ?? 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => rowHeight,
+    overscan: 30,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
 
   const setSlot = (slot: SlotId, next: SourceSlot) => {
     if (slot === "old") setOldSlot(next);
@@ -168,7 +174,6 @@ export function DiffView() {
     setDiff(null);
     clearPageCache();
     setCompareIds({ oldId: oldSlot.report.id, newId: newSlot.report.id });
-    setScrollTop(0);
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   };
 
@@ -300,40 +305,45 @@ export function DiffView() {
     clearPageCache();
     setDiff(null);
     setSelectedKey(null);
-    setScrollTop(0);
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
     void loadPage(0);
   }, [clearPageCache, compareIds, filterKey, loadPage, queryKey]);
 
   useEffect(() => {
     if (!compareIds || !diff || pageLoading) return;
-    const targetOffset = Math.floor(Math.max(0, Math.floor(scrollTop / rowHeight) - 12) / pageSize) * pageSize;
+    const firstRow = virtualRows[0]?.index ?? 0;
+    const lastRow = virtualRows[virtualRows.length - 1]?.index ?? firstRow;
+    const targetOffset = normalizePageOffset(firstRow);
     currentPageOffsetRef.current = targetOffset;
-    if (cacheRef.current.has(targetOffset)) {
-      const cached = cacheRef.current.get(targetOffset);
-      if (cached && cached.offset !== diff.offset) setDiff(cached);
-    } else {
+    const visiblePageOffsets = pageOffsetsForRange(firstRow, lastRow, pageSize);
+    const missingVisibleOffset = visiblePageOffsets.find((offset) => !cacheRef.current.has(offset));
+    if (missingVisibleOffset != null) {
       if (scrollDebounceRef.current != null) window.clearTimeout(scrollDebounceRef.current);
       scrollDebounceRef.current = window.setTimeout(() => {
-        void loadPage(targetOffset);
-      }, 120);
+        void loadPage(missingVisibleOffset);
+      }, 80);
+    } else if (cacheRef.current.has(targetOffset)) {
+      const cached = cacheRef.current.get(targetOffset);
+      if (cached && cached.offset !== diff.offset) setDiff(cached);
     }
     return () => {
       if (scrollDebounceRef.current != null) window.clearTimeout(scrollDebounceRef.current);
     };
-  }, [compareIds, diff, loadPage, pageLoading, pageSize, rowHeight, scrollTop]);
+  }, [compareIds, diff, loadPage, normalizePageOffset, pageLoading, pageSize, virtualRows]);
 
   useEffect(() => {
     if (!diff) return;
     const direction = scrollDirectionRef.current;
-    const nextOffset = diff.offset + pageSize;
-    const previousOffset = diff.offset - pageSize;
+    const firstRow = virtualRows[0]?.index ?? diff.offset;
+    const lastRow = virtualRows[virtualRows.length - 1]?.index ?? firstRow;
+    const nextOffset = normalizePageOffset(lastRow) + pageSize;
+    const previousOffset = normalizePageOffset(firstRow) - pageSize;
     if (direction === "down") {
       prefetchPage(nextOffset);
     } else {
       prefetchPage(previousOffset);
     }
-  }, [diff, pageSize, prefetchPage]);
+  }, [diff, normalizePageOffset, pageSize, prefetchPage, virtualRows]);
 
   const saveInventory = async (slot: SourceSlot) => {
     if (!slot.report) return;
@@ -352,9 +362,7 @@ export function DiffView() {
   const totalChanged = diff
     ? diff.summary.added + diff.summary.removed + diff.summary.modified + diff.summary.metadata_changed
     : 0;
-  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - 6);
-  const visibleCount = Math.ceil(viewportHeight / rowHeight) + 12;
-  const visibleRows = buildVisibleRows(pageCache, start, visibleCount, pageSize);
+  const visibleRows = buildVisibleRows(pageCache, virtualRows, pageSize);
 
   return (
     <div className="flex flex-col h-full bg-bg overflow-hidden">
@@ -463,28 +471,35 @@ export function DiffView() {
               const nextScrollTop = event.currentTarget.scrollTop;
               scrollDirectionRef.current = nextScrollTop >= lastScrollTopRef.current ? "down" : "up";
               lastScrollTopRef.current = nextScrollTop;
-              setScrollTop(nextScrollTop);
             }}
           >
-            <div style={{ height: (diff?.total_matching ?? 0) * rowHeight, position: "relative" }}>
-              {visibleRows.map(({ item, index }) => (
+            <div style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}>
+              {visibleRows.map(({ item, index, start }) => (
                 <div
-                  key={`${item.tier}:${item.key}`}
-                  style={{ position: "absolute", top: index * rowHeight, left: 0, right: 0, height: rowHeight }}
+                  key={`${item?.tier ?? "loading"}:${item?.key ?? index}`}
+                  style={{ position: "absolute", top: start, left: 0, right: 0, height: rowHeight }}
                 >
-                  <button
-                    onClick={() => setSelectedKey(item.key)}
-                    className={`grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 w-full px-3 text-left text-xs border-b border-border/60 hover:bg-surface/60 ${
-                      selected?.key === item.key ? "bg-primary/10" : ""
-                    }`}
-                    style={{ height: rowHeight }}
-                  >
-                    <span className={`self-center ${statusTone(item.status)}`}>{statusLabel(item.status)}</span>
-                    <span className="self-center text-text-sub">{tierLabel(item.tier)}</span>
-                    <span className="self-center truncate" title={item.display}>{item.display}</span>
-                    <span className="self-center truncate text-text-sub" title={itemType(item)}>{itemType(item)}</span>
-                    <span className="self-center truncate text-text-dim" title={item.reasons.join(", ")}>{item.reasons.join(", ")}</span>
-                  </button>
+                  {item ? (
+                    <button
+                      onClick={() => setSelectedKey(item.key)}
+                      className={`grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 w-full px-3 text-left text-xs border-b border-border/60 hover:bg-surface/60 ${
+                        selected?.key === item.key ? "bg-primary/10" : ""
+                      }`}
+                      style={{ height: rowHeight }}
+                    >
+                      <span className={`self-center ${statusTone(item.status)}`}>{statusLabel(item.status)}</span>
+                      <span className="self-center text-text-sub">{tierLabel(item.tier)}</span>
+                      <span className="self-center truncate" title={item.display}>{item.display}</span>
+                      <span className="self-center truncate text-text-sub" title={itemType(item)}>{itemType(item)}</span>
+                      <span className="self-center truncate text-text-dim" title={item.reasons.join(", ")}>{item.reasons.join(", ")}</span>
+                    </button>
+                  ) : (
+                    <div className="grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 w-full px-3 text-left text-xs border-b border-border/60 text-text-dim" style={{ height: rowHeight }}>
+                      <span className="self-center">...</span>
+                      <span className="self-center">...</span>
+                      <span className="self-center">Loading row {formatCount(index + 1)}</span>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -531,19 +546,26 @@ function cachedItems(cache: Map<number, DiffPage>): DiffItem[] {
 
 function buildVisibleRows(
   cache: Map<number, DiffPage>,
-  start: number,
-  visibleCount: number,
+  virtualRows: VirtualItem[],
   pageSize: number,
-): Array<{ item: DiffItem; index: number }> {
-  const rows: Array<{ item: DiffItem; index: number }> = [];
-  const end = start + visibleCount;
-  for (let index = start; index < end; index += 1) {
+): Array<{ item: DiffItem | null; index: number; start: number }> {
+  return virtualRows.map((row) => {
+    const index = row.index;
     const pageOffset = Math.floor(index / pageSize) * pageSize;
     const page = cache.get(pageOffset);
     const item = page?.items[index - pageOffset];
-    if (item) rows.push({ item, index });
+    return { item: item ?? null, index, start: row.start };
+  });
+}
+
+function pageOffsetsForRange(start: number, end: number, pageSize: number): number[] {
+  const offsets = [];
+  const firstOffset = Math.floor(start / pageSize) * pageSize;
+  const lastOffset = Math.floor(end / pageSize) * pageSize;
+  for (let offset = firstOffset; offset <= lastOffset; offset += pageSize) {
+    offsets.push(offset);
   }
-  return rows;
+  return offsets;
 }
 
 function SourcePanel({ slotId, slot, onLoad, onSave }: {

--- a/app/src/views/diff-view.tsx
+++ b/app/src/views/diff-view.tsx
@@ -21,35 +21,20 @@ import {
   diffSaveDiffReport,
   diffSaveInventoryReport,
   onDiffInventoryProgress,
-  type DiffInventoryProgress,
-  type DiffFilter,
   type DiffItem,
   type DiffPage,
   type DiffStatus,
   type DiffTier,
-  type DiffInventoryHandle,
 } from "../lib/commands";
-
-type SlotId = "old" | "new";
-
-interface SourceSlot {
-  path: string | null;
-  report: DiffInventoryHandle | null;
-  loading: boolean;
-  error: string | null;
-  progress: DiffInventoryProgress | null;
-}
-
-type StatusFilter = DiffStatus | "all";
-type TierFilter = DiffTier | "all";
-
-const emptySlot: SourceSlot = {
-  path: null,
-  report: null,
-  loading: false,
-  error: null,
-  progress: null,
-};
+import {
+  buildBackendFilter,
+  emptySlot,
+  useDiffStore,
+  type SlotId,
+  type SourceSlot,
+  type StatusFilter,
+  type TierFilter,
+} from "../stores/diff-store";
 
 function isInventoryPath(path: string): boolean {
   return path.toLowerCase().endsWith(".starbreaker-inventory.json");
@@ -88,26 +73,46 @@ function itemType(item: DiffItem): string {
 }
 
 export function DiffView() {
-  const [oldSlot, setOldSlot] = useState<SourceSlot>(emptySlot);
-  const [newSlot, setNewSlot] = useState<SourceSlot>(emptySlot);
-  const [diff, setDiff] = useState<DiffPage | null>(null);
+  const oldSlot = useDiffStore((s) => s.oldSlot);
+  const newSlot = useDiffStore((s) => s.newSlot);
+  const diff = useDiffStore((s) => s.diff);
+  const compareIds = useDiffStore((s) => s.compareIds);
+  const selectedKey = useDiffStore((s) => s.selectedKey);
+  const error = useDiffStore((s) => s.error);
+  const includeUnchanged = useDiffStore((s) => s.includeUnchanged);
+  const search = useDiffStore((s) => s.search);
+  const tier = useDiffStore((s) => s.tier);
+  const status = useDiffStore((s) => s.status);
+  const extension = useDiffStore((s) => s.extension);
+  const recordType = useDiffStore((s) => s.recordType);
+  const pathPrefix = useDiffStore((s) => s.pathPrefix);
+  const storedCurrentOffset = useDiffStore((s) => s.currentOffset);
+  const storedQueryKey = useDiffStore((s) => s.queryKey);
+  const setSlot = useDiffStore((s) => s.setSlot);
+  const updateSlot = useDiffStore((s) => s.updateSlot);
+  const setDiff = useDiffStore((s) => s.setDiff);
+  const setCompareIds = useDiffStore((s) => s.setCompareIds);
+  const setSelectedKey = useDiffStore((s) => s.setSelectedKey);
+  const setError = useDiffStore((s) => s.setError);
+  const setIncludeUnchanged = useDiffStore((s) => s.setIncludeUnchanged);
+  const setSearch = useDiffStore((s) => s.setSearch);
+  const setTier = useDiffStore((s) => s.setTier);
+  const setStatus = useDiffStore((s) => s.setStatus);
+  const setExtension = useDiffStore((s) => s.setExtension);
+  const setRecordType = useDiffStore((s) => s.setRecordType);
+  const setPathPrefix = useDiffStore((s) => s.setPathPrefix);
+  const setScrollTop = useDiffStore((s) => s.setScrollTop);
+  const setCurrentOffset = useDiffStore((s) => s.setCurrentOffset);
+  const setQueryKey = useDiffStore((s) => s.setQueryKey);
+  const resetComparison = useDiffStore((s) => s.resetComparison);
   const [pageCache, setPageCache] = useState<Map<number, DiffPage>>(() => new Map());
-  const [compareIds, setCompareIds] = useState<{ oldId: string; newId: string } | null>(null);
   const [pageLoading, setPageLoading] = useState(false);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [includeUnchanged, setIncludeUnchanged] = useState(false);
-  const [search, setSearch] = useState("");
-  const [tier, setTier] = useState<TierFilter>("all");
-  const [status, setStatus] = useState<StatusFilter>("all");
-  const [extension, setExtension] = useState("");
-  const [recordType, setRecordType] = useState("");
-  const [pathPrefix, setPathPrefix] = useState("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const cacheRef = useRef<Map<number, DiffPage>>(new Map());
   const inFlightRef = useRef<Map<number, Promise<DiffPage>>>(new Map());
-  const queryKeyRef = useRef("");
-  const currentPageOffsetRef = useRef(0);
+  const queryKeyRef = useRef(storedQueryKey);
+  const currentPageOffsetRef = useRef(storedCurrentOffset);
+  const restoredSessionRef = useRef<string | null>(null);
   const scrollDebounceRef = useRef<number | null>(null);
   const lastScrollTopRef = useRef(0);
   const scrollDirectionRef = useRef<"up" | "down">("down");
@@ -122,24 +127,12 @@ export function DiffView() {
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
 
-  const setSlot = (slot: SlotId, next: SourceSlot) => {
-    if (slot === "old") setOldSlot(next);
-    else setNewSlot(next);
-  };
-
-  const updateSlot = (slot: SlotId, update: (current: SourceSlot) => SourceSlot) => {
-    if (slot === "old") setOldSlot(update);
-    else setNewSlot(update);
-  };
-
   const loadSource = async (slot: SlotId) => {
     const path = await browseDiffSource();
     if (!path) return;
     setError(null);
-    setDiff(null);
+    resetComparison();
     clearPageCache();
-    setCompareIds(null);
-    setSelectedKey(null);
 
     if (isInventoryPath(path)) {
       setSlot(slot, { ...emptySlot, path, loading: true });
@@ -174,14 +167,17 @@ export function DiffView() {
     setDiff(null);
     clearPageCache();
     setCompareIds({ oldId: oldSlot.report.id, newId: newSlot.report.id });
+    setCurrentOffset(0);
+    setScrollTop(0);
+    setQueryKey("");
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   };
 
   function setSelectedFromPage(page: DiffPage) {
-    setSelectedKey((current) => {
-      if (current && page.items.some((item) => item.key === current)) return current;
-      return page.items[0]?.key ?? null;
-    });
+    const current = useDiffStore.getState().selectedKey;
+    setSelectedKey(current && page.items.some((item) => item.key === current)
+      ? current
+      : page.items[0]?.key ?? null);
   }
 
   const backendFilter = useMemo(() => buildBackendFilter({
@@ -268,6 +264,7 @@ export function DiffView() {
     const cached = cacheRef.current.get(pageOffset);
     if (cached) {
       setDiff(cached);
+      setCurrentOffset(cached.offset);
       setSelectedFromPage(cached);
       return;
     }
@@ -290,6 +287,7 @@ export function DiffView() {
         returnedItems: next.items.length,
       });
       setDiff(next);
+      setCurrentOffset(next.offset);
       setSelectedFromPage(next);
     } catch (err) {
       console.error("diff page failed", err);
@@ -297,17 +295,50 @@ export function DiffView() {
     } finally {
       setPageLoading(false);
     }
-  }, [backendFilter, compareIds, fetchPage, normalizePageOffset, pageSize, queryKey]);
+  }, [backendFilter, compareIds, fetchPage, normalizePageOffset, pageSize, queryKey, setCurrentOffset]);
 
   useEffect(() => {
     if (!compareIds) return;
+    if (queryKeyRef.current === queryKey && storedQueryKey === queryKey) {
+      if (diff && restoredSessionRef.current !== queryKey) {
+        const nextCache = new Map([[diff.offset, diff]]);
+        cacheRef.current = nextCache;
+        setPageCache(nextCache);
+        restoredSessionRef.current = queryKey;
+        window.requestAnimationFrame(() => {
+          if (scrollRef.current) scrollRef.current.scrollTop = useDiffStore.getState().scrollTop;
+        });
+      } else if (!diff) {
+        void loadPage(storedCurrentOffset);
+      }
+      return;
+    }
+
     queryKeyRef.current = queryKey;
+    restoredSessionRef.current = queryKey;
     clearPageCache();
     setDiff(null);
     setSelectedKey(null);
+    setCurrentOffset(0);
+    setScrollTop(0);
+    setQueryKey(queryKey);
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
     void loadPage(0);
-  }, [clearPageCache, compareIds, filterKey, loadPage, queryKey]);
+  }, [
+    clearPageCache,
+    compareIds,
+    diff,
+    filterKey,
+    loadPage,
+    queryKey,
+    setCurrentOffset,
+    setDiff,
+    setQueryKey,
+    setScrollTop,
+    setSelectedKey,
+    storedCurrentOffset,
+    storedQueryKey,
+  ]);
 
   useEffect(() => {
     if (!compareIds || !diff || pageLoading) return;
@@ -315,6 +346,7 @@ export function DiffView() {
     const lastRow = virtualRows[virtualRows.length - 1]?.index ?? firstRow;
     const targetOffset = normalizePageOffset(firstRow);
     currentPageOffsetRef.current = targetOffset;
+    setCurrentOffset(targetOffset);
     const visiblePageOffsets = pageOffsetsForRange(firstRow, lastRow, pageSize);
     const missingVisibleOffset = visiblePageOffsets.find((offset) => !cacheRef.current.has(offset));
     if (missingVisibleOffset != null) {
@@ -329,7 +361,7 @@ export function DiffView() {
     return () => {
       if (scrollDebounceRef.current != null) window.clearTimeout(scrollDebounceRef.current);
     };
-  }, [compareIds, diff, loadPage, normalizePageOffset, pageLoading, pageSize, virtualRows]);
+  }, [compareIds, diff, loadPage, normalizePageOffset, pageLoading, pageSize, setCurrentOffset, virtualRows]);
 
   useEffect(() => {
     if (!diff) return;
@@ -421,7 +453,7 @@ export function DiffView() {
           <p className="mt-2 text-xs text-text-dim">
             {diff.total_matching === 0
               ? "No matching rows."
-              : `Showing ${formatCount(diff.offset + 1)}-${formatCount(diff.offset + diff.items.length)} of ${formatCount(diff.total_matching)} matching rows.`}
+              : `${formatCount(diff.total_matching)} matching rows.`}
             {diff.total_matching !== totalChanged && ` ${formatCount(totalChanged)} changed rows before filters.`}
           </p>
         </section>
@@ -471,6 +503,7 @@ export function DiffView() {
               const nextScrollTop = event.currentTarget.scrollTop;
               scrollDirectionRef.current = nextScrollTop >= lastScrollTopRef.current ? "down" : "up";
               lastScrollTopRef.current = nextScrollTop;
+              setScrollTop(nextScrollTop);
             }}
           >
             <div style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}>
@@ -518,26 +551,6 @@ export function DiffView() {
       </div>
     </div>
   );
-}
-
-function buildBackendFilter(input: {
-  search: string;
-  tier: TierFilter;
-  status: StatusFilter;
-  extension: string;
-  recordType: string;
-  pathPrefix: string;
-  includeUnchanged: boolean;
-}): DiffFilter {
-  return {
-    search: input.search.trim() || null,
-    tiers: input.tier === "all" ? [] : [input.tier],
-    statuses: input.status === "all" ? [] : [input.status],
-    extensions: input.extension.trim() ? [input.extension.trim()] : [],
-    record_types: input.recordType.trim() ? [input.recordType.trim()] : [],
-    path_prefixes: input.pathPrefix.trim() ? [input.pathPrefix.trim()] : [],
-    include_unchanged: input.includeUnchanged,
-  };
 }
 
 function cachedItems(cache: Map<number, DiffPage>): DiffItem[] {

--- a/app/src/views/diff-view.tsx
+++ b/app/src/views/diff-view.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   Download,
@@ -14,16 +14,16 @@ import {
   browseDiffSource,
   browseInventorySavePath,
   diffCancelInventory,
-  diffCompareReports,
   diffGenerateInventory,
   diffLoadInventoryReport,
+  diffQueryReportPage,
   diffSaveDiffReport,
   diffSaveInventoryReport,
   onDiffInventoryProgress,
   type DiffInventoryProgress,
   type DiffFilter,
   type DiffItem,
-  type DiffReport,
+  type DiffPage,
   type DiffStatus,
   type DiffTier,
   type DiffInventoryHandle,
@@ -89,7 +89,10 @@ function itemType(item: DiffItem): string {
 export function DiffView() {
   const [oldSlot, setOldSlot] = useState<SourceSlot>(emptySlot);
   const [newSlot, setNewSlot] = useState<SourceSlot>(emptySlot);
-  const [diff, setDiff] = useState<DiffReport | null>(null);
+  const [diff, setDiff] = useState<DiffPage | null>(null);
+  const [pageCache, setPageCache] = useState<Map<number, DiffPage>>(() => new Map());
+  const [compareIds, setCompareIds] = useState<{ oldId: string; newId: string } | null>(null);
+  const [pageLoading, setPageLoading] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [includeUnchanged, setIncludeUnchanged] = useState(false);
@@ -101,6 +104,17 @@ export function DiffView() {
   const [pathPrefix, setPathPrefix] = useState("");
   const [scrollTop, setScrollTop] = useState(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const cacheRef = useRef<Map<number, DiffPage>>(new Map());
+  const inFlightRef = useRef<Map<number, Promise<DiffPage>>>(new Map());
+  const queryKeyRef = useRef("");
+  const currentPageOffsetRef = useRef(0);
+  const scrollDebounceRef = useRef<number | null>(null);
+  const lastScrollTopRef = useRef(0);
+  const scrollDirectionRef = useRef<"up" | "down">("down");
+  const rowHeight = 34;
+  const viewportHeight = 560;
+  const pageSize = 1000;
+  const pageCacheLimit = 7;
 
   const setSlot = (slot: SlotId, next: SourceSlot) => {
     if (slot === "old") setOldSlot(next);
@@ -117,6 +131,8 @@ export function DiffView() {
     if (!path) return;
     setError(null);
     setDiff(null);
+    clearPageCache();
+    setCompareIds(null);
     setSelectedKey(null);
 
     if (isInventoryPath(path)) {
@@ -149,37 +165,175 @@ export function DiffView() {
   const compare = async () => {
     if (!oldSlot.report || !newSlot.report) return;
     setError(null);
+    setDiff(null);
+    clearPageCache();
+    setCompareIds({ oldId: oldSlot.report.id, newId: newSlot.report.id });
+    setScrollTop(0);
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+  };
+
+  function setSelectedFromPage(page: DiffPage) {
+    setSelectedKey((current) => {
+      if (current && page.items.some((item) => item.key === current)) return current;
+      return page.items[0]?.key ?? null;
+    });
+  }
+
+  const backendFilter = useMemo(() => buildBackendFilter({
+    search,
+    tier,
+    status,
+    extension,
+    recordType,
+    pathPrefix,
+    includeUnchanged,
+  }), [extension, includeUnchanged, pathPrefix, recordType, search, status, tier]);
+  const filterKey = useMemo(() => JSON.stringify(backendFilter), [backendFilter]);
+  const queryKey = useMemo(() => {
+    if (!compareIds) return "";
+    return `${compareIds.oldId}:${compareIds.newId}:${filterKey}`;
+  }, [compareIds, filterKey]);
+
+  const normalizePageOffset = useCallback((offset: number) => {
+    return Math.max(0, Math.floor(offset / pageSize) * pageSize);
+  }, [pageSize]);
+
+  const clearPageCache = useCallback(() => {
+    cacheRef.current = new Map();
+    inFlightRef.current = new Map();
+    setPageCache(new Map());
+  }, []);
+
+  const storePage = useCallback((page: DiffPage) => {
+    const nextCache = new Map(cacheRef.current).set(page.offset, page);
+    while (nextCache.size > pageCacheLimit) {
+      const farthestOffset = Array.from(nextCache.keys()).reduce((farthest, offset) => {
+        return Math.abs(offset - currentPageOffsetRef.current) > Math.abs(farthest - currentPageOffsetRef.current)
+          ? offset
+          : farthest;
+      });
+      nextCache.delete(farthestOffset);
+    }
+    cacheRef.current = nextCache;
+    setPageCache(cacheRef.current);
+  }, [pageCacheLimit]);
+
+  const fetchPage = useCallback(async (offset: number) => {
+    if (!compareIds) return null;
+    const pageOffset = normalizePageOffset(offset);
+    const requestKey = queryKey;
+    const cached = cacheRef.current.get(pageOffset);
+    if (cached) return cached;
+    const existing = inFlightRef.current.get(pageOffset);
+    if (existing) return existing;
+    let request: Promise<DiffPage>;
+    request = diffQueryReportPage(
+      compareIds.oldId,
+      compareIds.newId,
+      backendFilter,
+      pageOffset,
+      pageSize,
+    ).then((page) => {
+      if (queryKeyRef.current === requestKey) {
+        storePage(page);
+      }
+      return page;
+    }).finally(() => {
+      if (inFlightRef.current.get(pageOffset) === request) {
+        inFlightRef.current.delete(pageOffset);
+      }
+    });
+    inFlightRef.current.set(pageOffset, request);
+    return request;
+  }, [backendFilter, compareIds, normalizePageOffset, pageSize, queryKey, storePage]);
+
+  const prefetchPage = useCallback((offset: number) => {
+    if (!compareIds || !diff) return;
+    const pageOffset = normalizePageOffset(offset);
+    if (pageOffset < 0 || pageOffset >= diff.total_matching) return;
+    if (cacheRef.current.has(pageOffset) || inFlightRef.current.has(pageOffset)) return;
+    void fetchPage(pageOffset).catch((err) => {
+      console.warn("diff page prefetch failed", err);
+    });
+  }, [compareIds, diff, fetchPage, normalizePageOffset]);
+
+  const loadPage = useCallback(async (offset: number) => {
+    if (!compareIds) return;
+    const pageOffset = normalizePageOffset(offset);
+    const cached = cacheRef.current.get(pageOffset);
+    if (cached) {
+      setDiff(cached);
+      setSelectedFromPage(cached);
+      return;
+    }
+    setError(null);
+    setPageLoading(true);
     try {
-      const filter = buildBackendFilter({
-        search,
-        tier,
-        status,
-        extension,
-        recordType,
-        pathPrefix,
+      console.info("diff page request", {
+        oldId: compareIds.oldId,
+        newId: compareIds.newId,
+        filter: backendFilter,
+        offset: pageOffset,
+        limit: pageSize,
       });
-      console.info("diff compare request", {
-        oldId: oldSlot.report.id,
-        oldLabel: oldSlot.report.label,
-        newId: newSlot.report.id,
-        newLabel: newSlot.report.label,
-        filter,
-        maxItems: 5000,
-      });
-      const next = await diffCompareReports(oldSlot.report.id, newSlot.report.id, false, filter, 5000);
-      console.info("diff compare response", {
+      const next = await fetchPage(pageOffset);
+      if (!next || queryKeyRef.current !== queryKey) return;
+      console.info("diff page response", {
         summary: next.summary,
+        totalMatching: next.total_matching,
+        offset: next.offset,
         returnedItems: next.items.length,
       });
       setDiff(next);
-      setSelectedKey(next.items[0]?.key ?? null);
-      setScrollTop(0);
-      if (scrollRef.current) scrollRef.current.scrollTop = 0;
+      setSelectedFromPage(next);
     } catch (err) {
-      console.error("diff compare failed", err);
+      console.error("diff page failed", err);
       setError(String(err));
+    } finally {
+      setPageLoading(false);
     }
-  };
+  }, [backendFilter, compareIds, fetchPage, normalizePageOffset, pageSize, queryKey]);
+
+  useEffect(() => {
+    if (!compareIds) return;
+    queryKeyRef.current = queryKey;
+    clearPageCache();
+    setDiff(null);
+    setSelectedKey(null);
+    setScrollTop(0);
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+    void loadPage(0);
+  }, [clearPageCache, compareIds, filterKey, loadPage, queryKey]);
+
+  useEffect(() => {
+    if (!compareIds || !diff || pageLoading) return;
+    const targetOffset = Math.floor(Math.max(0, Math.floor(scrollTop / rowHeight) - 12) / pageSize) * pageSize;
+    currentPageOffsetRef.current = targetOffset;
+    if (cacheRef.current.has(targetOffset)) {
+      const cached = cacheRef.current.get(targetOffset);
+      if (cached && cached.offset !== diff.offset) setDiff(cached);
+    } else {
+      if (scrollDebounceRef.current != null) window.clearTimeout(scrollDebounceRef.current);
+      scrollDebounceRef.current = window.setTimeout(() => {
+        void loadPage(targetOffset);
+      }, 120);
+    }
+    return () => {
+      if (scrollDebounceRef.current != null) window.clearTimeout(scrollDebounceRef.current);
+    };
+  }, [compareIds, diff, loadPage, pageLoading, pageSize, rowHeight, scrollTop]);
+
+  useEffect(() => {
+    if (!diff) return;
+    const direction = scrollDirectionRef.current;
+    const nextOffset = diff.offset + pageSize;
+    const previousOffset = diff.offset - pageSize;
+    if (direction === "down") {
+      prefetchPage(nextOffset);
+    } else {
+      prefetchPage(previousOffset);
+    }
+  }, [diff, pageSize, prefetchPage]);
 
   const saveInventory = async (slot: SourceSlot) => {
     if (!slot.report) return;
@@ -194,45 +348,13 @@ export function DiffView() {
     if (path) await diffSaveDiffReport(path, diff);
   };
 
-  const filteredItems = useMemo(() => {
-    if (!diff) return [];
-    const text = search.trim().toLowerCase();
-    const ext = extension.trim().toLowerCase();
-    const recType = recordType.trim().toLowerCase();
-    const prefix = pathPrefix.trim().replaceAll("\\", "/").toLowerCase();
-    return diff.items.filter((item) => {
-      if (tier !== "all" && item.tier !== tier) return false;
-      if (status !== "all" && item.status !== status) return false;
-      if (ext && (item.tier !== "p4k" || itemType(item) !== (ext.startsWith(".") ? ext : `.${ext}`))) {
-        return false;
-      }
-      if (recType && (item.tier !== "data_core" || !itemType(item).toLowerCase().includes(recType))) {
-        return false;
-      }
-      if (prefix && !itemPath(item).replaceAll("\\", "/").toLowerCase().startsWith(prefix)) {
-        return false;
-      }
-      if (!text) return true;
-      const fields = [
-        item.display,
-        item.key,
-        itemPath(item),
-        itemType(item),
-        item.reasons.join(" "),
-      ].join(" ").toLowerCase();
-      return fields.includes(text);
-    });
-  }, [diff, extension, includeUnchanged, pathPrefix, recordType, search, status, tier]);
-
-  const selected = filteredItems.find((item) => item.key === selectedKey) ?? filteredItems[0] ?? null;
+  const selected = cachedItems(pageCache).find((item) => item.key === selectedKey) ?? diff?.items[0] ?? null;
   const totalChanged = diff
     ? diff.summary.added + diff.summary.removed + diff.summary.modified + diff.summary.metadata_changed
     : 0;
-  const rowHeight = 34;
-  const viewportHeight = 560;
   const start = Math.max(0, Math.floor(scrollTop / rowHeight) - 6);
   const visibleCount = Math.ceil(viewportHeight / rowHeight) + 12;
-  const visibleItems = filteredItems.slice(start, start + visibleCount);
+  const visibleRows = buildVisibleRows(pageCache, start, visibleCount, pageSize);
 
   return (
     <div className="flex flex-col h-full bg-bg overflow-hidden">
@@ -246,10 +368,9 @@ export function DiffView() {
             <input
               type="checkbox"
               checked={includeUnchanged}
-              disabled
               onChange={(event) => setIncludeUnchanged(event.target.checked)}
             />
-            Unchanged counted in summary
+            Include unchanged
           </label>
           <button
             onClick={compare}
@@ -289,11 +410,12 @@ export function DiffView() {
             <SummaryCell label="Metadata" value={diff.summary.metadata_changed} tone="text-info" />
             <SummaryCell label="Unchanged" value={diff.summary.unchanged} tone="text-text-dim" />
           </div>
-          {diff.items.length < totalChanged && (
-            <p className="mt-2 text-xs text-text-dim">
-              Showing {formatCount(diff.items.length)} rows. Narrow filters and compare again for a focused result set.
-            </p>
-          )}
+          <p className="mt-2 text-xs text-text-dim">
+            {diff.total_matching === 0
+              ? "No matching rows."
+              : `Showing ${formatCount(diff.offset + 1)}-${formatCount(diff.offset + diff.items.length)} of ${formatCount(diff.total_matching)} matching rows.`}
+            {diff.total_matching !== totalChanged && ` ${formatCount(totalChanged)} changed rows before filters.`}
+          </p>
         </section>
       )}
 
@@ -336,14 +458,21 @@ export function DiffView() {
           </div>
           <div
             ref={scrollRef}
-            className="flex-1 overflow-auto"
-            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+            className="relative flex-1 overflow-auto"
+            onScroll={(event) => {
+              const nextScrollTop = event.currentTarget.scrollTop;
+              scrollDirectionRef.current = nextScrollTop >= lastScrollTopRef.current ? "down" : "up";
+              lastScrollTopRef.current = nextScrollTop;
+              setScrollTop(nextScrollTop);
+            }}
           >
-            <div style={{ height: filteredItems.length * rowHeight, position: "relative" }}>
-              <div style={{ transform: `translateY(${start * rowHeight}px)` }}>
-                {visibleItems.map((item) => (
+            <div style={{ height: (diff?.total_matching ?? 0) * rowHeight, position: "relative" }}>
+              {visibleRows.map(({ item, index }) => (
+                <div
+                  key={`${item.tier}:${item.key}`}
+                  style={{ position: "absolute", top: index * rowHeight, left: 0, right: 0, height: rowHeight }}
+                >
                   <button
-                    key={`${item.tier}:${item.key}`}
                     onClick={() => setSelectedKey(item.key)}
                     className={`grid grid-cols-[80px_76px_minmax(140px,1fr)_130px_minmax(120px,0.8fr)] gap-3 w-full px-3 text-left text-xs border-b border-border/60 hover:bg-surface/60 ${
                       selected?.key === item.key ? "bg-primary/10" : ""
@@ -356,9 +485,15 @@ export function DiffView() {
                     <span className="self-center truncate text-text-sub" title={itemType(item)}>{itemType(item)}</span>
                     <span className="self-center truncate text-text-dim" title={item.reasons.join(", ")}>{item.reasons.join(", ")}</span>
                   </button>
-                ))}
-              </div>
+                </div>
+              ))}
             </div>
+            {pageLoading && (
+              <div className="absolute right-4 bottom-4 flex items-center gap-2 rounded-md border border-border bg-bg-alt px-3 py-2 text-xs text-text-sub shadow">
+                <Loader2 size={14} className="animate-spin" />
+                Loading rows
+              </div>
+            )}
           </div>
         </main>
 
@@ -377,6 +512,7 @@ function buildBackendFilter(input: {
   extension: string;
   recordType: string;
   pathPrefix: string;
+  includeUnchanged: boolean;
 }): DiffFilter {
   return {
     search: input.search.trim() || null,
@@ -385,8 +521,29 @@ function buildBackendFilter(input: {
     extensions: input.extension.trim() ? [input.extension.trim()] : [],
     record_types: input.recordType.trim() ? [input.recordType.trim()] : [],
     path_prefixes: input.pathPrefix.trim() ? [input.pathPrefix.trim()] : [],
-    include_unchanged: false,
+    include_unchanged: input.includeUnchanged,
   };
+}
+
+function cachedItems(cache: Map<number, DiffPage>): DiffItem[] {
+  return Array.from(cache.values()).flatMap((page) => page.items);
+}
+
+function buildVisibleRows(
+  cache: Map<number, DiffPage>,
+  start: number,
+  visibleCount: number,
+  pageSize: number,
+): Array<{ item: DiffItem; index: number }> {
+  const rows: Array<{ item: DiffItem; index: number }> = [];
+  const end = start + visibleCount;
+  for (let index = start; index < end; index += 1) {
+    const pageOffset = Math.floor(index / pageSize) * pageSize;
+    const page = cache.get(pageOffset);
+    const item = page?.items[index - pageOffset];
+    if (item) rows.push({ item, index });
+  }
+  return rows;
 }
 
 function SourcePanel({ slotId, slot, onLoad, onSave }: {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ starbreaker-datacore = { path = "../crates/starbreaker-datacore" }
 starbreaker-3d = { path = "../crates/starbreaker-3d" }
 starbreaker-cryxml = { path = "../crates/starbreaker-cryxml" }
 starbreaker-dds = { path = "../crates/starbreaker-dds" }
+starbreaker-diff = { path = "../crates/starbreaker-diff" }
 
 clap = { version = "4", features = ["derive", "env"] }
 thiserror = "2"

--- a/cli/src/diff.rs
+++ b/cli/src/diff.rs
@@ -1,10 +1,11 @@
+use std::collections::BTreeMap;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
-use starbreaker_diff::compare::{DiffItem, DiffStatus};
+use starbreaker_diff::compare::{DiffItem, DiffSide, DiffStatus};
 use starbreaker_diff::report::{
-    read_inventory_report, write_diff_report, write_inventory_report, InventoryReport, Tier,
+    extension_for_path, read_inventory_report, write_diff_report, write_inventory_report, InventoryReport, Tier,
     INVENTORY_EXTENSION,
 };
 use starbreaker_diff::{compare_reports, generate_inventory_from_p4k_with_progress, DiffFilter};
@@ -79,11 +80,18 @@ pub struct CompareArgs {
     /// Skip DataCore if a compare input is a raw P4k.
     #[arg(long)]
     skip_datacore: bool,
+    /// Maximum rows printed by table output. Use 0 for all rows.
+    #[arg(long, default_value_t = 200)]
+    limit: usize,
+    /// Maximum groups printed in summary sections.
+    #[arg(long = "summary-top", default_value_t = 20)]
+    summary_top: usize,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
 pub enum OutputFormat {
     Table,
+    Summary,
     Json,
 }
 
@@ -152,7 +160,8 @@ fn compare(args: CompareArgs) -> Result<()> {
     }
 
     match args.format {
-        OutputFormat::Table => print_table(&diff.items),
+        OutputFormat::Table => print_table(&diff.items, args.limit),
+        OutputFormat::Summary => print_summary(&diff, args.summary_top),
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&diff)?),
     }
     Ok(())
@@ -232,18 +241,45 @@ fn summary_for_items(items: &[DiffItem]) -> starbreaker_diff::DiffSummary {
     summary
 }
 
-fn print_table(items: &[DiffItem]) {
-    println!("{:<16} {:<10} {:<32} Reasons", "Status", "Tier", "Item");
+fn print_table(items: &[DiffItem], limit: usize) {
+    let shown = if limit == 0 { items.len() } else { items.len().min(limit) };
+    println!("{:<16} {:<10} {:<32} Item", "Status", "Tier", "Reasons");
     println!("{:-<16} {:-<10} {:-<32} {:-<24}", "", "", "", "");
-    for item in items {
+    for item in items.iter().take(shown) {
         println!(
             "{:<16} {:<10} {:<32} {}",
             status_label(item.status),
             tier_label(item.tier),
-            truncate(&item.display, 32),
-            item.reasons.join(",")
+            item.reasons.join(","),
+            item.display
         );
     }
+    if shown < items.len() {
+        eprintln!(
+            "Showing {shown} of {} rows. Use --limit 0 for all rows, or --format summary for grouped totals.",
+            items.len()
+        );
+    }
+}
+
+fn print_summary(diff: &starbreaker_diff::DiffReport, top: usize) {
+    println!("{} -> {}", diff.old_label, diff.new_label);
+    println!();
+    println!("Totals");
+    println!("  added:     {}", diff.summary.added);
+    println!("  removed:   {}", diff.summary.removed);
+    println!("  modified:  {}", diff.summary.modified);
+    println!("  metadata:  {}", diff.summary.metadata_changed);
+    if diff.summary.unchanged > 0 {
+        println!("  unchanged: {}", diff.summary.unchanged);
+    }
+    println!("  p4k:       {}", diff.summary.p4k_items);
+    println!("  datacore:  {}", diff.summary.datacore_items);
+
+    print_status_by_tier(diff);
+    print_group_counts("P4k file types", p4k_extension_counts(&diff.items), top);
+    print_group_counts("DataCore record types", datacore_record_type_counts(&diff.items), top);
+    print_group_counts("Change reasons", reason_counts(&diff.items), top);
 }
 
 fn status_label(status: DiffStatus) -> &'static str {
@@ -263,13 +299,85 @@ fn tier_label(tier: Tier) -> &'static str {
     }
 }
 
-fn truncate(value: &str, width: usize) -> String {
-    if value.chars().count() <= width {
-        return value.to_string();
+fn print_status_by_tier(diff: &starbreaker_diff::DiffReport) {
+    println!();
+    println!("By tier");
+    println!("{:<10} {:>8} {:>8} {:>8} {:>10} {:>10}", "Tier", "Added", "Removed", "Modified", "Metadata", "Unchanged");
+    println!("{:-<10} {:->8} {:->8} {:->8} {:->10} {:->10}", "", "", "", "", "", "");
+    for tier in [Tier::P4k, Tier::DataCore] {
+        println!(
+            "{:<10} {:>8} {:>8} {:>8} {:>10} {:>10}",
+            tier_label(tier),
+            count_status(&diff.items, tier, DiffStatus::Added),
+            count_status(&diff.items, tier, DiffStatus::Removed),
+            count_status(&diff.items, tier, DiffStatus::Modified),
+            count_status(&diff.items, tier, DiffStatus::MetadataChanged),
+            count_status(&diff.items, tier, DiffStatus::Unchanged),
+        );
     }
-    let mut out: String = value.chars().take(width.saturating_sub(3)).collect();
-    out.push_str("...");
-    out
+}
+
+fn count_status(items: &[DiffItem], tier: Tier, status: DiffStatus) -> usize {
+    items
+        .iter()
+        .filter(|item| item.tier == tier && item.status == status)
+        .count()
+}
+
+fn p4k_extension_counts(items: &[DiffItem]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for item in items.iter().filter(|item| item.tier == Tier::P4k && item.status != DiffStatus::Unchanged) {
+        let path = match item.new.as_ref().or(item.old.as_ref()) {
+            Some(DiffSide::Archive(entry)) => &entry.path,
+            _ => &item.display,
+        };
+        let extension = extension_for_path(path).unwrap_or_else(|| "(no extension)".to_string());
+        *counts.entry(extension).or_default() += 1;
+    }
+    counts
+}
+
+fn datacore_record_type_counts(items: &[DiffItem]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for item in items.iter().filter(|item| item.tier == Tier::DataCore && item.status != DiffStatus::Unchanged) {
+        let record_type = match item.new.as_ref().or(item.old.as_ref()) {
+            Some(DiffSide::DataCore(record)) => record.record_type.as_str(),
+            _ => "(unknown)",
+        };
+        *counts.entry(record_type.to_string()).or_default() += 1;
+    }
+    counts
+}
+
+fn reason_counts(items: &[DiffItem]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for item in items.iter().filter(|item| item.status != DiffStatus::Unchanged) {
+        if item.reasons.is_empty() {
+            *counts.entry(status_label(item.status).to_string()).or_default() += 1;
+            continue;
+        }
+        for reason in &item.reasons {
+            *counts.entry(reason.clone()).or_default() += 1;
+        }
+    }
+    counts
+}
+
+fn print_group_counts(title: &str, counts: BTreeMap<String, usize>, top: usize) {
+    if counts.is_empty() {
+        return;
+    }
+    let mut rows: Vec<_> = counts.into_iter().collect();
+    rows.sort_by(|(a_name, a_count), (b_name, b_count)| b_count.cmp(a_count).then_with(|| a_name.cmp(b_name)));
+    let shown = if top == 0 { rows.len() } else { rows.len().min(top) };
+    println!();
+    println!("{title}");
+    for (name, count) in rows.iter().take(shown) {
+        println!("  {:>8}  {}", count, name);
+    }
+    if shown < rows.len() {
+        println!("  ... {} more groups hidden; use --summary-top 0 to show all.", rows.len() - shown);
+    }
 }
 
 struct CliProgress {

--- a/cli/src/diff.rs
+++ b/cli/src/diff.rs
@@ -1,3 +1,4 @@
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -108,20 +109,16 @@ fn inventory(args: InventoryArgs) -> Result<()> {
         label: args.label,
         ..Default::default()
     };
-    let mut progress = |event: starbreaker_diff::ProgressEvent| {
-        match (event.current, event.total) {
-            (Some(current), Some(total)) => {
-                eprintln!("{}: {current}/{total}", event.message);
-            }
-            _ => eprintln!("{}", event.message),
-        }
-    };
+    let mut progress_output = CliProgress::new();
+    let mut progress = |event: starbreaker_diff::ProgressEvent| progress_output.report(event);
     let report = generate_inventory_from_p4k_with_progress(
         &args.source,
         &options,
         Some(&mut progress),
         None,
     )?;
+    drop(progress);
+    progress_output.finish();
     write_inventory_report(&args.output, &report)?;
     eprintln!(
         "Wrote inventory: {} ({}, {} P4k entries, {} DataCore records)",
@@ -165,20 +162,17 @@ fn load_source(path: &Path, options: &starbreaker_diff::InventoryOptions) -> Res
     if is_inventory_report(path) {
         return Ok(read_inventory_report(path)?);
     }
-    let mut progress = |event: starbreaker_diff::ProgressEvent| {
-        match (event.current, event.total) {
-            (Some(current), Some(total)) => {
-                eprintln!("{}: {current}/{total}", event.message);
-            }
-            _ => eprintln!("{}", event.message),
-        }
-    };
-    Ok(generate_inventory_from_p4k_with_progress(
+    let mut progress_output = CliProgress::new();
+    let mut progress = |event: starbreaker_diff::ProgressEvent| progress_output.report(event);
+    let report = generate_inventory_from_p4k_with_progress(
         path,
         options,
         Some(&mut progress),
         None,
-    )?)
+    )?;
+    drop(progress);
+    progress_output.finish();
+    Ok(report)
 }
 
 fn is_inventory_report(path: &Path) -> bool {
@@ -276,4 +270,49 @@ fn truncate(value: &str, width: usize) -> String {
     let mut out: String = value.chars().take(width.saturating_sub(3)).collect();
     out.push_str("...");
     out
+}
+
+struct CliProgress {
+    dynamic: bool,
+    line_active: bool,
+}
+
+impl CliProgress {
+    fn new() -> Self {
+        Self {
+            dynamic: io::stderr().is_terminal(),
+            line_active: false,
+        }
+    }
+
+    fn report(&mut self, event: starbreaker_diff::ProgressEvent) {
+        if self.dynamic && event.phase == starbreaker_diff::ProgressPhase::HashingDataCoreRecords {
+            self.write_dynamic(&format_progress(&event));
+            return;
+        }
+
+        self.finish();
+        eprintln!("{}", format_progress(&event));
+    }
+
+    fn write_dynamic(&mut self, text: &str) {
+        let mut stderr = io::stderr().lock();
+        let _ = write!(stderr, "\r\x1b[2K{text}");
+        let _ = stderr.flush();
+        self.line_active = true;
+    }
+
+    fn finish(&mut self) {
+        if self.line_active {
+            eprintln!();
+            self.line_active = false;
+        }
+    }
+}
+
+fn format_progress(event: &starbreaker_diff::ProgressEvent) -> String {
+    match (event.current, event.total) {
+        (Some(current), Some(total)) => format!("{}: {current}/{total}", event.message),
+        _ => event.message.clone(),
+    }
 }

--- a/cli/src/diff.rs
+++ b/cli/src/diff.rs
@@ -1,0 +1,279 @@
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use starbreaker_diff::compare::{DiffItem, DiffStatus};
+use starbreaker_diff::report::{
+    read_inventory_report, write_diff_report, write_inventory_report, InventoryReport, Tier,
+    INVENTORY_EXTENSION,
+};
+use starbreaker_diff::{compare_reports, generate_inventory_from_p4k_with_progress, DiffFilter};
+
+use crate::error::Result;
+
+#[derive(Subcommand)]
+pub enum DiffCommand {
+    /// Generate a reusable P4k/DataCore inventory report.
+    Inventory(InventoryArgs),
+    /// Compare two P4k files and/or inventory reports.
+    Compare(CompareArgs),
+}
+
+impl DiffCommand {
+    pub fn run(self) -> Result<()> {
+        match self {
+            Self::Inventory(args) => inventory(args),
+            Self::Compare(args) => compare(args),
+        }
+    }
+}
+
+#[derive(Parser)]
+pub struct InventoryArgs {
+    /// Data.p4k path.
+    source: PathBuf,
+    /// Output *.starbreaker-inventory.json path.
+    #[arg(short, long)]
+    output: PathBuf,
+    /// Skip DataCore record inventory and compare only P4k file entries.
+    #[arg(long)]
+    skip_datacore: bool,
+    /// Optional display label stored in the report.
+    #[arg(long)]
+    label: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct CompareArgs {
+    /// Old source: Data.p4k or *.starbreaker-inventory.json.
+    old: PathBuf,
+    /// New source: Data.p4k or *.starbreaker-inventory.json.
+    new: PathBuf,
+    /// Optional output *.starbreaker-diff.json path.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+    /// Output format when not writing a diff file.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+    /// Filter by tier.
+    #[arg(long, value_enum, default_value_t = TierArg::All)]
+    tier: TierArg,
+    /// Filter by statuses. Comma-separated values are accepted.
+    #[arg(long, value_delimiter = ',')]
+    status: Vec<StatusArg>,
+    /// Plain-text search across paths, names, types, extensions, and GUIDs.
+    #[arg(long)]
+    search: Option<String>,
+    /// Filter archive files by extension, such as .dds or xml.
+    #[arg(long, value_delimiter = ',')]
+    extension: Vec<String>,
+    /// Filter DataCore records by record type.
+    #[arg(long = "record-type", value_delimiter = ',')]
+    record_type: Vec<String>,
+    /// Filter archive/DataCore paths by prefix.
+    #[arg(long = "path-prefix", value_delimiter = ',')]
+    path_prefix: Vec<String>,
+    /// Include unchanged rows in the diff output.
+    #[arg(long)]
+    include_unchanged: bool,
+    /// Skip DataCore if a compare input is a raw P4k.
+    #[arg(long)]
+    skip_datacore: bool,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+    Table,
+    Json,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum TierArg {
+    All,
+    P4k,
+    Datacore,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum StatusArg {
+    Added,
+    Removed,
+    Modified,
+    Metadata,
+    Unchanged,
+}
+
+fn inventory(args: InventoryArgs) -> Result<()> {
+    let options = starbreaker_diff::InventoryOptions {
+        skip_datacore: args.skip_datacore,
+        label: args.label,
+        ..Default::default()
+    };
+    let mut progress = |event: starbreaker_diff::ProgressEvent| {
+        match (event.current, event.total) {
+            (Some(current), Some(total)) => {
+                eprintln!("{}: {current}/{total}", event.message);
+            }
+            _ => eprintln!("{}", event.message),
+        }
+    };
+    let report = generate_inventory_from_p4k_with_progress(
+        &args.source,
+        &options,
+        Some(&mut progress),
+        None,
+    )?;
+    write_inventory_report(&args.output, &report)?;
+    eprintln!(
+        "Wrote inventory: {} ({}, {} P4k entries, {} DataCore records)",
+        args.output.display(),
+        report.source.label,
+        report.archive.len(),
+        report.datacore.status.records().len()
+    );
+    Ok(())
+}
+
+fn compare(args: CompareArgs) -> Result<()> {
+    let options = starbreaker_diff::InventoryOptions {
+        skip_datacore: args.skip_datacore,
+        ..Default::default()
+    };
+    let old = load_source(&args.old, &options)?;
+    let new = load_source(&args.new, &options)?;
+    let mut diff = compare_reports(&old, &new, args.include_unchanged);
+    let filter = build_filter(&args);
+    if filter_has_constraints(&filter) {
+        let filtered = starbreaker_diff::filter_diff_items(&diff.items, &filter);
+        diff.items = filtered.into_iter().cloned().collect();
+        diff.summary = summary_for_items(&diff.items);
+    }
+
+    if let Some(output) = args.output {
+        write_diff_report(&output, &diff)?;
+        eprintln!("Wrote diff: {}", output.display());
+        return Ok(());
+    }
+
+    match args.format {
+        OutputFormat::Table => print_table(&diff.items),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&diff)?),
+    }
+    Ok(())
+}
+
+fn load_source(path: &Path, options: &starbreaker_diff::InventoryOptions) -> Result<InventoryReport> {
+    if is_inventory_report(path) {
+        return Ok(read_inventory_report(path)?);
+    }
+    let mut progress = |event: starbreaker_diff::ProgressEvent| {
+        match (event.current, event.total) {
+            (Some(current), Some(total)) => {
+                eprintln!("{}: {current}/{total}", event.message);
+            }
+            _ => eprintln!("{}", event.message),
+        }
+    };
+    Ok(generate_inventory_from_p4k_with_progress(
+        path,
+        options,
+        Some(&mut progress),
+        None,
+    )?)
+}
+
+fn is_inventory_report(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(INVENTORY_EXTENSION))
+}
+
+fn build_filter(args: &CompareArgs) -> DiffFilter {
+    let tiers = match args.tier {
+        TierArg::All => Vec::new(),
+        TierArg::P4k => vec![Tier::P4k],
+        TierArg::Datacore => vec![Tier::DataCore],
+    };
+    let statuses = args.status.iter().map(|status| match status {
+        StatusArg::Added => DiffStatus::Added,
+        StatusArg::Removed => DiffStatus::Removed,
+        StatusArg::Modified => DiffStatus::Modified,
+        StatusArg::Metadata => DiffStatus::MetadataChanged,
+        StatusArg::Unchanged => DiffStatus::Unchanged,
+    }).collect();
+    DiffFilter {
+        search: args.search.clone(),
+        tiers,
+        statuses,
+        extensions: args.extension.clone(),
+        record_types: args.record_type.clone(),
+        path_prefixes: args.path_prefix.clone(),
+        include_unchanged: args.include_unchanged,
+    }
+}
+
+fn filter_has_constraints(filter: &DiffFilter) -> bool {
+    filter.search.as_ref().is_some_and(|s| !s.trim().is_empty())
+        || !filter.tiers.is_empty()
+        || !filter.statuses.is_empty()
+        || !filter.extensions.is_empty()
+        || !filter.record_types.is_empty()
+        || !filter.path_prefixes.is_empty()
+}
+
+fn summary_for_items(items: &[DiffItem]) -> starbreaker_diff::DiffSummary {
+    let mut summary = starbreaker_diff::DiffSummary::default();
+    for item in items {
+        match item.status {
+            DiffStatus::Added => summary.added += 1,
+            DiffStatus::Removed => summary.removed += 1,
+            DiffStatus::Modified => summary.modified += 1,
+            DiffStatus::MetadataChanged => summary.metadata_changed += 1,
+            DiffStatus::Unchanged => summary.unchanged += 1,
+        }
+        match item.tier {
+            Tier::P4k => summary.p4k_items += 1,
+            Tier::DataCore => summary.datacore_items += 1,
+        }
+    }
+    summary
+}
+
+fn print_table(items: &[DiffItem]) {
+    println!("{:<16} {:<10} {:<32} Reasons", "Status", "Tier", "Item");
+    println!("{:-<16} {:-<10} {:-<32} {:-<24}", "", "", "", "");
+    for item in items {
+        println!(
+            "{:<16} {:<10} {:<32} {}",
+            status_label(item.status),
+            tier_label(item.tier),
+            truncate(&item.display, 32),
+            item.reasons.join(",")
+        );
+    }
+}
+
+fn status_label(status: DiffStatus) -> &'static str {
+    match status {
+        DiffStatus::Added => "added",
+        DiffStatus::Removed => "removed",
+        DiffStatus::Modified => "modified",
+        DiffStatus::MetadataChanged => "metadata",
+        DiffStatus::Unchanged => "unchanged",
+    }
+}
+
+fn tier_label(tier: Tier) -> &'static str {
+    match tier {
+        Tier::P4k => "p4k",
+        Tier::DataCore => "datacore",
+    }
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.chars().count() <= width {
+        return value.to_string();
+    }
+    let mut out: String = value.chars().take(width.saturating_sub(3)).collect();
+    out.push_str("...");
+    out
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -22,6 +22,8 @@ pub enum CliError {
     #[error(transparent)]
     DataCoreParse(#[from] starbreaker_datacore::error::ParseError),
     #[error(transparent)]
+    Diff(#[from] starbreaker_diff::DiffError),
+    #[error(transparent)]
     Dds(#[from] DdsError),
     #[error(transparent)]
     Wwise(#[from] BnkError),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@ mod chf;
 mod common;
 mod cryxml;
 mod dcb;
+mod diff;
 mod dds;
 mod entity;
 mod error;
@@ -97,6 +98,11 @@ enum Command {
         #[command(subcommand)]
         command: dcb::DcbCommand,
     },
+    /// P4k and DataCore diff operations
+    Diff {
+        #[command(subcommand)]
+        command: diff::DiffCommand,
+    },
     /// Entity export operations
     Entity {
         #[command(subcommand)]
@@ -165,6 +171,7 @@ fn main() {
     let result = match cli.command {
         Command::P4k { command } => command.run(),
         Command::Dcb { command } => command.run(),
+        Command::Diff { command } => command.run(),
         Command::Entity { command } => command.run(),
         Command::Skin { command } => command.run(),
         Command::Socpak { command } => command.run(),

--- a/crates/starbreaker-diff/Cargo.toml
+++ b/crates/starbreaker-diff/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "starbreaker-diff"
+version.workspace = true
+edition = "2024"
+
+[dependencies]
+starbreaker-datacore = { path = "../starbreaker-datacore" }
+starbreaker-p4k = { path = "../starbreaker-p4k" }
+
+blake3 = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/starbreaker-diff/src/canonical.rs
+++ b/crates/starbreaker-diff/src/canonical.rs
@@ -1,0 +1,258 @@
+use std::io::Write;
+
+use serde_json::ser::{Formatter, PrettyFormatter};
+use starbreaker_datacore::database::Database;
+use starbreaker_datacore::sink::ExportSink;
+use starbreaker_datacore::types::{CigGuid, Record};
+
+use crate::Result;
+
+pub(crate) fn canonical_record_hash(db: &Database, record: &Record) -> Result<String> {
+    let mut bytes = Vec::new();
+    let mut sink = CanonicalJsonSink::new(&mut bytes);
+    starbreaker_datacore::walker::walk_record(db, record, &mut sink)?;
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)?;
+    strip_record_metadata(&mut value);
+    let record_value = value
+        .get("_RecordValue_")
+        .cloned()
+        .unwrap_or(value);
+    let canonical = serde_json::to_vec(&record_value)?;
+    Ok(format!("blake3:{}", blake3::hash(&canonical)))
+}
+
+fn strip_record_metadata(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("_RecordId_");
+            map.remove("_RecordName_");
+            map.remove("_RecordTag_");
+            for value in map.values_mut() {
+                strip_record_metadata(value);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                strip_record_metadata(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+struct CanonicalJsonSink<W: Write> {
+    writer: W,
+    fmt: PrettyFormatter<'static>,
+    first_stack: Vec<bool>,
+}
+
+impl<W: Write> CanonicalJsonSink<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer,
+            fmt: PrettyFormatter::with_indent(b""),
+            first_stack: Vec::new(),
+        }
+    }
+
+    fn is_first(&self) -> bool {
+        self.first_stack.last().copied().unwrap_or(true)
+    }
+
+    fn mark_not_first(&mut self) {
+        if let Some(first) = self.first_stack.last_mut() {
+            *first = false;
+        }
+    }
+
+    fn key_prefix(&mut self, name: &str) -> std::io::Result<()> {
+        let first = self.is_first();
+        self.fmt.begin_object_key(&mut self.writer, first)?;
+        self.mark_not_first();
+        serde_json::to_writer(&mut self.writer, name).map_err(std::io::Error::other)?;
+        self.fmt.end_object_key(&mut self.writer)?;
+        self.fmt.begin_object_value(&mut self.writer)?;
+        Ok(())
+    }
+
+    fn array_value_prefix(&mut self) -> std::io::Result<()> {
+        let first = self.is_first();
+        self.fmt.begin_array_value(&mut self.writer, first)?;
+        self.mark_not_first();
+        Ok(())
+    }
+
+    fn value_prefix(&mut self, name: Option<&str>) -> std::io::Result<()> {
+        if let Some(name) = name {
+            self.key_prefix(name)
+        } else if self.first_stack.is_empty() {
+            Ok(())
+        } else {
+            self.array_value_prefix()
+        }
+    }
+}
+
+impl<W: Write> ExportSink for CanonicalJsonSink<W> {
+    type Error = std::io::Error;
+
+    fn extension(&self) -> &str {
+        "json"
+    }
+
+    fn begin_object(&mut self, name: Option<&str>) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.begin_object(&mut self.writer)?;
+        self.first_stack.push(true);
+        Ok(())
+    }
+
+    fn end_object(&mut self) -> std::result::Result<(), Self::Error> {
+        self.first_stack.pop();
+        self.fmt.end_object(&mut self.writer)
+    }
+
+    fn begin_array(&mut self, name: &str) -> std::result::Result<(), Self::Error> {
+        self.key_prefix(name)?;
+        self.fmt.begin_array(&mut self.writer)?;
+        self.first_stack.push(true);
+        Ok(())
+    }
+
+    fn end_array(&mut self) -> std::result::Result<(), Self::Error> {
+        self.first_stack.pop();
+        self.fmt.end_array(&mut self.writer)
+    }
+
+    fn write_null(&mut self, name: Option<&str>) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_null(&mut self.writer)
+    }
+
+    fn write_bool(
+        &mut self,
+        name: Option<&str>,
+        value: bool,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_bool(&mut self.writer, value)
+    }
+
+    fn write_i8(&mut self, name: Option<&str>, value: i8) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_i8(&mut self.writer, value)
+    }
+
+    fn write_i16(
+        &mut self,
+        name: Option<&str>,
+        value: i16,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_i16(&mut self.writer, value)
+    }
+
+    fn write_i32(
+        &mut self,
+        name: Option<&str>,
+        value: i32,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_i32(&mut self.writer, value)
+    }
+
+    fn write_i64(
+        &mut self,
+        name: Option<&str>,
+        value: i64,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_i64(&mut self.writer, value)
+    }
+
+    fn write_u8(&mut self, name: Option<&str>, value: u8) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_u8(&mut self.writer, value)
+    }
+
+    fn write_u16(
+        &mut self,
+        name: Option<&str>,
+        value: u16,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_u16(&mut self.writer, value)
+    }
+
+    fn write_u32(
+        &mut self,
+        name: Option<&str>,
+        value: u32,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_u32(&mut self.writer, value)
+    }
+
+    fn write_u64(
+        &mut self,
+        name: Option<&str>,
+        value: u64,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        self.fmt.write_u64(&mut self.writer, value)
+    }
+
+    fn write_f32(
+        &mut self,
+        name: Option<&str>,
+        value: f32,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        if value.is_finite() {
+            self.fmt.write_f32(&mut self.writer, value)
+        } else {
+            self.fmt.write_null(&mut self.writer)
+        }
+    }
+
+    fn write_f64(
+        &mut self,
+        name: Option<&str>,
+        value: f64,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        if value.is_finite() {
+            self.fmt.write_f64(&mut self.writer, value)
+        } else {
+            self.fmt.write_null(&mut self.writer)
+        }
+    }
+
+    fn write_str(
+        &mut self,
+        name: Option<&str>,
+        value: &str,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        serde_json::to_writer(&mut self.writer, value).map_err(std::io::Error::other)
+    }
+
+    fn write_guid(
+        &mut self,
+        name: Option<&str>,
+        value: &CigGuid,
+    ) -> std::result::Result<(), Self::Error> {
+        self.value_prefix(name)?;
+        serde_json::to_writer(&mut self.writer, &value.to_string()).map_err(std::io::Error::other)
+    }
+
+    fn write_record_ref(
+        &mut self,
+        name: Option<&str>,
+        record_id: &CigGuid,
+        _record_name: &str,
+        _path: &str,
+    ) -> std::result::Result<(), Self::Error> {
+        self.write_guid(name, record_id)
+    }
+}

--- a/crates/starbreaker-diff/src/compare.rs
+++ b/crates/starbreaker-diff/src/compare.rs
@@ -1,0 +1,346 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::report::{
+    normalize_archive_path, ArchiveEntryInventory, DataCoreRecordInventory, InventoryReport, Tier,
+    DIFF_SCHEMA_VERSION,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffStatus {
+    Added,
+    Removed,
+    Modified,
+    MetadataChanged,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffSide {
+    Archive(ArchiveEntryInventory),
+    DataCore(DataCoreRecordInventory),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffItem {
+    pub tier: Tier,
+    pub status: DiffStatus,
+    pub key: String,
+    pub display: String,
+    pub old: Option<DiffSide>,
+    pub new: Option<DiffSide>,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiffSummary {
+    pub added: usize,
+    pub removed: usize,
+    pub modified: usize,
+    pub metadata_changed: usize,
+    pub unchanged: usize,
+    pub p4k_items: usize,
+    pub datacore_items: usize,
+}
+
+impl DiffSummary {
+    fn add(&mut self, item: &DiffItem) {
+        match item.status {
+            DiffStatus::Added => self.added += 1,
+            DiffStatus::Removed => self.removed += 1,
+            DiffStatus::Modified => self.modified += 1,
+            DiffStatus::MetadataChanged => self.metadata_changed += 1,
+            DiffStatus::Unchanged => self.unchanged += 1,
+        }
+        match item.tier {
+            Tier::P4k => self.p4k_items += 1,
+            Tier::DataCore => self.datacore_items += 1,
+        }
+    }
+}
+
+pub fn compare_reports(
+    old: &InventoryReport,
+    new: &InventoryReport,
+    include_unchanged: bool,
+) -> crate::report::DiffReport {
+    let mut items = Vec::new();
+    items.extend(compare_archive(old, new));
+    items.extend(compare_datacore(old, new));
+    items.sort_by(|a, b| {
+        status_rank(a.status)
+            .cmp(&status_rank(b.status))
+            .then_with(|| tier_rank(a.tier).cmp(&tier_rank(b.tier)))
+            .then_with(|| a.display.cmp(&b.display))
+            .then_with(|| a.key.cmp(&b.key))
+    });
+
+    let mut summary = DiffSummary::default();
+    for item in &items {
+        summary.add(item);
+    }
+    if !include_unchanged {
+        items.retain(|item| item.status != DiffStatus::Unchanged);
+    }
+
+    crate::report::DiffReport {
+        schema_version: DIFF_SCHEMA_VERSION,
+        old_label: old.source.label.clone(),
+        new_label: new.source.label.clone(),
+        old_inventory_hash: old.inventory_hash.clone(),
+        new_inventory_hash: new.inventory_hash.clone(),
+        summary,
+        items,
+    }
+}
+
+fn compare_archive(
+    old: &InventoryReport,
+    new: &InventoryReport,
+) -> Vec<DiffItem> {
+    let old_map: BTreeMap<_, _> = old
+        .archive
+        .iter()
+        .map(|entry| (entry.normalized_path.clone(), entry))
+        .collect();
+    let new_map: BTreeMap<_, _> = new
+        .archive
+        .iter()
+        .map(|entry| (entry.normalized_path.clone(), entry))
+        .collect();
+
+    let mut keys: Vec<_> = old_map.keys().chain(new_map.keys()).cloned().collect();
+    keys.sort();
+    keys.dedup();
+
+    let mut items = Vec::new();
+    for key in keys {
+        match (old_map.get(&key), new_map.get(&key)) {
+            (None, Some(new_entry)) => items.push(archive_item(
+                DiffStatus::Added,
+                key,
+                None,
+                Some((*new_entry).clone()),
+                Vec::new(),
+            )),
+            (Some(old_entry), None) => items.push(archive_item(
+                DiffStatus::Removed,
+                key,
+                Some((*old_entry).clone()),
+                None,
+                Vec::new(),
+            )),
+            (Some(old_entry), Some(new_entry)) => {
+                let mut reasons = Vec::new();
+                if old_entry.crc32 != new_entry.crc32 {
+                    reasons.push("crc32_changed".to_string());
+                }
+                if old_entry.uncompressed_size != new_entry.uncompressed_size {
+                    reasons.push("uncompressed_size_changed".to_string());
+                }
+                let content_changed = !reasons.is_empty();
+
+                if old_entry.compressed_size != new_entry.compressed_size {
+                    reasons.push("compressed_size_changed".to_string());
+                }
+                if old_entry.compression_method != new_entry.compression_method {
+                    reasons.push("compression_method_changed".to_string());
+                }
+                if old_entry.encrypted != new_entry.encrypted {
+                    reasons.push("encrypted_changed".to_string());
+                }
+                if old_entry.last_modified != new_entry.last_modified {
+                    reasons.push("last_modified_changed".to_string());
+                }
+                add_path_reasons(&mut reasons, &old_entry.path, &new_entry.path);
+
+                let status = if content_changed {
+                    DiffStatus::Modified
+                } else if reasons.is_empty() {
+                    DiffStatus::Unchanged
+                } else {
+                    DiffStatus::MetadataChanged
+                };
+
+                items.push(archive_item(
+                    status,
+                    key,
+                    Some((*old_entry).clone()),
+                    Some((*new_entry).clone()),
+                    reasons,
+                ));
+            }
+            (None, None) => {}
+        }
+    }
+    items
+}
+
+fn compare_datacore(
+    old: &InventoryReport,
+    new: &InventoryReport,
+) -> Vec<DiffItem> {
+    let old_map: BTreeMap<_, _> = old
+        .datacore
+        .status
+        .records()
+        .iter()
+        .map(|record| (record.id.clone(), record))
+        .collect();
+    let new_map: BTreeMap<_, _> = new
+        .datacore
+        .status
+        .records()
+        .iter()
+        .map(|record| (record.id.clone(), record))
+        .collect();
+
+    let mut keys: Vec<_> = old_map.keys().chain(new_map.keys()).cloned().collect();
+    keys.sort();
+    keys.dedup();
+
+    let mut items = Vec::new();
+    for key in keys {
+        match (old_map.get(&key), new_map.get(&key)) {
+            (None, Some(new_record)) => items.push(datacore_item(
+                DiffStatus::Added,
+                key,
+                None,
+                Some((*new_record).clone()),
+                Vec::new(),
+            )),
+            (Some(old_record), None) => items.push(datacore_item(
+                DiffStatus::Removed,
+                key,
+                Some((*old_record).clone()),
+                None,
+                Vec::new(),
+            )),
+            (Some(old_record), Some(new_record)) => {
+                let mut reasons = Vec::new();
+                if old_record.record_type != new_record.record_type {
+                    reasons.push("type_changed".to_string());
+                }
+                if old_record.content_hash != new_record.content_hash {
+                    reasons.push("content_hash_changed".to_string());
+                }
+                let content_changed = reasons
+                    .iter()
+                    .any(|reason| reason == "type_changed" || reason == "content_hash_changed");
+
+                if old_record.name != new_record.name {
+                    reasons.push("name_changed".to_string());
+                }
+                if old_record.path != new_record.path {
+                    reasons.push("path_changed".to_string());
+                }
+
+                let status = if content_changed {
+                    DiffStatus::Modified
+                } else if reasons.is_empty() {
+                    DiffStatus::Unchanged
+                } else {
+                    DiffStatus::MetadataChanged
+                };
+
+                items.push(datacore_item(
+                    status,
+                    key,
+                    Some((*old_record).clone()),
+                    Some((*new_record).clone()),
+                    reasons,
+                ));
+            }
+            (None, None) => {}
+        }
+    }
+    items
+}
+
+fn archive_item(
+    status: DiffStatus,
+    key: String,
+    old: Option<ArchiveEntryInventory>,
+    new: Option<ArchiveEntryInventory>,
+    reasons: Vec<String>,
+) -> DiffItem {
+    let display = new
+        .as_ref()
+        .or(old.as_ref())
+        .map(|entry| entry.path.clone())
+        .unwrap_or_else(|| key.clone());
+    DiffItem {
+        tier: Tier::P4k,
+        status,
+        key,
+        display,
+        old: old.map(DiffSide::Archive),
+        new: new.map(DiffSide::Archive),
+        reasons,
+    }
+}
+
+fn datacore_item(
+    status: DiffStatus,
+    key: String,
+    old: Option<DataCoreRecordInventory>,
+    new: Option<DataCoreRecordInventory>,
+    reasons: Vec<String>,
+) -> DiffItem {
+    let display = new
+        .as_ref()
+        .or(old.as_ref())
+        .map(|record| {
+            if record.name.is_empty() {
+                record.id.clone()
+            } else {
+                record.name.clone()
+            }
+        })
+        .unwrap_or_else(|| key.clone());
+    DiffItem {
+        tier: Tier::DataCore,
+        status,
+        key,
+        display,
+        old: old.map(DiffSide::DataCore),
+        new: new.map(DiffSide::DataCore),
+        reasons,
+    }
+}
+
+fn add_path_reasons(reasons: &mut Vec<String>, old: &str, new: &str) {
+    if old == new {
+        return;
+    }
+    if normalize_archive_path(old) == normalize_archive_path(new) {
+        if old.replace('/', "\\") != new.replace('/', "\\") {
+            reasons.push("path_separator_changed".to_string());
+        }
+        if old.replace('/', "\\").to_ascii_lowercase() == new.replace('/', "\\").to_ascii_lowercase()
+            && old.replace('/', "\\") != new.replace('/', "\\")
+        {
+            reasons.push("path_case_changed".to_string());
+        }
+    }
+}
+
+fn status_rank(status: DiffStatus) -> u8 {
+    match status {
+        DiffStatus::Added => 0,
+        DiffStatus::Removed => 1,
+        DiffStatus::Modified => 2,
+        DiffStatus::MetadataChanged => 3,
+        DiffStatus::Unchanged => 4,
+    }
+}
+
+fn tier_rank(tier: Tier) -> u8 {
+    match tier {
+        Tier::P4k => 0,
+        Tier::DataCore => 1,
+    }
+}

--- a/crates/starbreaker-diff/src/compare.rs
+++ b/crates/starbreaker-diff/src/compare.rs
@@ -47,7 +47,7 @@ pub struct DiffSummary {
 }
 
 impl DiffSummary {
-    fn add(&mut self, item: &DiffItem) {
+    pub(crate) fn add(&mut self, item: &DiffItem) {
         match item.status {
             DiffStatus::Added => self.added += 1,
             DiffStatus::Removed => self.removed += 1,
@@ -179,6 +179,70 @@ fn compare_archive(
     items
 }
 
+pub(crate) fn archive_item_for_key(
+    key: String,
+    old_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    new_map: &BTreeMap<String, &ArchiveEntryInventory>,
+) -> DiffItem {
+    match (old_map.get(&key), new_map.get(&key)) {
+        (None, Some(new_entry)) => archive_item(
+            DiffStatus::Added,
+            key,
+            None,
+            Some((*new_entry).clone()),
+            Vec::new(),
+        ),
+        (Some(old_entry), None) => archive_item(
+            DiffStatus::Removed,
+            key,
+            Some((*old_entry).clone()),
+            None,
+            Vec::new(),
+        ),
+        (Some(old_entry), Some(new_entry)) => {
+            let mut reasons = Vec::new();
+            if old_entry.crc32 != new_entry.crc32 {
+                reasons.push("crc32_changed".to_string());
+            }
+            if old_entry.uncompressed_size != new_entry.uncompressed_size {
+                reasons.push("uncompressed_size_changed".to_string());
+            }
+            let content_changed = !reasons.is_empty();
+
+            if old_entry.compressed_size != new_entry.compressed_size {
+                reasons.push("compressed_size_changed".to_string());
+            }
+            if old_entry.compression_method != new_entry.compression_method {
+                reasons.push("compression_method_changed".to_string());
+            }
+            if old_entry.encrypted != new_entry.encrypted {
+                reasons.push("encrypted_changed".to_string());
+            }
+            if old_entry.last_modified != new_entry.last_modified {
+                reasons.push("last_modified_changed".to_string());
+            }
+            add_path_reasons(&mut reasons, &old_entry.path, &new_entry.path);
+
+            let status = if content_changed {
+                DiffStatus::Modified
+            } else if reasons.is_empty() {
+                DiffStatus::Unchanged
+            } else {
+                DiffStatus::MetadataChanged
+            };
+
+            archive_item(
+                status,
+                key,
+                Some((*old_entry).clone()),
+                Some((*new_entry).clone()),
+                reasons,
+            )
+        }
+        (None, None) => archive_item(DiffStatus::Unchanged, key, None, None, Vec::new()),
+    }
+}
+
 fn compare_datacore(
     old: &InventoryReport,
     new: &InventoryReport,
@@ -258,6 +322,65 @@ fn compare_datacore(
         }
     }
     items
+}
+
+pub(crate) fn datacore_item_for_key(
+    key: String,
+    old_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    new_map: &BTreeMap<String, &DataCoreRecordInventory>,
+) -> DiffItem {
+    match (old_map.get(&key), new_map.get(&key)) {
+        (None, Some(new_record)) => datacore_item(
+            DiffStatus::Added,
+            key,
+            None,
+            Some((*new_record).clone()),
+            Vec::new(),
+        ),
+        (Some(old_record), None) => datacore_item(
+            DiffStatus::Removed,
+            key,
+            Some((*old_record).clone()),
+            None,
+            Vec::new(),
+        ),
+        (Some(old_record), Some(new_record)) => {
+            let mut reasons = Vec::new();
+            if old_record.record_type != new_record.record_type {
+                reasons.push("type_changed".to_string());
+            }
+            if old_record.content_hash != new_record.content_hash {
+                reasons.push("content_hash_changed".to_string());
+            }
+            let content_changed = reasons
+                .iter()
+                .any(|reason| reason == "type_changed" || reason == "content_hash_changed");
+
+            if old_record.name != new_record.name {
+                reasons.push("name_changed".to_string());
+            }
+            if old_record.path != new_record.path {
+                reasons.push("path_changed".to_string());
+            }
+
+            let status = if content_changed {
+                DiffStatus::Modified
+            } else if reasons.is_empty() {
+                DiffStatus::Unchanged
+            } else {
+                DiffStatus::MetadataChanged
+            };
+
+            datacore_item(
+                status,
+                key,
+                Some((*old_record).clone()),
+                Some((*new_record).clone()),
+                reasons,
+            )
+        }
+        (None, None) => datacore_item(DiffStatus::Unchanged, key, None, None, Vec::new()),
+    }
 }
 
 fn archive_item(

--- a/crates/starbreaker-diff/src/error.rs
+++ b/crates/starbreaker-diff/src/error.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, DiffError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiffError {
+    #[error("P4k error: {0}")]
+    P4k(#[from] starbreaker_p4k::P4kError),
+
+    #[error("DataCore parse error: {0}")]
+    DataCoreParse(#[from] starbreaker_datacore::error::ParseError),
+
+    #[error("DataCore export error: {0}")]
+    DataCoreExport(#[from] starbreaker_datacore::error::ExportError),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("inventory generation was cancelled")]
+    Cancelled,
+
+    #[error("DataCore file not found in P4k; tried Data\\Game2.dcb and Data\\Game.dcb")]
+    DataCoreNotFound,
+
+    #[error("unsupported diff source: {0}")]
+    UnsupportedSource(PathBuf),
+}

--- a/crates/starbreaker-diff/src/filter.rs
+++ b/crates/starbreaker-diff/src/filter.rs
@@ -18,11 +18,11 @@ pub fn filter_diff_items<'a>(
 ) -> Vec<&'a DiffItem> {
     items
         .iter()
-        .filter(|item| matches_filter(item, filter))
+        .filter(|item| diff_item_matches_filter(item, filter))
         .collect()
 }
 
-fn matches_filter(item: &DiffItem, filter: &DiffFilter) -> bool {
+pub fn diff_item_matches_filter(item: &DiffItem, filter: &DiffFilter) -> bool {
     if !filter.tiers.is_empty() && !filter.tiers.contains(&item.tier) {
         return false;
     }

--- a/crates/starbreaker-diff/src/filter.rs
+++ b/crates/starbreaker-diff/src/filter.rs
@@ -1,0 +1,156 @@
+use crate::compare::{DiffItem, DiffSide, DiffStatus};
+use crate::report::{extension_for_path, Tier};
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DiffFilter {
+    pub search: Option<String>,
+    pub tiers: Vec<Tier>,
+    pub statuses: Vec<DiffStatus>,
+    pub extensions: Vec<String>,
+    pub record_types: Vec<String>,
+    pub path_prefixes: Vec<String>,
+    pub include_unchanged: bool,
+}
+
+pub fn filter_diff_items<'a>(
+    items: &'a [DiffItem],
+    filter: &DiffFilter,
+) -> Vec<&'a DiffItem> {
+    items
+        .iter()
+        .filter(|item| matches_filter(item, filter))
+        .collect()
+}
+
+fn matches_filter(item: &DiffItem, filter: &DiffFilter) -> bool {
+    if !filter.tiers.is_empty() && !filter.tiers.contains(&item.tier) {
+        return false;
+    }
+    if !filter.statuses.is_empty() && !filter.statuses.contains(&item.status) {
+        return false;
+    }
+    if !filter.include_unchanged && item.status == DiffStatus::Unchanged {
+        return false;
+    }
+    if !filter.extensions.is_empty() && !matches_extension(item, &filter.extensions) {
+        return false;
+    }
+    if !filter.record_types.is_empty() && !matches_record_type(item, &filter.record_types) {
+        return false;
+    }
+    if !filter.path_prefixes.is_empty() && !matches_path_prefix(item, &filter.path_prefixes) {
+        return false;
+    }
+    if let Some(search) = &filter.search
+        && !search.trim().is_empty()
+        && !matches_search(item, search)
+    {
+        return false;
+    }
+    true
+}
+
+fn matches_search(item: &DiffItem, search: &str) -> bool {
+    let needle = search.to_ascii_lowercase();
+    searchable_fields(item)
+        .into_iter()
+        .any(|field| field.to_ascii_lowercase().contains(&needle))
+}
+
+fn matches_extension(item: &DiffItem, extensions: &[String]) -> bool {
+    if item.tier != Tier::P4k {
+        return false;
+    }
+    let normalized: Vec<_> = extensions
+        .iter()
+        .map(|ext| {
+            if ext.starts_with('.') {
+                ext.to_ascii_lowercase()
+            } else {
+                format!(".{}", ext.to_ascii_lowercase())
+            }
+        })
+        .collect();
+    archive_paths(item)
+        .into_iter()
+        .filter_map(|path| extension_for_path(&path))
+        .any(|ext| normalized.contains(&ext))
+}
+
+fn matches_record_type(item: &DiffItem, record_types: &[String]) -> bool {
+    if item.tier != Tier::DataCore {
+        return false;
+    }
+    let wanted: Vec<_> = record_types
+        .iter()
+        .map(|record_type| record_type.to_ascii_lowercase())
+        .collect();
+    datacore_types(item)
+        .into_iter()
+        .any(|record_type| wanted.contains(&record_type.to_ascii_lowercase()))
+}
+
+fn matches_path_prefix(item: &DiffItem, prefixes: &[String]) -> bool {
+    let normalized: Vec<_> = prefixes
+        .iter()
+        .map(|prefix| prefix.replace('/', "\\").to_ascii_lowercase())
+        .collect();
+    item_paths(item).into_iter().any(|path| {
+        let path = path.replace('/', "\\").to_ascii_lowercase();
+        normalized.iter().any(|prefix| path.starts_with(prefix))
+    })
+}
+
+fn searchable_fields(item: &DiffItem) -> Vec<String> {
+    let mut fields = vec![item.key.clone(), item.display.clone()];
+    for side in [&item.old, &item.new].into_iter().flatten() {
+        match side {
+            DiffSide::Archive(entry) => {
+                fields.push(entry.path.clone());
+                if let Some(ext) = extension_for_path(&entry.path) {
+                    fields.push(ext);
+                }
+            }
+            DiffSide::DataCore(record) => {
+                fields.push(record.id.clone());
+                fields.push(record.name.clone());
+                fields.push(record.record_type.clone());
+                fields.push(record.path.clone());
+            }
+        }
+    }
+    fields
+}
+
+fn archive_paths(item: &DiffItem) -> Vec<String> {
+    [&item.old, &item.new]
+        .into_iter()
+        .flatten()
+        .filter_map(|side| match side {
+            DiffSide::Archive(entry) => Some(entry.path.clone()),
+            DiffSide::DataCore(_) => None,
+        })
+        .collect()
+}
+
+fn item_paths(item: &DiffItem) -> Vec<String> {
+    [&item.old, &item.new]
+        .into_iter()
+        .flatten()
+        .map(|side| match side {
+            DiffSide::Archive(entry) => entry.path.clone(),
+            DiffSide::DataCore(record) => record.path.clone(),
+        })
+        .collect()
+}
+
+fn datacore_types(item: &DiffItem) -> Vec<String> {
+    [&item.old, &item.new]
+        .into_iter()
+        .flatten()
+        .filter_map(|side| match side {
+            DiffSide::Archive(_) => None,
+            DiffSide::DataCore(record) => Some(record.record_type.clone()),
+        })
+        .collect()
+}

--- a/crates/starbreaker-diff/src/inventory.rs
+++ b/crates/starbreaker-diff/src/inventory.rs
@@ -1,0 +1,380 @@
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use starbreaker_datacore::database::Database;
+use starbreaker_p4k::MappedP4k;
+
+use crate::canonical::canonical_record_hash;
+use crate::error::{DiffError, Result};
+use crate::report::{
+    normalize_archive_path, ArchiveEntryInventory, BuildManifestInfo, DataCoreInventory,
+    DataCoreRecordInventory, DataCoreStatus, HashAlgorithms, InventoryMode, InventoryReport,
+    SourceFileInfo, SourceInfo, INVENTORY_SCHEMA_VERSION,
+};
+
+#[derive(Debug, Clone)]
+pub struct InventoryOptions {
+    pub skip_datacore: bool,
+    pub label: Option<String>,
+    pub generated_by: String,
+}
+
+impl Default for InventoryOptions {
+    fn default() -> Self {
+        Self {
+            skip_datacore: false,
+            label: None,
+            generated_by: format!("starbreaker {}", env!("CARGO_PKG_VERSION")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressPhase {
+    OpeningP4k,
+    ReadingArchiveIndex,
+    ReadingDataCore,
+    HashingDataCoreRecords,
+    FinalizingReport,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProgressEvent {
+    pub phase: ProgressPhase,
+    pub current: Option<usize>,
+    pub total: Option<usize>,
+    pub message: String,
+}
+
+pub fn generate_inventory_from_p4k(
+    path: impl AsRef<Path>,
+    options: &InventoryOptions,
+) -> Result<InventoryReport> {
+    generate_inventory_from_p4k_with_progress(path, options, None, None)
+}
+
+pub fn generate_inventory_from_p4k_with_progress(
+    path: impl AsRef<Path>,
+    options: &InventoryOptions,
+    mut progress: Option<&mut dyn FnMut(ProgressEvent)>,
+    cancel: Option<&AtomicBool>,
+) -> Result<InventoryReport> {
+    let path = path.as_ref();
+    report_progress(
+        &mut progress,
+        ProgressPhase::OpeningP4k,
+        None,
+        None,
+        format!("Opening {}", path.display()),
+    );
+    check_cancel(cancel)?;
+    let p4k = MappedP4k::open(path)?;
+
+    report_progress(
+        &mut progress,
+        ProgressPhase::ReadingArchiveIndex,
+        Some(p4k.entries().len()),
+        Some(p4k.entries().len()),
+        "Reading P4k archive index".to_string(),
+    );
+    check_cancel(cancel)?;
+
+    let mut archive: Vec<_> = p4k
+        .entries()
+        .iter()
+        .map(|entry| ArchiveEntryInventory {
+            path: entry.name.clone(),
+            normalized_path: normalize_archive_path(&entry.name),
+            crc32: entry.crc32,
+            compressed_size: entry.compressed_size,
+            uncompressed_size: entry.uncompressed_size,
+            compression_method: entry.compression_method,
+            encrypted: entry.is_encrypted,
+            last_modified: entry.last_modified,
+        })
+        .collect();
+    archive.sort_by(|a, b| a.normalized_path.cmp(&b.normalized_path));
+
+    let mut warnings = Vec::new();
+    let manifest = read_build_manifest(path, &mut warnings);
+    let source_file = source_file_info(path, p4k.entries().len());
+    let label = options
+        .label
+        .clone()
+        .unwrap_or_else(|| default_label(path, source_file.as_ref(), manifest.as_ref()));
+
+    let datacore = if options.skip_datacore {
+        DataCoreInventory {
+            source_path: None,
+            status: DataCoreStatus::Skipped,
+        }
+    } else {
+        report_progress(
+            &mut progress,
+            ProgressPhase::ReadingDataCore,
+            None,
+            None,
+            "Reading DataCore".to_string(),
+        );
+        let (source_path, dcb_bytes) = read_datacore(&p4k)?;
+        check_cancel(cancel)?;
+        let db = Database::from_bytes(&dcb_bytes)?;
+        let records: Vec<_> = db
+            .records()
+            .iter()
+            .filter(|record| db.is_main_record(record))
+            .collect();
+        let total = records.len();
+        let mut inventory = Vec::with_capacity(total);
+        for (idx, record) in records.into_iter().enumerate() {
+            if idx % 250 == 0 {
+                check_cancel(cancel)?;
+                report_progress(
+                    &mut progress,
+                    ProgressPhase::HashingDataCoreRecords,
+                    Some(idx),
+                    Some(total),
+                    "Hashing DataCore records".to_string(),
+                );
+            }
+            let record_type = db
+                .resolve_string2(db.struct_def(record.struct_index).name_offset)
+                .to_string();
+            let name = db.resolve_string2(record.name_offset).to_string();
+            let path = db.resolve_string(record.file_name_offset).to_string();
+            let content_hash = canonical_record_hash(&db, record)?;
+            inventory.push(DataCoreRecordInventory {
+                id: record.id.to_string(),
+                record_type,
+                name,
+                path,
+                content_hash,
+            });
+        }
+        report_progress(
+            &mut progress,
+            ProgressPhase::HashingDataCoreRecords,
+            Some(total),
+            Some(total),
+            "Hashing DataCore records".to_string(),
+        );
+        inventory.sort_by(|a, b| a.id.cmp(&b.id));
+        DataCoreInventory {
+            source_path: Some(source_path),
+            status: DataCoreStatus::Present { records: inventory },
+        }
+    };
+
+    report_progress(
+        &mut progress,
+        ProgressPhase::FinalizingReport,
+        None,
+        None,
+        "Finalizing inventory report".to_string(),
+    );
+
+    let mode = if options.skip_datacore {
+        InventoryMode::P4kOnly
+    } else {
+        InventoryMode::Full
+    };
+    let mut report = InventoryReport {
+        schema_version: INVENTORY_SCHEMA_VERSION,
+        mode,
+        generated_by: options.generated_by.clone(),
+        generated_at_unix: now_unix(),
+        hash_algorithms: HashAlgorithms::default(),
+        source: SourceInfo {
+            label,
+            source_file,
+            build_manifest: manifest,
+            warnings,
+        },
+        archive,
+        datacore,
+        inventory_hash: String::new(),
+    };
+    report.inventory_hash = inventory_hash(&report)?;
+    Ok(report)
+}
+
+pub fn inventory_hash(report: &InventoryReport) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct TechnicalInventory<'a> {
+        schema_version: u32,
+        mode: InventoryMode,
+        hash_algorithms: &'a HashAlgorithms,
+        archive: &'a [ArchiveEntryInventory],
+        datacore: &'a DataCoreInventory,
+    }
+
+    let technical = TechnicalInventory {
+        schema_version: report.schema_version,
+        mode: report.mode,
+        hash_algorithms: &report.hash_algorithms,
+        archive: &report.archive,
+        datacore: &report.datacore,
+    };
+    Ok(format!("blake3:{}", blake3::hash(&serde_json::to_vec(&technical)?)))
+}
+
+fn read_datacore(p4k: &MappedP4k) -> Result<(String, Vec<u8>)> {
+    for path in ["Data\\Game2.dcb", "Data\\Game.dcb"] {
+        match p4k.read_file(path) {
+            Ok(bytes) => return Ok((path.to_string(), bytes)),
+            Err(starbreaker_p4k::P4kError::EntryNotFound(_)) => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Err(DiffError::DataCoreNotFound)
+}
+
+fn source_file_info(path: &Path, entry_count: usize) -> Option<SourceFileInfo> {
+    let metadata = fs::metadata(path).ok()?;
+    Some(SourceFileInfo {
+        path_hint: path.display().to_string(),
+        size: Some(metadata.len()),
+        modified_unix: metadata.modified().ok().and_then(system_time_unix),
+        entry_count,
+    })
+}
+
+fn read_build_manifest(path: &Path, warnings: &mut Vec<String>) -> Option<BuildManifestInfo> {
+    let manifest_path = path.parent()?.join("build_manifest.id");
+    let text = match fs::read_to_string(&manifest_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            warnings.push(format!(
+                "Failed to read build_manifest.id at {}: {err}",
+                manifest_path.display()
+            ));
+            return None;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(value) => value,
+        Err(err) => {
+            warnings.push(format!(
+                "Failed to parse build_manifest.id at {}: {err}",
+                manifest_path.display()
+            ));
+            return None;
+        }
+    };
+    let data = &value["Data"];
+    let branch = data
+        .get("Branch")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned);
+    let version = branch.as_deref().and_then(parse_version);
+    let requested_p4_change_num = data
+        .get("RequestedP4ChangeNum")
+        .and_then(|value| value.as_u64().or_else(|| value.as_str()?.parse().ok()));
+    let channel_hint = path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned);
+    Some(BuildManifestInfo {
+        branch,
+        version,
+        requested_p4_change_num,
+        channel_hint,
+    })
+}
+
+fn parse_version(branch: &str) -> Option<String> {
+    let bytes = branch.as_bytes();
+    for start in 0..bytes.len() {
+        if !bytes[start].is_ascii_digit() {
+            continue;
+        }
+        let rest = &branch[start..];
+        let mut parts = rest.splitn(4, '.');
+        let a = parts.next()?;
+        let b = parts.next()?;
+        let c_rest = parts.next()?;
+        if a.is_empty()
+            || b.is_empty()
+            || !a.bytes().all(|b| b.is_ascii_digit())
+            || !b.bytes().all(|b| b.is_ascii_digit())
+        {
+            continue;
+        }
+        let c: String = c_rest
+            .chars()
+            .take_while(|ch| ch.is_ascii_digit())
+            .collect();
+        if c.is_empty() {
+            continue;
+        }
+        return Some(format!("{a}.{b}.{c}"));
+    }
+    None
+}
+
+fn default_label(
+    path: &Path,
+    source_file: Option<&SourceFileInfo>,
+    manifest: Option<&BuildManifestInfo>,
+) -> String {
+    if let Some(manifest) = manifest {
+        if let Some(version) = &manifest.version {
+            let channel = manifest.channel_hint.as_deref().unwrap_or("SC");
+            if let Some(build) = manifest.requested_p4_change_num {
+                return format!("{version} {channel}.{build}");
+            }
+            return format!("{version} {channel}");
+        }
+        if let Some(branch) = &manifest.branch {
+            return branch.clone();
+        }
+    }
+
+    if let Some(parent) = path.parent().and_then(|parent| parent.file_name()).and_then(|s| s.to_str())
+        && let Some(source_file) = source_file
+        && let Some(modified) = source_file.modified_unix
+    {
+        return format!("{parent} Data.p4k {modified}");
+    }
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("Data.p4k")
+        .to_string()
+}
+
+fn check_cancel(cancel: Option<&AtomicBool>) -> Result<()> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+        Err(DiffError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+fn report_progress(
+    progress: &mut Option<&mut dyn FnMut(ProgressEvent)>,
+    phase: ProgressPhase,
+    current: Option<usize>,
+    total: Option<usize>,
+    message: String,
+) {
+    if let Some(progress) = progress {
+        progress(ProgressEvent {
+            phase,
+            current,
+            total,
+            message,
+        });
+    }
+}
+
+fn now_unix() -> u64 {
+    system_time_unix(SystemTime::now()).unwrap_or(0)
+}
+
+fn system_time_unix(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH).ok().map(|duration| duration.as_secs())
+}

--- a/crates/starbreaker-diff/src/lib.rs
+++ b/crates/starbreaker-diff/src/lib.rs
@@ -9,7 +9,7 @@ pub mod report;
 
 pub use compare::{compare_reports, DiffItem, DiffSide, DiffSummary};
 pub use error::{DiffError, Result};
-pub use filter::{filter_diff_items, DiffFilter};
+pub use filter::{diff_item_matches_filter, filter_diff_items, DiffFilter};
 pub use inventory::{
     generate_inventory_from_p4k, generate_inventory_from_p4k_with_progress, InventoryOptions,
     ProgressEvent, ProgressPhase,

--- a/crates/starbreaker-diff/src/lib.rs
+++ b/crates/starbreaker-diff/src/lib.rs
@@ -4,6 +4,7 @@ pub mod compare;
 pub mod error;
 pub mod filter;
 pub mod inventory;
+pub mod page;
 pub mod report;
 
 pub use compare::{compare_reports, DiffItem, DiffSide, DiffSummary};
@@ -13,6 +14,7 @@ pub use inventory::{
     generate_inventory_from_p4k, generate_inventory_from_p4k_with_progress, InventoryOptions,
     ProgressEvent, ProgressPhase,
 };
+pub use page::{compare_report_page, DiffPage};
 pub use report::{
     ArchiveEntryInventory, BuildManifestInfo, DataCoreInventory, DataCoreRecordInventory,
     DataCoreStatus, DiffReport, HashAlgorithms, InventoryMode, InventoryReport, SourceFileInfo,

--- a/crates/starbreaker-diff/src/lib.rs
+++ b/crates/starbreaker-diff/src/lib.rs
@@ -1,0 +1,20 @@
+mod canonical;
+
+pub mod compare;
+pub mod error;
+pub mod filter;
+pub mod inventory;
+pub mod report;
+
+pub use compare::{compare_reports, DiffItem, DiffSide, DiffSummary};
+pub use error::{DiffError, Result};
+pub use filter::{filter_diff_items, DiffFilter};
+pub use inventory::{
+    generate_inventory_from_p4k, generate_inventory_from_p4k_with_progress, InventoryOptions,
+    ProgressEvent, ProgressPhase,
+};
+pub use report::{
+    ArchiveEntryInventory, BuildManifestInfo, DataCoreInventory, DataCoreRecordInventory,
+    DataCoreStatus, DiffReport, HashAlgorithms, InventoryMode, InventoryReport, SourceFileInfo,
+    SourceInfo, Tier,
+};

--- a/crates/starbreaker-diff/src/page.rs
+++ b/crates/starbreaker-diff/src/page.rs
@@ -1,0 +1,252 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::compare::{
+    archive_item_for_key, datacore_item_for_key, DiffItem, DiffStatus, DiffSummary,
+};
+use crate::filter::{diff_item_matches_filter, DiffFilter};
+use crate::report::{
+    ArchiveEntryInventory, DataCoreRecordInventory, InventoryReport, Tier, DIFF_SCHEMA_VERSION,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffPage {
+    pub schema_version: u32,
+    pub old_label: String,
+    pub new_label: String,
+    pub old_inventory_hash: String,
+    pub new_inventory_hash: String,
+    pub summary: DiffSummary,
+    pub total_matching: usize,
+    pub offset: usize,
+    pub limit: usize,
+    pub items: Vec<DiffItem>,
+}
+
+pub fn compare_report_page(
+    old: &InventoryReport,
+    new: &InventoryReport,
+    filter: &DiffFilter,
+    offset: usize,
+    limit: usize,
+) -> DiffPage {
+    let archive_old_map: BTreeMap<_, _> = old
+        .archive
+        .iter()
+        .map(|entry| (entry.normalized_path.clone(), entry))
+        .collect();
+    let archive_new_map: BTreeMap<_, _> = new
+        .archive
+        .iter()
+        .map(|entry| (entry.normalized_path.clone(), entry))
+        .collect();
+    let archive_keys = sorted_keys(&archive_old_map, &archive_new_map);
+
+    let datacore_old_map: BTreeMap<_, _> = old
+        .datacore
+        .status
+        .records()
+        .iter()
+        .map(|record| (record.id.clone(), record))
+        .collect();
+    let datacore_new_map: BTreeMap<_, _> = new
+        .datacore
+        .status
+        .records()
+        .iter()
+        .map(|record| (record.id.clone(), record))
+        .collect();
+    let datacore_keys = sorted_keys(&datacore_old_map, &datacore_new_map);
+
+    let summary = summarize(
+        &archive_keys,
+        &archive_old_map,
+        &archive_new_map,
+        &datacore_keys,
+        &datacore_old_map,
+        &datacore_new_map,
+    );
+    let (total_matching, items) = page_items(
+        &archive_keys,
+        &archive_old_map,
+        &archive_new_map,
+        &datacore_keys,
+        &datacore_old_map,
+        &datacore_new_map,
+        filter,
+        offset,
+        limit.max(1),
+    );
+
+    DiffPage {
+        schema_version: DIFF_SCHEMA_VERSION,
+        old_label: old.source.label.clone(),
+        new_label: new.source.label.clone(),
+        old_inventory_hash: old.inventory_hash.clone(),
+        new_inventory_hash: new.inventory_hash.clone(),
+        summary,
+        total_matching,
+        offset,
+        limit: limit.max(1),
+        items,
+    }
+}
+
+fn sorted_keys<T>(
+    old_map: &BTreeMap<String, &T>,
+    new_map: &BTreeMap<String, &T>,
+) -> Vec<String> {
+    let mut keys: Vec<_> = old_map.keys().chain(new_map.keys()).cloned().collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+fn summarize(
+    archive_keys: &[String],
+    archive_old_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    archive_new_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    datacore_keys: &[String],
+    datacore_old_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    datacore_new_map: &BTreeMap<String, &DataCoreRecordInventory>,
+) -> DiffSummary {
+    let mut summary = DiffSummary::default();
+    for key in archive_keys {
+        summary.add(&archive_item_for_key(
+            key.clone(),
+            archive_old_map,
+            archive_new_map,
+        ));
+    }
+    for key in datacore_keys {
+        summary.add(&datacore_item_for_key(
+            key.clone(),
+            datacore_old_map,
+            datacore_new_map,
+        ));
+    }
+    summary
+}
+
+fn page_items(
+    archive_keys: &[String],
+    archive_old_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    archive_new_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    datacore_keys: &[String],
+    datacore_old_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    datacore_new_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    filter: &DiffFilter,
+    offset: usize,
+    limit: usize,
+) -> (usize, Vec<DiffItem>) {
+    let mut total_matching = 0usize;
+    let mut items = Vec::new();
+    let wanted_statuses = ordered_statuses(filter);
+    let wanted_tiers = ordered_tiers(filter);
+
+    for status in wanted_statuses {
+        for tier in &wanted_tiers {
+            match tier {
+                Tier::P4k => page_archive_items(
+                    status,
+                    archive_keys,
+                    archive_old_map,
+                    archive_new_map,
+                    filter,
+                    offset,
+                    limit,
+                    &mut total_matching,
+                    &mut items,
+                ),
+                Tier::DataCore => page_datacore_items(
+                    status,
+                    datacore_keys,
+                    datacore_old_map,
+                    datacore_new_map,
+                    filter,
+                    offset,
+                    limit,
+                    &mut total_matching,
+                    &mut items,
+                ),
+            }
+        }
+    }
+
+    (total_matching, items)
+}
+
+fn page_archive_items(
+    status: DiffStatus,
+    keys: &[String],
+    old_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    new_map: &BTreeMap<String, &ArchiveEntryInventory>,
+    filter: &DiffFilter,
+    offset: usize,
+    limit: usize,
+    total_matching: &mut usize,
+    items: &mut Vec<DiffItem>,
+) {
+    for key in keys {
+        let item = archive_item_for_key(key.clone(), old_map, new_map);
+        push_page_item(status, item, filter, offset, limit, total_matching, items);
+    }
+}
+
+fn page_datacore_items(
+    status: DiffStatus,
+    keys: &[String],
+    old_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    new_map: &BTreeMap<String, &DataCoreRecordInventory>,
+    filter: &DiffFilter,
+    offset: usize,
+    limit: usize,
+    total_matching: &mut usize,
+    items: &mut Vec<DiffItem>,
+) {
+    for key in keys {
+        let item = datacore_item_for_key(key.clone(), old_map, new_map);
+        push_page_item(status, item, filter, offset, limit, total_matching, items);
+    }
+}
+
+fn push_page_item(
+    status: DiffStatus,
+    item: DiffItem,
+    filter: &DiffFilter,
+    offset: usize,
+    limit: usize,
+    total_matching: &mut usize,
+    items: &mut Vec<DiffItem>,
+) {
+    if item.status != status || !diff_item_matches_filter(&item, filter) {
+        return;
+    }
+    if *total_matching >= offset && items.len() < limit {
+        items.push(item);
+    }
+    *total_matching += 1;
+}
+
+fn ordered_statuses(filter: &DiffFilter) -> Vec<DiffStatus> {
+    let statuses = [
+        DiffStatus::Added,
+        DiffStatus::Removed,
+        DiffStatus::Modified,
+        DiffStatus::MetadataChanged,
+        DiffStatus::Unchanged,
+    ];
+    statuses
+        .into_iter()
+        .filter(|status| filter.statuses.is_empty() || filter.statuses.contains(status))
+        .collect()
+}
+
+fn ordered_tiers(filter: &DiffFilter) -> Vec<Tier> {
+    let tiers = [Tier::P4k, Tier::DataCore];
+    tiers
+        .into_iter()
+        .filter(|tier| filter.tiers.is_empty() || filter.tiers.contains(tier))
+        .collect()
+}

--- a/crates/starbreaker-diff/src/report.rs
+++ b/crates/starbreaker-diff/src/report.rs
@@ -1,0 +1,169 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+pub const INVENTORY_SCHEMA_VERSION: u32 = 1;
+pub const DIFF_SCHEMA_VERSION: u32 = 1;
+pub const INVENTORY_EXTENSION: &str = ".starbreaker-inventory.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InventoryMode {
+    Full,
+    P4kOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Tier {
+    P4k,
+    DataCore,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashAlgorithms {
+    pub inventory_hash: String,
+    pub archive_identity: String,
+    pub datacore_hash: String,
+}
+
+impl Default for HashAlgorithms {
+    fn default() -> Self {
+        Self {
+            inventory_hash: "blake3-inventory-v1".to_string(),
+            archive_identity: "zip-crc32-size-v1".to_string(),
+            datacore_hash: "starbreaker-dcb-canonical-json-v1".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceFileInfo {
+    pub path_hint: String,
+    pub size: Option<u64>,
+    pub modified_unix: Option<u64>,
+    pub entry_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildManifestInfo {
+    pub branch: Option<String>,
+    pub version: Option<String>,
+    pub requested_p4_change_num: Option<u64>,
+    pub channel_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceInfo {
+    pub label: String,
+    pub source_file: Option<SourceFileInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_manifest: Option<BuildManifestInfo>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArchiveEntryInventory {
+    pub path: String,
+    pub normalized_path: String,
+    pub crc32: u32,
+    pub compressed_size: u64,
+    pub uncompressed_size: u64,
+    pub compression_method: u16,
+    pub encrypted: bool,
+    pub last_modified: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataCoreRecordInventory {
+    pub id: String,
+    pub record_type: String,
+    pub name: String,
+    pub path: String,
+    pub content_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum DataCoreStatus {
+    Present { records: Vec<DataCoreRecordInventory> },
+    Skipped,
+}
+
+impl DataCoreStatus {
+    pub fn records(&self) -> &[DataCoreRecordInventory] {
+        match self {
+            Self::Present { records } => records,
+            Self::Skipped => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataCoreInventory {
+    pub source_path: Option<String>,
+    #[serde(flatten)]
+    pub status: DataCoreStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InventoryReport {
+    pub schema_version: u32,
+    pub mode: InventoryMode,
+    pub generated_by: String,
+    pub generated_at_unix: u64,
+    pub hash_algorithms: HashAlgorithms,
+    pub source: SourceInfo,
+    pub archive: Vec<ArchiveEntryInventory>,
+    pub datacore: DataCoreInventory,
+    pub inventory_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffReport {
+    pub schema_version: u32,
+    pub old_label: String,
+    pub new_label: String,
+    pub old_inventory_hash: String,
+    pub new_inventory_hash: String,
+    pub summary: crate::compare::DiffSummary,
+    pub items: Vec<crate::compare::DiffItem>,
+}
+
+pub fn normalize_archive_path(path: &str) -> String {
+    path.replace('/', "\\")
+        .trim_start_matches('\\')
+        .to_ascii_lowercase()
+}
+
+pub fn extension_for_path(path: &str) -> Option<String> {
+    let file_name = path.rsplit(['\\', '/']).next().unwrap_or(path);
+    file_name
+        .rsplit_once('.')
+        .map(|(_, ext)| format!(".{}", ext.to_ascii_lowercase()))
+}
+
+pub fn read_inventory_report(path: impl AsRef<std::path::Path>) -> Result<InventoryReport> {
+    let bytes = std::fs::read(path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+pub fn write_inventory_report(
+    path: impl AsRef<std::path::Path>,
+    report: &InventoryReport,
+) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(report)?;
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+pub fn read_diff_report(path: impl AsRef<std::path::Path>) -> Result<DiffReport> {
+    let bytes = std::fs::read(path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+pub fn write_diff_report(path: impl AsRef<std::path::Path>, report: &DiffReport) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(report)?;
+    std::fs::write(path, bytes)?;
+    Ok(())
+}

--- a/crates/starbreaker-diff/tests/compare.rs
+++ b/crates/starbreaker-diff/tests/compare.rs
@@ -1,0 +1,142 @@
+use starbreaker_diff::compare::DiffStatus;
+use starbreaker_diff::inventory::inventory_hash;
+use starbreaker_diff::report::{
+    ArchiveEntryInventory, DataCoreInventory, DataCoreRecordInventory, DataCoreStatus,
+    HashAlgorithms, InventoryMode, InventoryReport, SourceInfo, Tier, INVENTORY_SCHEMA_VERSION,
+};
+use starbreaker_diff::{compare_reports, DiffFilter};
+
+fn report(
+    label: &str,
+    archive: Vec<ArchiveEntryInventory>,
+    records: Vec<DataCoreRecordInventory>,
+) -> InventoryReport {
+    let mut report = InventoryReport {
+        schema_version: INVENTORY_SCHEMA_VERSION,
+        mode: InventoryMode::Full,
+        generated_by: "test".to_string(),
+        generated_at_unix: 1,
+        hash_algorithms: HashAlgorithms::default(),
+        source: SourceInfo {
+            label: label.to_string(),
+            source_file: None,
+            build_manifest: None,
+            warnings: Vec::new(),
+        },
+        archive,
+        datacore: DataCoreInventory {
+            source_path: Some("Data\\Game2.dcb".to_string()),
+            status: DataCoreStatus::Present { records },
+        },
+        inventory_hash: String::new(),
+    };
+    report.inventory_hash = inventory_hash(&report).unwrap();
+    report
+}
+
+fn archive(path: &str, crc32: u32, uncompressed_size: u64) -> ArchiveEntryInventory {
+    ArchiveEntryInventory {
+        path: path.to_string(),
+        normalized_path: starbreaker_diff::report::normalize_archive_path(path),
+        crc32,
+        compressed_size: uncompressed_size / 2,
+        uncompressed_size,
+        compression_method: 100,
+        encrypted: true,
+        last_modified: 10,
+    }
+}
+
+fn record(id: &str, name: &str, record_type: &str, hash: &str) -> DataCoreRecordInventory {
+    DataCoreRecordInventory {
+        id: id.to_string(),
+        record_type: record_type.to_string(),
+        name: name.to_string(),
+        path: format!("libs/foundry/records/{name}.xml"),
+        content_hash: hash.to_string(),
+    }
+}
+
+#[test]
+fn classifies_archive_and_datacore_changes() {
+    let old = report(
+        "old",
+        vec![archive("Data\\a.dds", 1, 10), archive("Data\\b.xml", 2, 20)],
+        vec![record("guid-a", "Alpha", "EntityClassDefinition", "hash-a")],
+    );
+    let new = report(
+        "new",
+        vec![archive("data/a.dds", 1, 10), archive("Data\\b.xml", 3, 20)],
+        vec![record("guid-a", "AlphaRenamed", "EntityClassDefinition", "hash-a")],
+    );
+
+    let diff = compare_reports(&old, &new, true);
+
+    let file_a = diff.items.iter().find(|item| item.key == "data\\a.dds").unwrap();
+    assert_eq!(file_a.status, DiffStatus::MetadataChanged);
+    assert!(file_a.reasons.contains(&"path_case_changed".to_string()));
+
+    let file_b = diff.items.iter().find(|item| item.key == "data\\b.xml").unwrap();
+    assert_eq!(file_b.status, DiffStatus::Modified);
+    assert!(file_b.reasons.contains(&"crc32_changed".to_string()));
+
+    let dc = diff.items.iter().find(|item| item.key == "guid-a").unwrap();
+    assert_eq!(dc.status, DiffStatus::MetadataChanged);
+    assert!(dc.reasons.contains(&"name_changed".to_string()));
+}
+
+#[test]
+fn inventory_hash_excludes_label_and_generated_time() {
+    let mut a = report("first", vec![archive("Data\\a.dds", 1, 10)], Vec::new());
+    let mut b = a.clone();
+    b.source.label = "second".to_string();
+    b.generated_at_unix = 999;
+    a.inventory_hash = inventory_hash(&a).unwrap();
+    b.inventory_hash = inventory_hash(&b).unwrap();
+
+    assert_eq!(a.inventory_hash, b.inventory_hash);
+
+    b.archive[0].crc32 = 42;
+    b.inventory_hash = inventory_hash(&b).unwrap();
+    assert_ne!(a.inventory_hash, b.inventory_hash);
+}
+
+#[test]
+fn filters_use_shared_semantics() {
+    let old = report(
+        "old",
+        vec![archive("Data\\Textures\\a.dds", 1, 10)],
+        vec![record("guid-a", "Aurora", "EntityClassDefinition", "hash-a")],
+    );
+    let new = report(
+        "new",
+        vec![archive("Data\\Textures\\a.dds", 2, 10)],
+        vec![record("guid-a", "Aurora", "EntityClassDefinition", "hash-b")],
+    );
+    let diff = compare_reports(&old, &new, true);
+
+    let filtered = starbreaker_diff::filter_diff_items(
+        &diff.items,
+        &DiffFilter {
+            search: Some("aurora".to_string()),
+            tiers: vec![Tier::DataCore],
+            statuses: vec![DiffStatus::Modified],
+            include_unchanged: true,
+            ..DiffFilter::default()
+        },
+    );
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].tier, Tier::DataCore);
+}
+
+#[test]
+fn summary_counts_unchanged_even_when_rows_are_omitted() {
+    let old = report("old", vec![archive("Data\\a.dds", 1, 10)], Vec::new());
+    let new = report("new", vec![archive("Data\\a.dds", 1, 10)], Vec::new());
+
+    let diff = compare_reports(&old, &new, false);
+
+    assert_eq!(diff.summary.unchanged, 1);
+    assert!(diff.items.is_empty());
+}

--- a/crates/starbreaker-diff/tests/compare.rs
+++ b/crates/starbreaker-diff/tests/compare.rs
@@ -4,7 +4,7 @@ use starbreaker_diff::report::{
     ArchiveEntryInventory, DataCoreInventory, DataCoreRecordInventory, DataCoreStatus,
     HashAlgorithms, InventoryMode, InventoryReport, SourceInfo, Tier, INVENTORY_SCHEMA_VERSION,
 };
-use starbreaker_diff::{compare_reports, DiffFilter};
+use starbreaker_diff::{compare_report_page, compare_reports, DiffFilter};
 
 fn report(
     label: &str,
@@ -139,4 +139,44 @@ fn summary_counts_unchanged_even_when_rows_are_omitted() {
 
     assert_eq!(diff.summary.unchanged, 1);
     assert!(diff.items.is_empty());
+}
+
+#[test]
+fn paged_compare_counts_all_matches_but_returns_requested_window() {
+    let old = report(
+        "old",
+        vec![
+            archive("Data\\a.dds", 1, 10),
+            archive("Data\\b.dds", 2, 20),
+            archive("Data\\c.txt", 3, 30),
+        ],
+        Vec::new(),
+    );
+    let new = report(
+        "new",
+        vec![
+            archive("Data\\a.dds", 9, 10),
+            archive("Data\\b.dds", 8, 20),
+            archive("Data\\c.txt", 7, 30),
+        ],
+        Vec::new(),
+    );
+
+    let page = compare_report_page(
+        &old,
+        &new,
+        &DiffFilter {
+            extensions: vec![".dds".to_string()],
+            statuses: vec![DiffStatus::Modified],
+            include_unchanged: false,
+            ..DiffFilter::default()
+        },
+        1,
+        1,
+    );
+
+    assert_eq!(page.summary.modified, 3);
+    assert_eq!(page.total_matching, 2);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].key, "data\\b.dds");
 }

--- a/docs/diff-viewer-design.md
+++ b/docs/diff-viewer-design.md
@@ -1,0 +1,452 @@
+# P4k and DataCore Diff Viewer Design
+
+## Goal
+
+StarBreaker should provide a user-friendly way to compare Star Citizen
+`Data.p4k` versions across both the CLI and the Tauri app.
+
+The feature answers two questions:
+
+- which files inside the P4k were added, removed, modified, or changed only in
+  archive metadata
+- which DataCore records were added, removed, modified, or changed only in
+  display metadata
+
+The CLI and GUI must use the same core diff engine and report schema so their
+results stay in parity.
+
+## Non-Goals
+
+Version 1 does not compute arbitrary file content diffs. It does not
+decompress and compare every changed binary, texture, geometry, XML, Wwise
+asset, or other file payload.
+
+Version 1 also does not provide multi-version timeline diffing, first-class
+rename detection, or a custom query language.
+
+Future versions may use the changed-file list to open selected files or
+DataCore records side by side when the original sources are available.
+
+## Architecture
+
+Add a shared Rust crate, tentatively `crates/starbreaker-diff`.
+
+The crate owns:
+
+- inventory report schema
+- diff result schema
+- P4k archive inventory generation
+- DataCore record inventory generation
+- canonical DataCore hashing
+- report JSON read/write
+- report comparison
+- shared filter predicates
+- progress and cancellation hooks
+
+The crate does not own:
+
+- CLI table rendering
+- Tauri DTOs beyond serializable domain structs
+- React state, layout, icons, colors, or labels
+- persistent GUI cache policy
+
+Thin adapters call the crate:
+
+- `cli/src/diff.rs` exposes commands and terminal formatting
+- `app/src-tauri/src/diff_commands.rs` exposes Tauri commands and progress
+  events
+- `app/src/views/diff-view.tsx` renders the interactive diff view
+
+## Inventory Reports
+
+Inventory reports are reusable, portable JSON snapshots named:
+
+```text
+*.starbreaker-inventory.json
+```
+
+Reports include all archive entries and, unless skipped, all DataCore records.
+They are not just changed-item outputs.
+
+Reports are plain JSON in version 1. If real reports become too large,
+`*.starbreaker-inventory.json.gz` can be added later without changing the core
+schema model.
+
+### Report Metadata
+
+Reports include technical provenance and schema metadata:
+
+- `schema_version`
+- `mode`
+- `generated_by`
+- `generated_at`
+- `hash_algorithms`
+- `source_file`
+- optional `build_manifest`
+- optional display `label`
+- `inventory_hash`
+
+`label`, source path, source modified time, and generation time are display or
+provenance metadata. They are not part of `inventory_hash`.
+
+`inventory_hash` is a stable technical hash over normalized inventory content
+and hash algorithm identifiers. It should not change when a user renames a
+source label.
+
+### Source Labels
+
+When the source is a `Data.p4k`, StarBreaker should look for
+`build_manifest.id` beside it. If found and valid, parse:
+
+- `Data.Branch`
+- first `x.y.z` version pattern from the branch string, when present
+- `Data.RequestedP4ChangeNum`
+- channel hint from the parent folder name, such as `LIVE`, `PTU`, or `HOTFIX`
+
+The default label order is:
+
+1. user-provided label
+2. parsed manifest label, such as `4.7.0 LIVE.123456`
+3. parent folder plus source modified date
+4. `Data.p4k`
+
+Missing `build_manifest.id` is normal and must not fail inventory generation.
+Invalid manifest JSON should produce a warning and fall back to the next label
+strategy.
+
+### Inventory Modes
+
+Default mode is full inventory:
+
+- archive entries
+- DataCore records
+
+An explicit advanced mode may skip DataCore:
+
+- CLI flag: `--skip-datacore`
+- report mode: `p4k_only`
+- GUI wording: `Skip DataCore record inventory`
+
+If DataCore is not skipped, missing or unparseable DataCore is an inventory
+failure. Star Citizen `Data.p4k` is expected to contain readable DataCore data;
+failure likely means the game format changed or StarBreaker cannot read the
+archive correctly.
+
+## P4k Archive Inventory
+
+Archive inventory uses central-directory metadata and does not read or
+decompress every file.
+
+For each file entry, store:
+
+- original path
+- normalized path key
+- CRC32
+- compressed size
+- uncompressed size
+- compression method
+- encrypted flag
+- last modified value, if available
+
+The existing P4k layer already exposes `name`, `compressed_size`,
+`uncompressed_size`, `compression_method`, `is_encrypted`, `crc32`, and
+`last_modified`.
+
+### Archive Identity
+
+Archive content identity is based on:
+
+- `crc32`
+- `uncompressed_size`
+
+If a stronger archive-provided content hash is exposed later, it can be added
+with a new versioned archive identity algorithm.
+
+Full-file hashing of `Data.p4k` is intentionally avoided. The report's
+technical identity is the inventory hash, not a cryptographic hash of the
+massive source archive.
+
+### Archive Path Matching
+
+Archive paths match by normalized identity:
+
+- normalize separators
+- match case-insensitively
+- preserve original spelling for display
+
+If only path spelling, casing, or separator style changes, do not show the file
+as added and removed. Match it as the same entry and record a metadata/path
+reason.
+
+### Archive Status
+
+Archive statuses:
+
+- `added`: normalized path exists only in new
+- `removed`: normalized path exists only in old
+- `modified`: same normalized path exists in both, but content identity changed
+- `metadata_changed`: content identity is unchanged, but metadata changed
+- `unchanged`: no relevant change
+
+Archive change reasons may include:
+
+- `crc32_changed`
+- `uncompressed_size_changed`
+- `compressed_size_changed`
+- `compression_method_changed`
+- `encrypted_changed`
+- `last_modified_changed`
+- `path_case_changed`
+- `path_separator_changed`
+
+`last_modified` alone must not make a file content-modified.
+
+Version 1 does not classify renames. A removed path and added path remain
+separate changes, even if their content identity matches. Later versions may
+show possible move/copy hints.
+
+## DataCore Inventory
+
+DataCore inventory stores one entry per main DataCore record.
+
+For each record, store:
+
+- GUID identity key
+- record type / struct name
+- record name
+- record file path
+- canonical content hash
+
+The GUID is the comparison key. It is not included in the content hash.
+
+Record name and file path are display metadata. They are not included in the
+content hash.
+
+The record type is part of the canonical content hash because a type change
+changes how the payload should be interpreted.
+
+### Canonical DataCore Hashing
+
+DataCore hashes must represent decoded semantic content, not raw byte spans in
+the DCB.
+
+The canonical hash includes:
+
+- type identity
+- property names and types
+- primitive values
+- arrays in stored order
+- strings resolved to text
+- enum values resolved to names
+- GUID values
+- references represented by referenced GUIDs
+
+The canonical hash excludes:
+
+- record GUID
+- record display name
+- record file path
+- source path
+- report label
+- generation time
+
+References are not recursively expanded. If record A references record B and B
+changes, only B is modified unless A changes its own referenced GUID or other
+stored content.
+
+Use a versioned algorithm name, for example
+`starbreaker-dcb-canonical-v1`, and a strong hash such as BLAKE3 or SHA-256.
+
+### DataCore Status
+
+DataCore statuses:
+
+- `added`: GUID exists only in new
+- `removed`: GUID exists only in old
+- `modified`: GUID exists in both and canonical content hash changed
+- `metadata_changed`: content hash is unchanged, but display name or record
+  path changed
+- `unchanged`: no relevant change
+
+If record type changes, classify it as `modified` with reason `type_changed`.
+
+DataCore change reasons may include:
+
+- `content_hash_changed`
+- `type_changed`
+- `name_changed`
+- `path_changed`
+
+## Diff Results
+
+Saved diff results are optional and named:
+
+```text
+*.starbreaker-diff.json
+```
+
+The GUI normally computes diffs in memory from two inventories. Users can
+export a saved diff result when they need to share or script against it.
+
+Saved diff results include:
+
+- schema version
+- old/new source summaries
+- old/new inventory hashes
+- summary counts
+- changed items by default
+- filter/output metadata, if generated with filters
+
+Unchanged items are omitted from saved diff files by default. A CLI flag such
+as `--include-unchanged` may include them.
+
+## CLI Design
+
+Add a top-level `diff` command with separate subcommands:
+
+```text
+starbreaker diff inventory <SOURCE> -o <REPORT> [--skip-datacore] [--label <LABEL>]
+starbreaker diff compare <OLD> <NEW> [-o <DIFF>] [filters...]
+```
+
+`<SOURCE>` for inventory is normally `Data.p4k`.
+
+`<OLD>` and `<NEW>` for compare may each be:
+
+- a `Data.p4k`
+- a `*.starbreaker-inventory.json`
+
+If compare receives a P4k source, it generates a temporary inventory in memory.
+
+Recommended compare filters:
+
+- `--tier all|p4k|datacore`
+- `--status added,removed,modified,metadata,unchanged`
+- `--search <text>`
+- `--extension <ext>`
+- `--record-type <type>`
+- `--path-prefix <prefix>`
+- `--include-unchanged`
+- `--format table|json`
+
+Progress should be written to stderr. Machine-readable JSON should go to stdout
+or the file specified by `-o`.
+
+## GUI Design
+
+Add a Diff view with two source slots:
+
+- Old
+- New
+
+Each slot accepts either:
+
+- `Data.p4k`
+- `*.starbreaker-inventory.json`
+
+If a slot receives a P4k, the app generates an inventory first. The generated
+inventory is cached in memory for the current session. It is persisted only
+when the user explicitly chooses to save it.
+
+Inventory generation runs as a cancellable background task with progress
+events:
+
+- opening P4k
+- reading archive index
+- reading DataCore
+- hashing DataCore records
+- writing report, if requested
+
+The main result view is one unified table rather than separate archive and
+DataCore screens.
+
+Recommended layout:
+
+- source summary bar for old/new
+- summary counts for added, removed, modified, metadata-only, unchanged
+- facet rail for tier, status, extension, record type, and path prefix
+- virtualized result table
+- detail panel for selected item metadata and change reasons
+
+The table should support simple text search plus explicit facets. Do not build
+a custom query language in version 1.
+
+Text search should match:
+
+- archive path
+- archive filename
+- archive extension
+- DataCore record name
+- DataCore record type
+- DataCore record path
+- DataCore GUID
+
+Large result sets require virtualization from the first implementation.
+
+## Shared Filters
+
+Filter semantics belong in `starbreaker-diff` so CLI and GUI stay consistent.
+The GUI owns view state and rendering.
+
+Shared filters should cover:
+
+- text search
+- tier
+- status
+- extension
+- record type
+- path prefix
+- include unchanged
+
+## Sorting and Stability
+
+Reports preserve original display values but sort entries canonically.
+
+Recommended report order:
+
+- archive entries by normalized path
+- DataCore records by GUID
+
+The GUI may sort differently for display.
+
+Stable sorting keeps report JSON deterministic, makes inventory hashes
+repeatable, and makes tests easier to reason about.
+
+## Testing Strategy
+
+Automated tests should not require real Star Citizen P4k files.
+
+Test `starbreaker-diff` with small and synthetic fixtures:
+
+- report JSON roundtrip
+- inventory hash stability
+- label and timestamp excluded from inventory hash
+- archive added/removed/modified/metadata-only statuses
+- DataCore added/removed/modified/metadata-only statuses
+- path normalization and case handling
+- skip-DataCore mode compatibility
+- filter semantics
+- saved diff omission of unchanged items by default
+
+If practical, add tiny archive fixture tests for P4k central-directory metadata.
+If practical, use existing DataCore builder/test helpers to generate tiny DCB
+fixtures for canonical hashing tests.
+
+Real P4k validation should be manual or env-gated, for example:
+
+```text
+SC_DATA_P4K=... cargo test -p starbreaker-diff -- --ignored
+```
+
+## Future Work
+
+Possible future extensions:
+
+- selected file side-by-side viewers
+- selected DataCore record field diffs
+- possible rename/move/copy hints
+- gzip-compressed reports
+- persistent GUI inventory cache with invalidation
+- multi-version timeline comparison
+- advanced query syntax
+- MCP tools for inventory and report inspection

--- a/docs/diff-viewer-prd.md
+++ b/docs/diff-viewer-prd.md
@@ -1,0 +1,343 @@
+# Diff Viewer PRD
+
+## Problem Statement
+
+Star Citizen updates change both raw files inside `Data.p4k` and structured
+records inside DataCore. StarBreaker users need a fast, understandable way to
+compare two game versions without extracting or line-diffing the entire
+archive.
+
+Today a user can browse P4k files and DataCore records, but they cannot produce
+a reusable inventory snapshot or answer "what changed between these two
+versions?" from either the CLI or the GUI.
+
+## Solution
+
+Build a shared diff engine that inventories P4k archive entries and DataCore
+records, writes portable inventory reports, compares two sources or reports,
+and exposes the same results through the CLI and Tauri GUI.
+
+The first version focuses on change discovery:
+
+- P4k file added, removed, modified, metadata-only, unchanged
+- DataCore record added, removed, modified, metadata-only, unchanged
+- searchable and filterable results
+- reusable `*.starbreaker-inventory.json` reports
+- optional `*.starbreaker-diff.json` outputs
+
+Full file content diffing and side-by-side viewers are future work.
+
+## User Stories
+
+1. As a StarBreaker CLI user, I want to generate an inventory report from a
+   `Data.p4k`, so that I can reuse it for later comparisons.
+2. As a StarBreaker GUI user, I want to select a `Data.p4k` directly, so that I
+   do not need to understand the report format before comparing versions.
+3. As a power user, I want to compare two saved inventory reports, so that I do
+   not need both massive P4k files available.
+4. As a user with one local P4k and one saved report, I want to compare those
+   sources directly, so that I can work with whichever artifacts I have.
+5. As a modding/research user, I want to see changed archive files by path and
+   extension, so that I can inspect changed asset categories quickly.
+6. As a DataCore researcher, I want to see changed records by type, name, path,
+   and GUID, so that I can identify changed ships, items, components, and
+   records without reading the whole DCB.
+7. As a GUI user, I want inventory generation to run in the background with
+   progress and cancellation, so that the app remains responsive.
+8. As a CLI user, I want progress on stderr and machine-readable output on
+   stdout or a file, so that scripts can consume the command reliably.
+9. As a user comparing two patches, I want content changes separated from
+   metadata-only changes, so that packaging noise does not hide meaningful
+   changes.
+10. As a user, I want simple text search and explicit filters, so that I can
+    narrow results without learning a query language.
+11. As a GUI user, I want one unified results table for files and records, so
+    that I can search across the full patch surface in one place.
+12. As a CLI user, I want filter flags that match the GUI semantics, so that
+    CLI and GUI results agree.
+13. As a user, I want missing `build_manifest.id` to be tolerated, so that I
+    can still inventory P4ks copied away from their install folder.
+14. As a user, I want StarBreaker to use `build_manifest.id` when present, so
+    that reports get useful default labels.
+15. As a user, I want to rename the source label, so that reports can use my
+    own version naming.
+16. As a user, I want source labels not to affect technical inventory identity,
+    so that renaming a report does not change what it represents.
+17. As a user, I want reports to be plain JSON, so that they are easy to inspect
+    and share.
+18. As a developer, I want the diff engine in a shared crate, so that CLI and
+    GUI cannot drift apart.
+19. As a developer, I want stable inventory hashes, so that snapshots can be
+    compared and tested deterministically.
+20. As a developer, I want synthetic automated tests, so that normal tests do
+    not require proprietary large P4k files.
+21. As an advanced user, I want an explicit option to skip DataCore inventory,
+    so that I can still inspect raw archive changes in debug or degraded
+    workflows.
+22. As a normal user, I want full inventory to fail if DataCore cannot be read,
+    so that serious parser or format failures are not hidden.
+23. As a future user, I want changed items to retain enough identity to open
+    side-by-side views later, so that v1 reports can support future detail
+    workflows.
+
+## Implementation Decisions
+
+- Build a new shared Rust crate for diff data structures, inventory generation,
+  comparison, canonical hashing, report IO, and shared filter semantics.
+- Keep CLI and Tauri code as adapters over the shared crate.
+- Use plain JSON inventory reports named `*.starbreaker-inventory.json`.
+- Use optional plain JSON diff result files named `*.starbreaker-diff.json`.
+- Treat inventory reports as reusable snapshots that include all archive
+  entries and all DataCore records unless DataCore was explicitly skipped.
+- Treat saved diff results as optional outputs that omit unchanged rows by
+  default while preserving summary counts.
+- Accept both raw P4k files and saved inventory reports as compare inputs.
+- Generate temporary in-memory inventories when a compare input is a P4k.
+- Cache GUI-generated inventories in memory for the current session only.
+- Persist inventory reports only when the user explicitly saves them.
+- Use cancellable inventory generation with progress callbacks/events.
+- Use P4k central-directory metadata for archive inventory. Do not decompress
+  every file.
+- Match archive entries by normalized case-insensitive path while preserving
+  original display paths.
+- Classify archive content changes by `crc32` plus `uncompressed_size`.
+- Classify archive metadata-only changes separately from content changes.
+- Do not classify renames in version 1.
+- Hash DataCore records by canonical decoded semantic content, not raw DCB byte
+  spans.
+- Match DataCore records by GUID.
+- Exclude record GUID, record name, and record path from DataCore content hash.
+- Include record type in DataCore content hash.
+- Represent DataCore references by referenced GUID and do not recursively hash
+  referenced records.
+- Treat DataCore record name/path changes as metadata-only when content hash is
+  unchanged.
+- Treat DataCore record type changes as modified.
+- Version all hash algorithms in the report.
+- Avoid full-file hashing of `Data.p4k`; use source file metadata and an
+  inventory-level hash instead.
+- Parse `build_manifest.id` beside `Data.p4k` when present, but tolerate
+  missing or invalid manifests.
+- Provide a clear `--skip-datacore` CLI flag and equivalent advanced GUI label
+  if the GUI exposes it.
+- Keep shared filters in the core crate, but keep UI state and presentation in
+  the GUI.
+- Use virtualization in the GUI result table from the first implementation.
+
+## CLI Requirements
+
+Initial commands:
+
+```text
+starbreaker diff inventory <SOURCE> -o <REPORT> [--skip-datacore] [--label <LABEL>]
+starbreaker diff compare <OLD> <NEW> [-o <DIFF>] [filters...]
+```
+
+Compare inputs may be P4k files or inventory reports.
+
+Recommended filters:
+
+- `--tier all|p4k|datacore`
+- `--status added,removed,modified,metadata,unchanged`
+- `--search <text>`
+- `--extension <ext>`
+- `--record-type <type>`
+- `--path-prefix <prefix>`
+- `--include-unchanged`
+- `--format table|json`
+
+## GUI Requirements
+
+The Diff view should contain:
+
+- two source slots, Old and New
+- support for selecting P4k files or inventory reports in either slot
+- background inventory generation for P4k sources
+- progress and cancellation
+- save inventory action for generated inventories
+- compare action when both sources are ready
+- summary counts
+- unified virtualized result table
+- facet rail for tier, status, extension, record type, and path prefix
+- simple text search
+- detail panel for selected item identity, old/new metadata, and change reasons
+- optional export diff action
+
+## Trackable Goals
+
+### Milestone 1: Shared Schema and Fixtures
+
+- Create the shared diff crate.
+- Define inventory report structs.
+- Define diff result structs.
+- Define status, tier, reason, and filter enums/structs.
+- Implement JSON read/write.
+- Implement canonical report sorting.
+- Implement inventory hash calculation that excludes display/provenance fields.
+- Add synthetic report fixtures.
+- Add schema roundtrip and inventory hash tests.
+
+Acceptance criteria:
+
+- A test can write and read an inventory report without data loss.
+- Changing a label or generated timestamp does not change `inventory_hash`.
+- Changing a technical archive or DataCore entry does change `inventory_hash`.
+
+### Milestone 2: Report Comparison Engine
+
+- Implement archive comparison.
+- Implement DataCore comparison.
+- Implement summary counts.
+- Implement changed-item result generation.
+- Implement optional unchanged inclusion.
+- Implement shared filters.
+- Add tests for added, removed, modified, metadata-only, unchanged, path
+  normalization, and filter semantics.
+
+Acceptance criteria:
+
+- Synthetic old/new reports produce expected statuses and reasons.
+- Archive metadata-only changes are not reported as content modifications.
+- DataCore name/path changes are metadata-only when content hash is unchanged.
+- CLI and GUI adapters can use the same filter object.
+
+### Milestone 3: Inventory Generation
+
+- Generate P4k archive inventory from central-directory metadata.
+- Parse source file metadata.
+- Parse optional `build_manifest.id`.
+- Generate DataCore record inventory.
+- Implement canonical DataCore record hashing.
+- Implement `--skip-datacore` behavior in the core inventory options.
+- Add progress and cancellation plumbing.
+- Add small fixture tests where practical.
+
+Acceptance criteria:
+
+- Full inventory fails if DataCore is missing or unparseable and DataCore was
+  not skipped.
+- Missing `build_manifest.id` does not fail inventory generation.
+- `--skip-datacore` produces a `p4k_only` report with DataCore marked skipped.
+- Inventory generation reports progress and respects cancellation.
+
+### Milestone 4: CLI Adapter
+
+- Add `starbreaker diff inventory`.
+- Add `starbreaker diff compare`.
+- Support P4k and report inputs for compare.
+- Support table and JSON output.
+- Support writing inventory and diff files.
+- Support shared filter flags.
+- Print progress to stderr.
+- Add CLI smoke tests or command-level tests where practical.
+
+Acceptance criteria:
+
+- A user can generate an inventory report from a P4k.
+- A user can compare two reports.
+- A user can compare a P4k and a report.
+- Filtered CLI results match core filter tests.
+
+### Milestone 5: Tauri Commands
+
+- Add Tauri commands for selecting/loading inventory reports.
+- Add Tauri commands for generating inventories from P4k sources.
+- Add Tauri commands for comparing inventories.
+- Emit progress events.
+- Support cancellation.
+- Keep generated inventories in session memory.
+
+Acceptance criteria:
+
+- The app can load two saved reports and compare them.
+- The app can generate an inventory from a P4k without blocking the UI thread.
+- Cancelling an inventory job stops work and returns a clear state.
+
+### Milestone 6: GUI Diff View
+
+- Add the Diff navigation entry/view.
+- Build Old/New source slots.
+- Build source summary cards with labels and manifest-derived defaults.
+- Build progress/cancel UI.
+- Build summary counts.
+- Build unified virtualized result table.
+- Build facets and text search.
+- Build selected item detail panel.
+- Add save inventory and export diff actions.
+
+Acceptance criteria:
+
+- A user can compare two reports from the GUI.
+- A user can compare two P4ks from the GUI.
+- The result table remains responsive with large synthetic result sets.
+- Search and facets match CLI/core behavior.
+
+### Milestone 7: Documentation and Manual Validation
+
+- Document CLI usage.
+- Document GUI workflow.
+- Document report modes and limitations.
+- Document manual real-P4k validation.
+- Add examples for LIVE vs PTU comparison.
+
+Acceptance criteria:
+
+- A user can follow docs to generate two inventories and compare them.
+- The docs explain that v1 does not perform full file content diffs.
+- The docs explain `--skip-datacore` and its consequences.
+
+## Testing Decisions
+
+Automated tests should focus on externally observable behavior:
+
+- report roundtrip
+- inventory hash stability
+- comparison statuses
+- change reasons
+- filter semantics
+- skip-DataCore behavior
+- manifest parsing fallbacks
+- cancellation behavior where practical
+
+Tests should avoid asserting implementation details such as internal helper
+function boundaries or temporary allocation strategy.
+
+Real Star Citizen P4k files should not be required for normal tests. Use
+synthetic reports and tiny generated fixtures. Real P4k validation should be
+manual or ignored/env-gated.
+
+## Out of Scope
+
+- full content diffing for arbitrary P4k files
+- automatic rename classification
+- multi-version timeline comparison
+- persistent GUI inventory cache
+- compressed report format
+- custom query language
+- publishing reports to a remote service
+- changing existing P4k browser or DataCore browser behavior except where
+  shared helpers are reused
+
+## Open Questions
+
+- Should DataCore canonical hashing reuse compact JSON export initially, or
+  should it start with a dedicated hashing sink?
+- Which hash crate should be used for canonical content and inventory hashes:
+  BLAKE3 or SHA-256?
+- Can the existing P4k reader open tiny standard ZIP fixtures directly, or do
+  tests need purpose-built fixture helpers?
+- Which React virtualization library best fits the current app dependency
+  policy?
+- Should `--skip-datacore` be exposed in the GUI v1 or only available through
+  the CLI/debug path?
+
+## Further Notes
+
+The design intentionally makes reports portable and reusable. Source paths,
+manifest data, and labels help humans understand reports, but comparison
+correctness comes from the inventory entries and their versioned hash
+algorithms.
+
+The most important engineering constraint is keeping comparison behavior in
+the shared Rust crate. CLI and GUI parity depends on having one implementation
+of inventory generation, comparison, status classification, and filtering.


### PR DESCRIPTION
# [WIP] Diffing feature (Open to requests and comments)

<img width="1909" height="1016" alt="image" src="https://github.com/user-attachments/assets/d5c6ec21-8340-4ca8-b634-8a4843ee7216" />


https://github.com/user-attachments/assets/817aa556-851e-449d-880e-c520ebb26d61


## Summary

Adds a new Diff Viewer workflow for comparing Star Citizen `Data.p4k` builds through reusable inventory reports, plus a performance pass for browsing very large diff results.

## New Capabilities

- Generate portable inventory reports from `Data.p4k` files.
- Load saved `*.starbreaker-inventory.json` reports instead of re-hashing archives every time.
- Compare two inventories across both tiers:
  - P4k archive entries
  - DataCore records
- View added, removed, modified, metadata-only, and unchanged counts.
- Browse changed rows in the Tauri Diff Viewer with search and explicit filters:
  - tier
  - status
  - extension
  - record type
  - path prefix
- Save diff output as an optional `*.starbreaker-diff.json` report.
- Use the CLI for inventory generation and report comparison.
- Cancel long-running inventory generation from the GUI.
- Scroll large diff results without the previous 5000-row practical ceiling.

## Performance Changes

- Diff rows are queried in pages instead of sending the full diff payload to React.
- Rust now keeps diff sessions in memory so repeated page requests reuse the same compare result.
- Filter indexes are cached per diff session to avoid rescanning rows for the same filters.
- The GUI uses `@tanstack/react-virtual` for row virtualization.
- Adjacent pages are prefetched based on scroll direction.
- Fast scrollbar dragging shows lightweight loading rows while the target page is fetched.
- Client-side page and session caches are bounded to avoid unbounded memory growth.

## How To Use

### GUI

1. Open the Tauri app.
2. Go to **Diff** in the sidebar.
3. Load an **Old** source:
   - choose a `Data.p4k`, or
   - choose a saved `*.starbreaker-inventory.json`.
4. Load a **New** source the same way.
5. Click **Compare**.
6. Use the filters on the left to narrow results:
   - extension example: `.dds`
   - record type example: `EntityClassDefinition`
   - path prefix example: `Data/Objects`
7. Select a row to inspect old/new metadata in the details panel.
8. Use the save buttons to export inventory reports or an optional diff report.

### CLI

Generate inventories:

```bash
cargo run -p starbreaker -- diff inventory <path-to-old-Data.p4k> -o old.starbreaker-inventory.json
cargo run -p starbreaker -- diff inventory <path-to-new-Data.p4k> -o new.starbreaker-inventory.json
```

Compare reports or archives:

```bash
cargo run -p starbreaker -- diff compare old.starbreaker-inventory.json new.starbreaker-inventory.json -o build-diff.starbreaker-diff.json
```

Use filters for focused output:

```bash
cargo run -p starbreaker -- diff compare old.starbreaker-inventory.json new.starbreaker-inventory.json \
  --status modified \
  --extension .dds \
  --path-prefix Data/Objects \
  -o objects-dds-diff.starbreaker-diff.json
```

## Validation

- `cargo check -p starbreaker-app`
- `cargo test -p starbreaker-diff`
- `npm run build`