### PR TITLE
feat(cli): add --all flag to dcb extract for non-main records

### DIFF
--- a/cli/src/dcb.rs
+++ b/cli/src/dcb.rs
@@ -35,6 +35,10 @@ pub enum DcbCommand {
         /// Filter record names by glob
         #[arg(long)]
         filter: Option<String>,
+        /// Also export non-main records (types like ResourceType only exist as
+        /// non-main records); written as <stem>.<record-name>.<guid>.<ext>
+        #[arg(long)]
+        all: bool,
     },
     /// Query DataCore records by property path
     Query {
@@ -75,7 +79,8 @@ impl DcbCommand {
                 output,
                 format,
                 filter,
-            } => extract(p4k, dcb, output, format, filter),
+                all,
+            } => extract(p4k, dcb, output, format, filter, all),
             Self::Query {
                 p4k,
                 dcb,
@@ -92,6 +97,7 @@ fn extract(
     output: PathBuf,
     format: DcbFormat,
     filter: Option<String>,
+    all: bool,
 ) -> Result<()> {
     let (_p4k, dcb_bytes) = load_dcb_bytes(p4k_path.as_deref(), dcb_path.as_deref())?;
     let db = Database::from_bytes(&dcb_bytes)?;
@@ -103,13 +109,15 @@ fn extract(
         DcbFormat::Xml | DcbFormat::Unp4k => "xml",
     };
 
-    // Only export main records (matching C#'s behavior), using the file path
-    // from the DataCore as the output directory structure.
+    // By default only export main records (matching C#'s behavior), using the
+    // file path from the DataCore as the output directory structure. With
+    // --all, non-main records (earlier records sharing a file name) are
+    // exported too under de-duplicated names.
     let records: Vec<_> = db
         .records()
         .iter()
         .filter(|r| {
-            if !db.is_main_record(r) {
+            if !all && !db.is_main_record(r) {
                 return false;
             }
             let file_name = db.resolve_string(r.file_name_offset);
@@ -130,9 +138,21 @@ fn extract(
     records.par_iter().for_each(|record| {
         let file_name = db.resolve_string(record.file_name_offset);
         // Change extension to match output format (C# uses Path.ChangeExtension)
-        let out_name = match file_name.rfind('.') {
-            Some(dot) => format!("{}.{ext}", &file_name[..dot]),
-            None => format!("{file_name}.{ext}"),
+        let stem = match file_name.rfind('.') {
+            Some(dot) => &file_name[..dot],
+            None => file_name,
+        };
+        // Non-main records share their file name with the main record, so
+        // suffix record name + guid to keep every output file unique.
+        let out_name = if db.is_main_record(record) {
+            format!("{stem}.{ext}")
+        } else {
+            let rec_name: String = db
+                .resolve_string2(record.name_offset)
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '_' })
+                .collect();
+            format!("{stem}.{rec_name}.{}.{ext}", record.id)
         };
         let out_path = output.join(&out_name);
 


### PR DESCRIPTION
## Problem

`dcb extract` only writes **main records** (last record per unique file name, matching the original C# behavior). Some record types exist *only* as non-main records and are therefore invisible to extraction — the clearest case is `ResourceType`: all ~225 of them share the single `resourcetypedatabase.xml` file name behind the `ResourceTypeDatabase` record, so `dcb query 'ResourceType'` reports "no main records" and `dcb extract` emits none of them.

This matters for tools consuming unforge-style output downstream — e.g. octfx/ScDataDumper's `load:commodities` iterates `ResourceType` documents and comes up empty on a StarBreaker extraction.

## Change

A new opt-in `--all` flag on `dcb extract` also exports non-main records. Default behavior is unchanged. Non-main records share their file name with the main record, so they're written as `<stem>.<record-name>.<guid>.<ext>` (record name sanitized) — collision-proof against the main record and each other.

## Testing

Ran against a 4.8.2-LIVE `Data.p4k`: default extract = 60,531 records (unchanged); `--all` = 115,219. The `--all` output (unp4k format) was consumed end-to-end by ScDataDumper (`generate:cache` + all load commands) — the previously-missing `ResourceType`/`ResourceTypeGroup` records extract correctly and downstream FK resolution works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)